### PR TITLE
feat(graph): ship Phase 3 — local code-graph MCP server (0.1.0-alpha.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.1.0-alpha.5] — 2026-04-17
+
+Major release: **local code-graph MCP server** (Phase 3 of the roadmap) lands end-to-end. Tokenomy grows from a pair of transparent hooks into an opt-in context-retrieval toolkit: the agent queries a pre-built graph of your TS/JS codebase and gets focused snippets instead of brute-forcing `Read` calls.
+
+### Added
+
+- **Graph schema + persistent store** (`src/graph/schema.ts`, `store.ts`) — versioned JSON snapshot at `~/.tokenomy/graphs/<sha256(git-root)>/snapshot.json`. Node kinds: `file`, `external-module`, `function`, `class`, `method`, `exported-symbol`, `imported-symbol`, `test-file`. Edge kinds: `imports`, `exports`, `contains`, `calls`, `references`, `tests`. Every edge carries `confidence: "definite" | "inferred"` from day one.
+- **TypeScript / JavaScript parser** (`src/parsers/ts/*`) using the TypeScript compiler API via AST-only (`ts.createSourceFile`) — no type checker, no program. Extracts imports/re-exports, named/default/namespace symbols, top-level functions/classes/methods, call edges, and `require()` / dynamic `import()` (flagged inferred). Type-only imports and JSX skipped in v1 (documented).
+- **Repo identity** (`src/graph/repo-id.ts`) — `sha256(git-root)` so one cache per unique checkout, shared across Claude Code and Codex on the same machine. Falls back to `sha256(cwd)` if not in a git repo.
+- **Stale detection with mtime fast-path** (`src/graph/stale.ts`) — only re-hashes files whose mtime changed. Queries always serve stale + emit `{stale, stale_files}` per the "serve stale + loud warning" policy.
+- **Scale caps enforced inline** — hardcoded ignore list (`node_modules`, `.next`, `.turbo`, `.yarn`, `dist`, `coverage`, `.git`, `.nuxt`) plus a 5 000-file hard cap that trips during enumeration, not post-facto. Per-file edge cap (default 1 000) and snapshot byte cap (default 20 MB) checked pre-write.
+- **Build concurrency safety** — `.build.lock` file via `openSync(path, "wx")` (`O_CREAT|O_EXCL`); concurrent builds return `{ok: false, reason: "build-in-progress"}` cleanly.
+- **Pure-function queries** (`src/graph/query/{minimal,impact,review,budget,common}.ts`) — BFS over the graph with rank + pre-clip + budget-clip safety net. All three queries return `{stale, stale_files, data, truncated?}`.
+- **MCP stdio server** (`src/mcp/*`) — exposes 4 tools: `build_or_update_graph`, `get_minimal_context`, `get_impact_radius`, `get_review_context`. Each tool's output is hard-capped by `budget-clip.ts` (4 KB / 4 KB / 6 KB / 1 KB respectively).
+- **CLI subcommands** (`src/cli/graph{,-build,-status,-serve,-query,-purge}.ts`): `tokenomy graph build [--force] [--path]`, `graph status`, `graph serve` (spawns the MCP server), `graph query <minimal|impact|review>` (dev helper), `graph purge [--all]`.
+- **Graph-aware Read-clamp hint** — `pre-dispatch.ts` now appends a nudge toward `get_minimal_context` / `get_impact_radius` / `get_review_context` when a graph snapshot exists for the current repo. Gated behind `cfg.graph.enabled` and a cheap `existsSync(~/.tokenomy/graphs/)` pre-check so the git subprocess in `resolveRepoId` is skipped on installs with no graph.
+- **`tokenomy init --graph-path <dir>`** — registers the `tokenomy-graph` MCP server in `~/.claude/settings.json` alongside the existing PostToolUse / PreToolUse hooks. `tokenomy uninstall` now strips the server entry too.
+- **`tokenomy doctor` gains a "Graph MCP registration" check** — reports whether the server is registered and flags path/args drift.
+- **`typescript` is a `peerDependencies` + `peerDependenciesMeta.optional`** — core install stays zero-runtime-deps. Users who want the graph run `npm i -g typescript` alongside. `loader.ts` falls back with a structured error if missing.
+- **Config extension** — new `DEFAULT_CONFIG.graph` section: `enabled`, `max_files`, `hard_max_files`, `build_timeout_ms`, `max_edges_per_file`, `max_snapshot_bytes`, `query_budget_bytes.{build_or_update_graph, get_minimal_context, get_impact_radius, get_review_context}`. Aggression multiplier scales all numeric budgets.
+- **Graph build log** — best-effort JSONL at `~/.tokenomy/graphs/<id>/build.jsonl` via `appendGraphBuildLog`.
+- **Fixture repo for tests** (`tests/fixtures/graph-fixture-repo/`) — 8-file synthetic TS/JS repo exercising imports, re-exports, default exports, require, dynamic import, and a co-located test file.
+- **23 new tests** across unit (schema, repo-id, store, enumerate, stale, resolve, parser loader, parser import extraction, pre-dispatch) and integration (graph-build-cli, graph-status-cli, graph-mcp, init-uninstall graph-path path). Total: 67 passing.
+
+### Fixed
+
+- **Resolver silently dropped `.js` imports to `.ts` sources** (TypeScript NodeNext convention). The specifier-already-has-extension branch short-circuited the probe loop, so `import … from "./foo.js"` never tried `./foo.ts`. On Tokenomy's own source: **146 phantom parse errors → 0**. Resolver now also tries `.tsx` for `.jsx`, `.mts` for `.mjs`, `.cts` for `.cjs`. Regression tests added.
+- **`tokenomy graph query … --file <path>`** with space-separated flags returned `invalid-input`. The outer CLI parser consumed `--file` / `--files` into its own flags map before forwarding to `runGraphQuery`. Fix: forward raw argv for the `query` subcommand; let the inner parser own its flags end-to-end.
+- **`resolveRepoId` was called (spawning `git`) on every Read hook invocation**, even when no graph had ever been built. Fix: early-return `graphHint` if `~/.tokenomy/graphs/` directory doesn't exist.
+
+### Notes
+
+- `@modelcontextprotocol/sdk` is now a **runtime dependency**. This is the first non-zero-deps addition. The core hook path still has zero deps at runtime (typescript / @modelcontextprotocol/sdk are loaded dynamically only when the graph path is exercised).
+
 ## [0.1.0-alpha.4] — 2026-04-17
 
 ### Changed
@@ -74,7 +108,8 @@ First public alpha. Phase 1 scope: transparent MCP tool-output trimming via `Pos
 - Statusline with live savings counter — Phase 2.
 - `tokenomy analyze` over transcripts — Phase 2.
 
-[Unreleased]: https://github.com/RahulDhiman93/Tokenomy/compare/v0.1.0-alpha.4...HEAD
+[Unreleased]: https://github.com/RahulDhiman93/Tokenomy/compare/v0.1.0-alpha.5...HEAD
+[0.1.0-alpha.5]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.5
 [0.1.0-alpha.4]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.4
 [0.1.0-alpha.3]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.3
 [0.1.0-alpha.2]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.2

--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ Assistant → read src/config.ts    ← 14 KB
 
 200 K tokens gone before Claude did any real work. **Compaction kicks in too late, and it's lossy.**
 
-Tokenomy plugs two holes the Claude Code hook contract actually lets you close — with zero proxy, no monkey-patching, and a total of ~800 lines of TypeScript:
+Tokenomy plugs the holes the Claude Code hook contract lets you close — with zero proxy, no monkey-patching:
 
 | Surface | Mechanism | What it kills |
 |---|---|---|
 | `PostToolUse` on `mcp__.*` | `updatedMCPToolOutput` | 10–50 KB MCP responses from Atlassian, Notion, Gmail, Asana, HubSpot, Intercom… |
 | `PreToolUse` on `Read` | `updatedInput` | Unbounded reads on huge source files |
+| `tokenomy-graph` MCP server | 4 tools over stdio | Brute-force `Read` sweeps of the codebase — agent gets focused context by querying a pre-built graph |
 
 Each trim appends a row to `~/.tokenomy/savings.jsonl` with measured bytes-in / bytes-out, so you can prove the savings.
 
@@ -168,11 +169,73 @@ Config changes take effect **immediately** — no Claude Code restart needed. On
 ✓ Log directory writable
 ✓ Manifest drift — clean
 ✓ No overlapping mcp__ hook
+✓ Graph MCP registration — not configured
 
-9/9 checks passed
+10/10 checks passed
 ```
 
 Every check has an actionable remediation hint on failure.
+
+---
+
+## 🕸️ Code-graph MCP server (opt-in, Phase 3)
+
+Once the two hooks stop bleeding tokens on tool chatter, the next waste is Claude reading half a codebase to find one function. The optional **`tokenomy-graph` MCP server** gives the agent four surgical tools over stdio — the graph is built once, queries return focused neighborhoods, budgets are hard-capped.
+
+### Install + register
+
+```bash
+npm install -g typescript              # peer-optional; required for the graph
+tokenomy init --graph-path "$PWD"      # adds tokenomy-graph to ~/.claude/settings.json
+tokenomy graph build --path "$PWD"     # parses TS/JS into ~/.tokenomy/graphs/<id>/
+tokenomy doctor                        # 10/10 ✓
+# restart Claude Code
+```
+
+### The four tools
+
+| Tool | Input | Output | Budget |
+|---|---|---|---|
+| `build_or_update_graph` | `{force?, path?}` | build stats | 4 KB |
+| `get_minimal_context` | `{target: {file, symbol?}, depth?}` | focal + ranked neighbors (imports/exports/contains) | 4 KB |
+| `get_impact_radius` | `{changed: [{file, symbols?}], max_depth?}` | reverse deps + suggested tests | 6 KB |
+| `get_review_context` | `{files: [...]}` | fanout + hotspots across changed files | 1 KB |
+
+Stale detection is always-on: queries return `{stale, stale_files}` so the agent knows whether to trust the result. `tokenomy graph build --force` regenerates.
+
+### Good prompt to test it
+
+> First call `build_or_update_graph` if needed.
+> Then call `get_minimal_context` for `{"target":{"file":"src/index.ts"},"depth":1}`.
+> Then call `get_review_context` for `{"files":["src/index.ts","src/foo.ts"]}`.
+> Only use `Read` if the graph result is insufficient.
+
+### Dev CLI (no MCP needed)
+
+```bash
+tokenomy graph status --path "$PWD"
+tokenomy graph query minimal --path "$PWD" --file src/index.ts
+tokenomy graph query impact  --path "$PWD" --file src/index.ts
+tokenomy graph query review  --path "$PWD" --files src/index.ts,src/foo.ts
+tokenomy graph purge [--all]
+```
+
+### Codex
+
+The MCP server ports cleanly:
+
+```bash
+codex mcp add tokenomy-graph -- tokenomy graph serve --path "$PWD"
+codex mcp list
+```
+
+### Scope + limits (v1)
+
+- **TypeScript + JavaScript only** (`.ts`/`.tsx`/`.js`/`.jsx`/`.mjs`/`.cjs`, with `.mts`/`.cts` probed). Python / 23-lang support explicitly out of scope.
+- **Soft cap 2 000 files, hard cap 5 000** — larger repos abort cleanly with `repo-too-large`.
+- **AST-only** via the TypeScript compiler API (no type checker); type-only imports and JSX element references skipped in v1.
+- **No `tsconfig.paths`, no `node_modules` resolution** — bare specifiers become `external-module` nodes. Will revisit in v2.
+- **Fail-open always:** every tool and CLI subcommand returns `{ok: false, reason}` rather than throwing; graph features never break the core hook path.
 
 ---
 
@@ -188,9 +251,9 @@ Removes both hook entries from `~/.claude/settings.json` (matched by absolute co
 
 ## 🧭 Roadmap
 
-- [x] **Phase 1.** `PostToolUse` MCP trim + `PreToolUse` Read clamp + CLI + 9-check doctor + savings log
+- [x] **Phase 1.** `PostToolUse` MCP trim + `PreToolUse` Read clamp + CLI + 10-check doctor + savings log
 - [ ] **Phase 2.** `tokenomy analyze` — walk `~/.claude/projects/**/*.jsonl`, surface waste patterns, benchmark real savings with a real tokenizer
-- [ ] **Phase 3.** Portable MCP companion server — `tokenomy_summarize`, `tokenomy_read_slice`, `tokenomy_grep_bucketed`. Works in Codex via `~/.codex/config.toml`
+- [x] **Phase 3.** Local code-graph MCP server: `tokenomy-graph` stdio server + `graph build|status|serve|query|purge` CLI + `init --graph-path` + doctor check. TypeScript AST, 4 tools, hard budget caps, fail-open everywhere.
 - [ ] **Phase 4.** `PreToolUse` Bash input-bounder (auto-append `| head -N` on verbose commands) + hinting layer nudging Claude toward Tokenomy MCP alternatives
 - [ ] **Phase 5.** Polish — statusline with live savings counter, `UserPromptSubmit` prompt-classifier for effort-level nudges, npm publish
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "tokenomy",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-alpha.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tokenomy",
-      "version": "0.1.0-alpha.0",
+      "version": "0.1.0-alpha.4",
       "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.15.0"
+      },
       "bin": {
         "tokenomy": "dist/cli/entry.js",
         "tokenomy-hook": "dist/hook/entry.js"
@@ -20,6 +23,14 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.6.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -530,6 +541,29 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.15.0.tgz",
+      "integrity": "sha512-67hnl/ROKdb03Vuu0YOr+baKTvf1/5YBHBm9KnZdjdAh8hjt4FRCPD5ucwxGB237sBpzlqQsLy1PFu7z/ekZ9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.6",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -556,6 +590,35 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-regex": {
@@ -594,6 +657,30 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -605,6 +692,15 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/c8": {
@@ -639,6 +735,35 @@
         "monocart-coverage-reports": {
           "optional": true
         }
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/cliui": {
@@ -755,6 +880,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -762,11 +909,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -777,11 +958,57 @@
         "node": ">= 8"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
@@ -790,6 +1017,45 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -843,6 +1109,133 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.7.tgz",
+      "integrity": "sha512-zwxwiQqexizSXFZV13zMiEtW1E3lv7RlUv+1f5FBiR4x7wFhEjm3aFTyYkZQWzyN08WnPdox015GoRH5D/E5YA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -877,6 +1270,24 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -892,6 +1303,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -900,6 +1320,43 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -970,6 +1427,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -980,12 +1449,87 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -997,11 +1541,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -1059,6 +1608,12 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1098,6 +1653,61 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -1122,6 +1732,63 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/p-limit": {
@@ -1163,6 +1830,15 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1177,7 +1853,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1200,6 +1875,86 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1220,6 +1975,28 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -1233,11 +2010,61 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -1250,10 +2077,81 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -1267,6 +2165,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/string-width": {
@@ -1401,6 +2308,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
@@ -1419,6 +2335,20 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typescript": {
@@ -1442,6 +2372,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -1457,11 +2405,19 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -1571,6 +2527,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -1666,6 +2628,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenomy",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "Surgical Claude Code hook that transparently trims bloated MCP tool responses and clamps oversized file reads — stop burning tokens on tool chatter.",
   "type": "module",
   "engines": {
@@ -54,10 +54,21 @@
     "cli"
   ],
   "license": "MIT",
+  "peerDependencies": {
+    "typescript": "^5.6.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/node": "^20.14.0",
     "c8": "^10.1.0",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.15.0"
   }
 }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -11,6 +11,7 @@ import {
 import { safeParse } from "../util/json.js";
 import {
   countHooksForPath,
+  getMcpServer,
   hasOverlappingMcpHook,
 } from "../util/settings-patch.js";
 import type { SettingsShape } from "../util/settings-patch.js";
@@ -210,6 +211,44 @@ const overlapWarnCheck = (settings: SettingsShape | undefined): CheckResult => {
   };
 };
 
+const graphRegistrationCheck = (settings: SettingsShape | undefined): CheckResult => {
+  if (!settings) return { name: "Graph MCP registration", ok: true, detail: "no settings" };
+  const entry = getMcpServer(settings, "tokenomy-graph");
+  if (!entry) {
+    return {
+      name: "Graph MCP registration",
+      ok: true,
+      detail: "not configured",
+    };
+  }
+  const args = Array.isArray(entry.args) ? entry.args : [];
+  const ok = entry.command === "tokenomy" && args[0] === "graph" && args[1] === "serve";
+  return {
+    name: "Graph MCP registration",
+    ok,
+    detail: ok ? "tokenomy-graph configured" : "tokenomy-graph entry is malformed",
+    remediation: ok ? undefined : "Re-run `tokenomy init --graph-path=<repo>` to repair it.",
+  };
+};
+
+const mcpSdkCheck = async (): Promise<CheckResult> => {
+  try {
+    await import("@modelcontextprotocol/sdk/server/index.js");
+    return {
+      name: "Graph MCP SDK available",
+      ok: true,
+      detail: "@modelcontextprotocol/sdk import ok",
+    };
+  } catch (error) {
+    return {
+      name: "Graph MCP SDK available",
+      ok: false,
+      detail: (error as Error).message,
+      remediation: "Install dependencies and rebuild Tokenomy.",
+    };
+  }
+};
+
 export const runDoctor = async (): Promise<CheckResult[]> => {
   const out: CheckResult[] = [];
   out.push(nodeVersionCheck());
@@ -226,5 +265,7 @@ export const runDoctor = async (): Promise<CheckResult[]> => {
   out.push(logDirWritableCheck(cfgRaw));
   out.push(manifestDriftCheck(s.settings));
   out.push(overlapWarnCheck(s.settings));
+  out.push(graphRegistrationCheck(s.settings));
+  out.push(await mcpSdkCheck());
   return out;
 };

--- a/src/cli/entry.ts
+++ b/src/cli/entry.ts
@@ -3,15 +3,20 @@ import { runInit } from "./init.js";
 import { runUninstall } from "./uninstall.js";
 import { runDoctor } from "./doctor.js";
 import { configGet, configSet } from "./config-cmd.js";
+import { runGraph } from "./graph.js";
 import type { Config } from "../core/types.js";
-
-const VERSION = "0.1.0-alpha.0";
+import { TOKENOMY_VERSION } from "../core/version.js";
 
 const HELP = `tokenomy — transparent MCP tool-output trimmer for Claude Code
 
 Usage:
-  tokenomy init [--aggression=conservative|balanced|aggressive] [--no-backup]
+  tokenomy init [--aggression=conservative|balanced|aggressive] [--no-backup] [--graph-path=<dir>]
   tokenomy doctor
+  tokenomy graph build [--force] [--path=<dir>]
+  tokenomy graph status [--path=<dir>]
+  tokenomy graph serve [--path=<dir>]
+  tokenomy graph purge [--path=<dir>|--all]
+  tokenomy graph query <minimal|impact|review> ...
   tokenomy uninstall [--purge] [--no-backup]
   tokenomy config get <key>
   tokenomy config set <key> <value>
@@ -25,11 +30,22 @@ interface ArgMap {
 
 const parseArgs = (argv: string[]): ArgMap => {
   const out: ArgMap = { _: [], flags: {} };
-  for (const a of argv) {
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === undefined) continue;
     if (a.startsWith("--")) {
       const eq = a.indexOf("=");
-      if (eq === -1) out.flags[a.slice(2)] = true;
-      else out.flags[a.slice(2, eq)] = a.slice(eq + 1);
+      if (eq !== -1) {
+        out.flags[a.slice(2, eq)] = a.slice(eq + 1);
+        continue;
+      }
+      const next = argv[i + 1];
+      if (next && !next.startsWith("--")) {
+        out.flags[a.slice(2)] = next;
+        i++;
+      } else {
+        out.flags[a.slice(2)] = true;
+      }
     } else {
       out._.push(a);
     }
@@ -57,7 +73,7 @@ const main = async (): Promise<number> => {
   const args = parseArgs(process.argv.slice(2));
 
   if (args.flags["version"] || args.flags["v"]) {
-    process.stdout.write(`tokenomy ${VERSION}\n`);
+    process.stdout.write(`tokenomy ${TOKENOMY_VERSION}\n`);
     return 0;
   }
   if (args.flags["help"] || args.flags["h"] || args._.length === 0) {
@@ -72,7 +88,9 @@ const main = async (): Promise<number> => {
     const aggression =
       typeof aggRaw === "string" && isAggression(aggRaw) ? aggRaw : undefined;
     const backup = args.flags["no-backup"] !== true;
-    const result = runInit({ aggression, backup });
+    const graphPath =
+      typeof args.flags["graph-path"] === "string" ? args.flags["graph-path"] : undefined;
+    const result = runInit({ aggression, backup, graphPath });
     process.stdout.write(
       [
         `✓ Tokenomy installed`,
@@ -80,6 +98,9 @@ const main = async (): Promise<number> => {
         `  settings: ${result.settingsPath}`,
         `  backup:   ${result.backupPath ?? "(none)"}`,
         `  config:   ${result.configPath}`,
+        ...(result.graphServerPath
+          ? [`  graph:    tokenomy-graph -> ${result.graphServerPath}`]
+          : []),
         `  manifest: ${result.manifestPath}`,
         `  Run: tokenomy doctor`,
         ``,
@@ -104,6 +125,7 @@ const main = async (): Promise<number> => {
   }
 
   if (cmd === "doctor") return printDoctor();
+  if (cmd === "graph") return runGraph(process.argv.slice(3));
 
   if (cmd === "config") {
     const sub = args._[1];

--- a/src/cli/graph-build.ts
+++ b/src/cli/graph-build.ts
@@ -1,0 +1,18 @@
+import { stableStringify } from "../util/json.js";
+import { buildGraph } from "../graph/build.js";
+import { loadConfig } from "../core/config.js";
+
+export const runGraphBuild = async (opts: {
+  cwd: string;
+  path?: string;
+  force?: boolean;
+}): Promise<number> => {
+  const target = opts.path ?? opts.cwd;
+  const result = await buildGraph({
+    cwd: target,
+    force: opts.force,
+    config: loadConfig(target),
+  });
+  process.stdout.write(`${stableStringify(result)}\n`);
+  return result.ok ? 0 : 1;
+};

--- a/src/cli/graph-purge.ts
+++ b/src/cli/graph-purge.ts
@@ -1,0 +1,28 @@
+import { existsSync, rmSync } from "node:fs";
+import { stableStringify } from "../util/json.js";
+import { graphDir, tokenomyGraphRootDir } from "../core/paths.js";
+import { resolveRepoId } from "../graph/repo-id.js";
+
+export const runGraphPurge = async (opts: {
+  cwd: string;
+  path?: string;
+  all?: boolean;
+}): Promise<number> => {
+  if (opts.all) {
+    rmSync(tokenomyGraphRootDir(), { recursive: true, force: true });
+    process.stdout.write(
+      `${stableStringify({ ok: true, data: { purged: true, scope: "all" } })}\n`,
+    );
+    return 0;
+  }
+
+  const target = opts.path ?? opts.cwd;
+  const { repoId } = resolveRepoId(target);
+  const path = graphDir(repoId);
+  const existed = existsSync(path);
+  rmSync(path, { recursive: true, force: true });
+  process.stdout.write(
+    `${stableStringify({ ok: true, data: { purged: existed, scope: "repo", repo_id: repoId } })}\n`,
+  );
+  return 0;
+};

--- a/src/cli/graph-query.ts
+++ b/src/cli/graph-query.ts
@@ -1,0 +1,133 @@
+import { loadConfig } from "../core/config.js";
+import { stableStringify } from "../util/json.js";
+import { impactRadius } from "../graph/query/impact.js";
+import { loadGraphContext } from "../graph/query/common.js";
+import { minimalContext } from "../graph/query/minimal.js";
+import { reviewContext } from "../graph/query/review.js";
+
+const parseIntegerFlag = (
+  value: string | boolean | undefined,
+  fallback: number,
+): number => {
+  if (typeof value !== "string") return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const parseCsv = (value: string | boolean | undefined): string[] =>
+  typeof value === "string"
+    ? value
+        .split(",")
+        .map((part) => part.trim())
+        .filter((part) => part.length > 0)
+    : [];
+
+const parseFlags = (argv: string[]): Record<string, string | boolean> => {
+  const flags: Record<string, string | boolean> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const current = argv[i];
+    if (current === undefined) continue;
+    if (!current.startsWith("--")) continue;
+    const eq = current.indexOf("=");
+    if (eq !== -1) {
+      flags[current.slice(2, eq)] = current.slice(eq + 1);
+      continue;
+    }
+    const next = argv[i + 1];
+    if (next && !next.startsWith("--")) {
+      flags[current.slice(2)] = next;
+      i++;
+    } else {
+      flags[current.slice(2)] = true;
+    }
+  }
+  return flags;
+};
+
+const print = (value: unknown): number => {
+  process.stdout.write(`${stableStringify(value)}\n`);
+  return value && typeof value === "object" && (value as { ok?: boolean }).ok === false ? 1 : 0;
+};
+
+export const runGraphQuery = async (opts: {
+  cwd: string;
+  path?: string;
+  argv: string[];
+}): Promise<number> => {
+  const mode = opts.argv[0];
+  const flags = parseFlags(opts.argv.slice(1));
+  const target = opts.path ?? opts.cwd;
+  const config = loadConfig(target);
+  const context = loadGraphContext(target, config);
+  if (!context.ok) return print(context);
+
+  if (mode === "minimal") {
+    const file = typeof flags["file"] === "string" ? flags["file"] : undefined;
+    if (!file) return print({ ok: false, reason: "invalid-input", hint: "Pass --file=<path>." });
+    return print(
+      minimalContext(
+        context.data.graph,
+        {
+          target: {
+            file,
+            ...(typeof flags["symbol"] === "string" ? { symbol: flags["symbol"] } : {}),
+          },
+          depth: parseIntegerFlag(flags["depth"], 1),
+        },
+        config,
+        context.data.stale,
+        context.data.stale_files,
+      ),
+    );
+  }
+
+  if (mode === "impact") {
+    const file = typeof flags["file"] === "string" ? flags["file"] : undefined;
+    if (!file) return print({ ok: false, reason: "invalid-input", hint: "Pass --file=<path>." });
+    return print(
+      impactRadius(
+        context.data.graph,
+        {
+          changed: [
+            {
+              file,
+              ...(parseCsv(flags["symbols"]).length > 0
+                ? { symbols: parseCsv(flags["symbols"]) }
+                : {}),
+            },
+          ],
+          max_depth: parseIntegerFlag(flags["max-depth"], 2),
+        },
+        config,
+        context.data.stale,
+        context.data.stale_files,
+      ),
+    );
+  }
+
+  if (mode === "review") {
+    const files = parseCsv(flags["files"]);
+    if (files.length === 0) {
+      return print({
+        ok: false,
+        reason: "invalid-input",
+        hint: "Pass --files=a.ts,b.ts.",
+      });
+    }
+    return print(
+      reviewContext(
+        context.data.graph,
+        { files },
+        config,
+        context.data.stale,
+        context.data.stale_files,
+      ),
+    );
+  }
+
+  return print({
+    ok: false,
+    reason: "invalid-input",
+    hint: "Use `minimal`, `impact`, or `review`.",
+  });
+};

--- a/src/cli/graph-serve.ts
+++ b/src/cli/graph-serve.ts
@@ -1,0 +1,7 @@
+import { startGraphServer } from "../mcp/server.js";
+
+export const runGraphServe = async (opts: { cwd: string; path?: string }): Promise<number> => {
+  const target = opts.path ?? opts.cwd;
+  await startGraphServer(target);
+  return await new Promise<number>(() => {});
+};

--- a/src/cli/graph-status.ts
+++ b/src/cli/graph-status.ts
@@ -1,0 +1,10 @@
+import { stableStringify } from "../util/json.js";
+import { loadConfig } from "../core/config.js";
+import { readGraphStatus } from "../graph/build.js";
+
+export const runGraphStatus = async (opts: { cwd: string; path?: string }): Promise<number> => {
+  const target = opts.path ?? opts.cwd;
+  const result = readGraphStatus(target, loadConfig(target));
+  process.stdout.write(`${stableStringify(result)}\n`);
+  return result.ok ? 0 : 1;
+};

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -1,0 +1,92 @@
+import { runGraphBuild } from "./graph-build.js";
+import { runGraphPurge } from "./graph-purge.js";
+import { runGraphQuery } from "./graph-query.js";
+import { runGraphServe } from "./graph-serve.js";
+import { runGraphStatus } from "./graph-status.js";
+
+interface ArgMap {
+  _: string[];
+  flags: Record<string, string | boolean>;
+}
+
+const HELP = `Usage:
+  tokenomy graph build [--force] [--path=<dir>]
+  tokenomy graph status [--path=<dir>]
+  tokenomy graph serve [--path=<dir>]
+  tokenomy graph purge [--path=<dir>|--all]
+  tokenomy graph query <minimal|impact|review> [--path=<dir>] ...
+`;
+
+const parseArgs = (argv: string[]): ArgMap => {
+  const out: ArgMap = { _: [], flags: {} };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === undefined) continue;
+    if (a.startsWith("--")) {
+      const eq = a.indexOf("=");
+      if (eq !== -1) {
+        out.flags[a.slice(2, eq)] = a.slice(eq + 1);
+        continue;
+      }
+      const next = argv[i + 1];
+      if (next && !next.startsWith("--")) {
+        out.flags[a.slice(2)] = next;
+        i++;
+      } else {
+        out.flags[a.slice(2)] = true;
+      }
+    } else {
+      out._.push(a);
+    }
+  }
+  return out;
+};
+
+export const runGraph = async (argv: string[]): Promise<number> => {
+  const cmd = argv[0];
+
+  if (!cmd) {
+    process.stderr.write(HELP);
+    return 1;
+  }
+
+  // `query` owns its own flag parsing (each sub-mode has different flags);
+  // forward the raw argv so `--file` / `--files` survive the hop.
+  if (cmd === "query") {
+    // Pre-scan for --path only, don't eat anything else.
+    const path = extractPath(argv.slice(1));
+    return runGraphQuery({ cwd: process.cwd(), path, argv: argv.slice(1) });
+  }
+
+  const args = parseArgs(argv);
+  const path = typeof args.flags["path"] === "string" ? args.flags["path"] : undefined;
+
+  if (cmd === "build") {
+    return runGraphBuild({ cwd: process.cwd(), path, force: args.flags["force"] === true });
+  }
+  if (cmd === "status") {
+    return runGraphStatus({ cwd: process.cwd(), path });
+  }
+  if (cmd === "serve") {
+    return runGraphServe({ cwd: process.cwd(), path });
+  }
+  if (cmd === "purge") {
+    return runGraphPurge({ cwd: process.cwd(), path, all: args.flags["all"] === true });
+  }
+
+  process.stderr.write(`Unknown graph command: ${cmd}\n${HELP}`);
+  return 1;
+};
+
+const extractPath = (argv: string[]): string | undefined => {
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === undefined) continue;
+    if (a === "--path") {
+      const next = argv[i + 1];
+      return typeof next === "string" && !next.startsWith("--") ? next : undefined;
+    }
+    if (a.startsWith("--path=")) return a.slice("--path=".length);
+  }
+  return undefined;
+};

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -7,7 +7,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Config } from "../core/types.js";
 import {
@@ -22,18 +22,24 @@ import { DEFAULT_CONFIG } from "../core/config.js";
 import { atomicWrite } from "../util/atomic.js";
 import { backupFile } from "../util/backup.js";
 import { safeParse, stableStringify } from "../util/json.js";
-import { addHook, removeHookByCommandPath } from "../util/settings-patch.js";
+import {
+  addHook,
+  removeHookByCommandPath,
+  upsertMcpServer,
+} from "../util/settings-patch.js";
 import type { SettingsShape } from "../util/settings-patch.js";
 import { readManifest, upsertEntry, writeManifest } from "../util/manifest.js";
 
 export interface InitOptions {
   aggression?: Config["aggression"];
   backup?: boolean;
+  graphPath?: string;
 }
 
 const POST_MATCHER = "mcp__.*";
 const PRE_MATCHER = "Read";
 const TIMEOUT_SECONDS = 10;
+const GRAPH_SERVER_NAME = "tokenomy-graph";
 
 const stageHookBinary = (): string => {
   mkdirSync(tokenomyBinDir(), { recursive: true });
@@ -84,6 +90,7 @@ export const runInit = (opts: InitOptions = {}): {
   settingsPath: string;
   configPath: string;
   manifestPath: string;
+  graphServerPath: string | null;
 } => {
   const hookPath = stageHookBinary();
   const settingsPath = claudeSettingsPath();
@@ -105,6 +112,13 @@ export const runInit = (opts: InitOptions = {}): {
   settings = removeHookByCommandPath(settings, hookPath);
   settings = addHook(settings, "PostToolUse", hookPath, POST_MATCHER, TIMEOUT_SECONDS);
   settings = addHook(settings, "PreToolUse", hookPath, PRE_MATCHER, TIMEOUT_SECONDS);
+  const graphServerPath = opts.graphPath ? resolve(opts.graphPath) : null;
+  if (graphServerPath) {
+    settings = upsertMcpServer(settings, GRAPH_SERVER_NAME, {
+      command: "tokenomy",
+      args: ["graph", "serve", "--path", graphServerPath],
+    });
+  }
 
   atomicWrite(settingsPath, stableStringify(settings) + "\n");
 
@@ -125,5 +139,6 @@ export const runInit = (opts: InitOptions = {}): {
     settingsPath,
     configPath,
     manifestPath: manifestPath(),
+    graphServerPath,
   };
 };

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -3,7 +3,7 @@ import { claudeSettingsPath, hookBinaryPath, tokenomyDir } from "../core/paths.j
 import { atomicWrite } from "../util/atomic.js";
 import { backupFile } from "../util/backup.js";
 import { safeParse, stableStringify } from "../util/json.js";
-import { removeHookByCommandPath } from "../util/settings-patch.js";
+import { removeHookByCommandPath, removeMcpServerByName } from "../util/settings-patch.js";
 import type { SettingsShape } from "../util/settings-patch.js";
 import { deleteManifestFile, readManifest, writeManifest, removeEntryByCommand } from "../util/manifest.js";
 
@@ -31,7 +31,8 @@ export const runUninstall = (opts: UninstallOptions = {}): {
         `Could not parse ${settingsPath}. Manual cleanup required; backup at ${backupPath ?? "<none>"}`,
       );
     }
-    const cleaned = removeHookByCommandPath(parsed, hookPath);
+    let cleaned = removeHookByCommandPath(parsed, hookPath);
+    cleaned = removeMcpServerByName(cleaned, "tokenomy-graph");
     if (JSON.stringify(cleaned) !== JSON.stringify(parsed)) {
       atomicWrite(settingsPath, stableStringify(cleaned) + "\n");
       hooksRemoved = true;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -19,6 +19,20 @@ export const DEFAULT_CONFIG: Config = {
     clamp_above_bytes: 40_000,
     injected_limit: 500,
   },
+  graph: {
+    enabled: true,
+    max_files: 2_000,
+    hard_max_files: 5_000,
+    build_timeout_ms: 30_000,
+    max_edges_per_file: 1_000,
+    max_snapshot_bytes: 20_000_000,
+    query_budget_bytes: {
+      build_or_update_graph: 4_000,
+      get_minimal_context: 4_000,
+      get_impact_radius: 6_000,
+      get_review_context: 1_000,
+    },
+  },
   log_path: defaultLogPath(),
   disabled_tools: [],
 };
@@ -86,6 +100,28 @@ const applyAggression = (cfg: Config): Config => {
       // larger injected limit). Aggressive (×0.5) is stricter on both.
       clamp_above_bytes: Math.round(cfg.read.clamp_above_bytes * m),
       injected_limit: Math.max(50, Math.round(cfg.read.injected_limit * m)),
+    },
+    graph: {
+      ...cfg.graph,
+      build_timeout_ms: Math.max(1_000, Math.round(cfg.graph.build_timeout_ms * m)),
+      query_budget_bytes: {
+        build_or_update_graph: Math.max(
+          512,
+          Math.round(cfg.graph.query_budget_bytes.build_or_update_graph * m),
+        ),
+        get_minimal_context: Math.max(
+          512,
+          Math.round(cfg.graph.query_budget_bytes.get_minimal_context * m),
+        ),
+        get_impact_radius: Math.max(
+          512,
+          Math.round(cfg.graph.query_budget_bytes.get_impact_radius * m),
+        ),
+        get_review_context: Math.max(
+          512,
+          Math.round(cfg.graph.query_budget_bytes.get_review_context * m),
+        ),
+      },
     },
   };
 };

--- a/src/core/log.ts
+++ b/src/core/log.ts
@@ -1,6 +1,7 @@
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import type { SavingsLogEntry } from "./types.js";
+import type { GraphBuildLogEntry } from "../graph/schema.js";
 
 export const appendSavingsLog = (logPath: string, entry: SavingsLogEntry): void => {
   try {
@@ -8,5 +9,14 @@ export const appendSavingsLog = (logPath: string, entry: SavingsLogEntry): void 
     appendFileSync(logPath, JSON.stringify(entry) + "\n", { flag: "a" });
   } catch {
     // Best-effort: logging must never break the hook.
+  }
+};
+
+export const appendGraphBuildLog = (logPath: string, entry: GraphBuildLogEntry): void => {
+  try {
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, JSON.stringify(entry) + "\n", { flag: "a" });
+  } catch {
+    // Best-effort: graph logging must never break build/status flows.
   }
 };

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -6,10 +6,20 @@ export const expandHome = (p: string): string =>
 
 export const tokenomyDir = (): string => join(homedir(), ".tokenomy");
 export const tokenomyBinDir = (): string => join(tokenomyDir(), "bin");
+export const tokenomyGraphRootDir = (): string => join(tokenomyDir(), "graphs");
 export const hookBinaryPath = (): string => join(tokenomyBinDir(), "tokenomy-hook");
 export const globalConfigPath = (): string => join(tokenomyDir(), "config.json");
 export const manifestPath = (): string => join(tokenomyDir(), "installed.json");
 export const defaultLogPath = (): string => join(tokenomyDir(), "savings.jsonl");
+export const graphDir = (repoId: string): string => join(tokenomyGraphRootDir(), repoId);
+export const graphSnapshotPath = (repoId: string): string =>
+  join(graphDir(repoId), "snapshot.json");
+export const graphMetaPath = (repoId: string): string =>
+  join(graphDir(repoId), "meta.json");
+export const graphBuildLogPath = (repoId: string): string =>
+  join(graphDir(repoId), "build.jsonl");
+export const graphLockPath = (repoId: string): string =>
+  join(graphDir(repoId), ".build.lock");
 
 export const claudeSettingsPath = (): string =>
   join(homedir(), ".claude", "settings.json");

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -82,11 +82,29 @@ export interface ReadRuleConfig {
   injected_limit: number;
 }
 
+export interface GraphQueryBudgetConfig {
+  build_or_update_graph: number;
+  get_minimal_context: number;
+  get_impact_radius: number;
+  get_review_context: number;
+}
+
+export interface GraphConfig {
+  enabled: boolean;
+  max_files: number;
+  hard_max_files: number;
+  build_timeout_ms: number;
+  max_edges_per_file: number;
+  max_snapshot_bytes: number;
+  query_budget_bytes: GraphQueryBudgetConfig;
+}
+
 export interface Config {
   aggression: "conservative" | "balanced" | "aggressive";
   gate: GateConfig;
   mcp: McpRuleConfig;
   read: ReadRuleConfig;
+  graph: GraphConfig;
   log_path: string;
   disabled_tools: string[];
 }

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,0 +1,1 @@
+export const TOKENOMY_VERSION = "0.1.0-alpha.4";

--- a/src/graph/build.ts
+++ b/src/graph/build.ts
@@ -1,0 +1,251 @@
+import { closeSync, mkdirSync, openSync, readFileSync, rmSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { Config } from "../core/types.js";
+import { graphBuildLogPath, graphLockPath } from "../core/paths.js";
+import { stableStringify } from "../util/json.js";
+import { TOKENOMY_VERSION } from "../core/version.js";
+import { enumerateGraphFiles } from "./enumerate.js";
+import { sha256FileSync } from "./hash.js";
+import { resolveRepoId } from "./repo-id.js";
+import {
+  GRAPH_SCHEMA_VERSION,
+  normalizeGraph,
+  type Edge,
+  type Graph,
+  type GraphMeta,
+  type Node,
+} from "./schema.js";
+import { getGraphStaleStatus } from "./stale.js";
+import { JsonGraphStore } from "./store.js";
+import type { BuildGraphResult, FailOpen } from "./types.js";
+import { loadTypescript } from "../parsers/ts/loader.js";
+import { extractTsFileGraph } from "../parsers/ts/extract.js";
+import { appendGraphBuildLog } from "../core/log.js";
+
+export interface BuildGraphOptions {
+  cwd: string;
+  force?: boolean;
+  config: Config;
+}
+
+const fail = (reason: string, hint?: string): FailOpen => ({ ok: false, reason, hint });
+
+const logGraphBuild = (
+  repoId: string,
+  repoPath: string,
+  result: BuildGraphResult,
+): void => {
+  appendGraphBuildLog(graphBuildLogPath(repoId), {
+    ts: new Date().toISOString(),
+    repo_id: repoId,
+    repo_path: repoPath,
+    built: result.ok ? result.data.built : false,
+    node_count: result.ok ? result.data.node_count : 0,
+    edge_count: result.ok ? result.data.edge_count : 0,
+    parse_error_count: result.ok ? result.data.parse_error_count : 0,
+    duration_ms: result.ok ? result.data.duration_ms : 0,
+    ...(result.ok ? {} : { reason: result.reason }),
+  });
+};
+
+const acquireBuildLock = (repoId: string): (() => void) | FailOpen => {
+  const path = graphLockPath(repoId);
+  mkdirSync(dirname(path), { recursive: true });
+  try {
+    const fd = openSync(path, "wx");
+    return () => {
+      closeSync(fd);
+      rmSync(path, { force: true });
+    };
+  } catch {
+    return fail("build-in-progress");
+  }
+};
+
+const buildGraphFromFiles = async (
+  repoId: string,
+  repoPath: string,
+  files: string[],
+  skipped_files: string[],
+  cfg: Config,
+): Promise<BuildGraphResult> => {
+  const tsLoaded = await loadTypescript(repoPath);
+  if (!tsLoaded.ok) return tsLoaded;
+
+  const deadline = Date.now() + cfg.graph.build_timeout_ms;
+  const fileSet = new Set(files);
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+  const parse_errors: Graph["parse_errors"] = [];
+  const file_hashes: Record<string, string> = {};
+  const file_mtimes: Record<string, number> = {};
+
+  for (const file of files) {
+    if (Date.now() > deadline) return fail("timeout");
+    const absPath = join(repoPath, ...file.split("/"));
+    const st = statSync(absPath);
+    file_hashes[file] = sha256FileSync(absPath);
+    file_mtimes[file] = st.mtimeMs;
+    const source = readFileSync(absPath, "utf8");
+    const extracted = extractTsFileGraph(file, source, fileSet, tsLoaded.ts);
+    if (extracted.edges.length > cfg.graph.max_edges_per_file) {
+      return fail("graph-too-large", `Edge cap exceeded in ${file}`);
+    }
+    nodes.push(...extracted.nodes);
+    edges.push(...extracted.edges);
+    parse_errors.push(...extracted.parse_errors);
+  }
+
+  const graph = normalizeGraph({
+    schema_version: GRAPH_SCHEMA_VERSION,
+    repo_id: repoId,
+    nodes,
+    edges,
+    parse_errors,
+  });
+  const serialized = `${stableStringify(graph)}\n`;
+  const snapshotBytes = Buffer.byteLength(serialized, "utf8");
+  if (snapshotBytes > cfg.graph.max_snapshot_bytes) {
+    return fail("graph-too-large", "Snapshot exceeded graph.max_snapshot_bytes");
+  }
+
+  const meta: GraphMeta = {
+    schema_version: GRAPH_SCHEMA_VERSION,
+    repo_id: repoId,
+    repo_path: repoPath,
+    built_at: new Date().toISOString(),
+    tokenomy_version: TOKENOMY_VERSION,
+    node_count: graph.nodes.length,
+    edge_count: graph.edges.length,
+    file_hashes,
+    file_mtimes,
+    soft_cap: cfg.graph.max_files,
+    hard_cap: cfg.graph.hard_max_files,
+    parse_error_count: graph.parse_errors.length,
+  };
+  new JsonGraphStore().save(repoId, graph, meta);
+
+  return {
+    ok: true,
+    stale: false,
+    stale_files: [],
+    data: {
+      repo_id: repoId,
+      built: true,
+      node_count: graph.nodes.length,
+      edge_count: graph.edges.length,
+      parse_error_count: graph.parse_errors.length,
+      duration_ms: 0,
+      skipped_files,
+    },
+  };
+};
+
+export const buildGraph = async (options: BuildGraphOptions): Promise<BuildGraphResult> => {
+  const start = Date.now();
+  const identity = resolveRepoId(options.cwd);
+  const store = new JsonGraphStore();
+
+  if (!options.config.graph.enabled) {
+    const result = fail("graph-disabled");
+    logGraphBuild(identity.repoId, identity.repoPath, result);
+    return result;
+  }
+
+  const unlock = acquireBuildLock(identity.repoId);
+  if (typeof unlock !== "function") {
+    logGraphBuild(identity.repoId, identity.repoPath, unlock);
+    return unlock;
+  }
+
+  try {
+    if (!options.force) {
+      const existingMeta = store.loadMeta(identity.repoId);
+      const existingGraph = store.loadGraph(identity.repoId);
+      if (existingMeta && existingGraph) {
+        const stale = getGraphStaleStatus(identity.repoPath, existingMeta, options.config);
+        if (!stale.ok) {
+          logGraphBuild(identity.repoId, identity.repoPath, stale);
+          return stale;
+        }
+        if (!stale.stale) {
+          const result: BuildGraphResult = {
+            ok: true,
+            stale: false,
+            stale_files: [],
+            data: {
+              repo_id: identity.repoId,
+              built: false,
+              node_count: existingMeta.node_count,
+              edge_count: existingMeta.edge_count,
+              parse_error_count: existingMeta.parse_error_count,
+              duration_ms: Date.now() - start,
+              skipped_files: [],
+            },
+          };
+          logGraphBuild(identity.repoId, identity.repoPath, result);
+          return result;
+        }
+      }
+    }
+
+    const enumerated = enumerateGraphFiles(identity.repoPath, options.config);
+    if (!enumerated.ok) {
+      logGraphBuild(identity.repoId, identity.repoPath, enumerated);
+      return enumerated;
+    }
+    if (enumerated.files.length === 0) {
+      const result = fail("no-files");
+      logGraphBuild(identity.repoId, identity.repoPath, result);
+      return result;
+    }
+
+    const built = await buildGraphFromFiles(
+      identity.repoId,
+      identity.repoPath,
+      enumerated.files,
+      enumerated.skipped_files,
+      options.config,
+    );
+    if (!built.ok) {
+      logGraphBuild(identity.repoId, identity.repoPath, built);
+      return built;
+    }
+    built.data.duration_ms = Date.now() - start;
+    logGraphBuild(identity.repoId, identity.repoPath, built);
+    return built;
+  } catch (error) {
+    const result = fail("io-error", (error as Error).message);
+    logGraphBuild(identity.repoId, identity.repoPath, result);
+    return result;
+  } finally {
+    unlock();
+  }
+};
+
+export const readGraphStatus = (cwd: string, config: Config): import("./types.js").GraphStatusResult => {
+  if (!config.graph.enabled) return fail("graph-disabled");
+  const identity = resolveRepoId(cwd);
+  const store = new JsonGraphStore();
+  const meta = store.loadMeta(identity.repoId);
+  const graph = store.loadGraph(identity.repoId);
+  if (!meta || !graph) return fail("graph-not-built");
+
+  const stale = getGraphStaleStatus(identity.repoPath, meta, config);
+  if (!stale.ok) return stale;
+
+  return {
+    ok: true,
+    stale: stale.stale,
+    stale_files: stale.stale_files,
+    data: {
+      repo_id: identity.repoId,
+      repo_path: meta.repo_path,
+      built_at: meta.built_at,
+      file_count: Object.keys(meta.file_hashes).length,
+      node_count: meta.node_count,
+      edge_count: meta.edge_count,
+      parse_error_count: meta.parse_error_count,
+    },
+  };
+};

--- a/src/graph/enumerate.ts
+++ b/src/graph/enumerate.ts
@@ -1,0 +1,116 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join, posix, relative } from "node:path";
+import type { Config } from "../core/types.js";
+import type { FailOpen } from "./types.js";
+
+const CODE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
+const IGNORED_DIRS = new Set([
+  ".git",
+  ".next",
+  ".nuxt",
+  ".turbo",
+  ".yarn",
+  "coverage",
+  "dist",
+  "node_modules",
+]);
+
+export interface EnumerateFilesOk {
+  ok: true;
+  files: string[];
+  skipped_files: string[];
+  source: "git" | "walk";
+}
+
+export type EnumerateFilesResult = EnumerateFilesOk | FailOpen;
+
+const toPosixRelative = (root: string, absPath: string): string =>
+  relative(root, absPath).split("\\").join("/");
+
+const isCodeFile = (relPath: string): boolean => {
+  if (relPath.endsWith(".d.ts")) return false;
+  const idx = relPath.lastIndexOf(".");
+  if (idx === -1) return false;
+  return CODE_EXTS.has(relPath.slice(idx));
+};
+
+const filterFiles = (
+  repoPath: string,
+  candidates: string[],
+  cfg: Config,
+): EnumerateFilesResult => {
+  const files = new Set<string>();
+  for (const candidate of candidates) {
+    if (!isCodeFile(candidate)) continue;
+    const abs = join(repoPath, ...candidate.split("/"));
+    if (!existsSync(abs)) continue;
+    try {
+      const st = statSync(abs);
+      if (!st.isFile()) continue;
+    } catch {
+      continue;
+    }
+    files.add(posix.normalize(candidate));
+    if (files.size > cfg.graph.hard_max_files) {
+      return { ok: false, reason: "repo-too-large" };
+    }
+  }
+  return { ok: true, files: [...files].sort(), skipped_files: [], source: "git" };
+};
+
+const enumerateViaGit = (repoPath: string, cfg: Config): EnumerateFilesResult => {
+  try {
+    const out = execFileSync(
+      "git",
+      ["ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+      { cwd: repoPath, encoding: "buffer", stdio: ["ignore", "pipe", "ignore"] },
+    );
+    const candidates = out
+      .toString("utf8")
+      .split("\u0000")
+      .filter((entry) => entry.length > 0);
+    return filterFiles(repoPath, candidates, cfg);
+  } catch {
+    return { ok: false, reason: "git-unavailable" };
+  }
+};
+
+const walkDir = (
+  repoPath: string,
+  dirPath: string,
+  files: Set<string>,
+  cfg: Config,
+): FailOpen | null => {
+  const entries = readdirSync(dirPath, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (IGNORED_DIRS.has(entry.name)) continue;
+      const nested = walkDir(repoPath, join(dirPath, entry.name), files, cfg);
+      if (nested) return nested;
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    const rel = posix.normalize(toPosixRelative(repoPath, join(dirPath, entry.name)));
+    if (!isCodeFile(rel)) continue;
+    files.add(rel);
+    if (files.size > cfg.graph.hard_max_files) {
+      return { ok: false, reason: "repo-too-large" };
+    }
+  }
+  return null;
+};
+
+const enumerateViaWalk = (repoPath: string, cfg: Config): EnumerateFilesResult => {
+  const files = new Set<string>();
+  const error = walkDir(repoPath, repoPath, files, cfg);
+  if (error) return error;
+  return { ok: true, files: [...files].sort(), skipped_files: [], source: "walk" };
+};
+
+export const enumerateGraphFiles = (repoPath: string, cfg: Config): EnumerateFilesResult => {
+  const viaGit = enumerateViaGit(repoPath, cfg);
+  if (viaGit.ok) return viaGit;
+  if (viaGit.reason !== "git-unavailable") return viaGit;
+  return enumerateViaWalk(repoPath, cfg);
+};

--- a/src/graph/hash.ts
+++ b/src/graph/hash.ts
@@ -1,0 +1,21 @@
+import { closeSync, openSync, readSync } from "node:fs";
+import { createHash } from "node:crypto";
+
+export const sha256String = (input: string): string =>
+  createHash("sha256").update(input).digest("hex");
+
+export const sha256FileSync = (path: string): string => {
+  const fd = openSync(path, "r");
+  const hash = createHash("sha256");
+  const buffer = Buffer.allocUnsafe(64 * 1024);
+  try {
+    while (true) {
+      const read = readSync(fd, buffer, 0, buffer.length, null);
+      if (read === 0) break;
+      hash.update(buffer.subarray(0, read));
+    }
+  } finally {
+    closeSync(fd);
+  }
+  return hash.digest("hex");
+};

--- a/src/graph/query/budget.ts
+++ b/src/graph/query/budget.ts
@@ -1,0 +1,62 @@
+import { utf8Bytes } from "../../rules/text-trim.js";
+
+const findArrayPaths = (
+  value: unknown,
+  path: Array<string | number> = [],
+  out: Array<{ path: Array<string | number>; length: number }> = [],
+): Array<{ path: Array<string | number>; length: number }> => {
+  if (Array.isArray(value)) {
+    out.push({ path, length: value.length });
+    value.forEach((item, index) => findArrayPaths(item, [...path, index], out));
+    return out;
+  }
+  if (value && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) findArrayPaths(child, [...path, key], out);
+  }
+  return out;
+};
+
+const getAtPath = (root: unknown, path: Array<string | number>): unknown =>
+  path.reduce<unknown>((acc, part) => (acc && typeof acc === "object" ? (acc as Record<string, unknown>)[part as string] : undefined), root);
+
+const cloneValue = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+const setAtPath = (root: unknown, path: Array<string | number>, next: unknown): void => {
+  if (path.length === 0) return;
+  let current = root as Record<string, unknown>;
+  for (let i = 0; i < path.length - 1; i++) {
+    current = current[path[i] as string] as Record<string, unknown>;
+  }
+  current[path[path.length - 1] as string] = next;
+};
+
+export const clipResultToBudget = <T extends { ok: boolean; truncated?: { dropped_count: number } }>(
+  result: T,
+  budgetBytes: number,
+): T => {
+  const copy = cloneValue(result);
+  let serialized = JSON.stringify(copy);
+  if (utf8Bytes(serialized) <= budgetBytes) return copy;
+
+  let dropped = 0;
+  while (utf8Bytes(serialized) > budgetBytes) {
+    const candidates = findArrayPaths(copy)
+      .filter((candidate) => candidate.length > 0)
+      .sort((a, b) => b.length - a.length);
+    const largest = candidates[0];
+    if (!largest) break;
+    const arr = getAtPath(copy, largest.path);
+    if (!Array.isArray(arr) || arr.length === 0) break;
+    const next = arr.slice(0, arr.length - 1);
+    setAtPath(copy, largest.path, next);
+    dropped++;
+    serialized = JSON.stringify(copy);
+  }
+
+  if (dropped > 0 && copy.ok) {
+    copy.truncated = { dropped_count: dropped };
+  }
+  return copy;
+};
+
+export const limitByCount = <T>(items: T[], max: number): T[] => items.slice(0, Math.max(0, max));

--- a/src/graph/query/common.ts
+++ b/src/graph/query/common.ts
@@ -1,0 +1,116 @@
+import type { Config } from "../../core/types.js";
+import { resolveRepoId } from "../repo-id.js";
+import type { Edge, Graph, GraphMeta, Node, NodeKind } from "../schema.js";
+import { JsonGraphStore } from "../store.js";
+import { getGraphStaleStatus } from "../stale.js";
+import type { FailOpen, QueryResult } from "../types.js";
+
+export interface GraphQueryContext {
+  graph: Graph;
+  meta: GraphMeta;
+  stale: boolean;
+  stale_files: string[];
+  repo_id: string;
+  repo_path: string;
+}
+
+export interface GraphIndex {
+  nodesById: Map<string, Node>;
+  outgoing: Map<string, Edge[]>;
+  incoming: Map<string, Edge[]>;
+  byFile: Map<string, Node[]>;
+}
+
+export const fail = (reason: string, hint?: string): FailOpen => ({ ok: false, reason, hint });
+
+export const loadGraphContext = (
+  cwd: string,
+  config: Config,
+): QueryResult<GraphQueryContext> => {
+  if (!config.graph.enabled) return fail("graph-disabled");
+  const identity = resolveRepoId(cwd);
+  const store = new JsonGraphStore();
+  const graph = store.loadGraph(identity.repoId);
+  const meta = store.loadMeta(identity.repoId);
+  if (!graph || !meta) return fail("graph-not-built");
+
+  const stale = getGraphStaleStatus(identity.repoPath, meta, config);
+  if (!stale.ok) return stale;
+
+  return {
+    ok: true,
+    stale: stale.stale,
+    stale_files: stale.stale_files,
+    data: {
+      graph,
+      meta,
+      stale: stale.stale,
+      stale_files: stale.stale_files,
+      repo_id: identity.repoId,
+      repo_path: identity.repoPath,
+    },
+  };
+};
+
+export const buildGraphIndex = (graph: Graph): GraphIndex => {
+  const nodesById = new Map<string, Node>();
+  const outgoing = new Map<string, Edge[]>();
+  const incoming = new Map<string, Edge[]>();
+  const byFile = new Map<string, Node[]>();
+
+  for (const node of graph.nodes) {
+    nodesById.set(node.id, node);
+    if (node.file) {
+      const bucket = byFile.get(node.file) ?? [];
+      bucket.push(node);
+      byFile.set(node.file, bucket);
+    }
+  }
+
+  for (const edge of graph.edges) {
+    const outBucket = outgoing.get(edge.from) ?? [];
+    outBucket.push(edge);
+    outgoing.set(edge.from, outBucket);
+
+    const inBucket = incoming.get(edge.to) ?? [];
+    inBucket.push(edge);
+    incoming.set(edge.to, inBucket);
+  }
+
+  return { nodesById, outgoing, incoming, byFile };
+};
+
+export const projectNode = (node: Node): {
+  id: string;
+  kind: NodeKind;
+  name: string;
+  file?: string;
+  line?: number;
+} => ({
+  id: node.id,
+  kind: node.kind,
+  name: node.name,
+  ...(node.file ? { file: node.file } : {}),
+  ...(node.range?.line ? { line: node.range.line } : {}),
+});
+
+export const resolveTargetNode = (
+  graph: Graph,
+  file: string,
+  symbol: string | undefined,
+): Node | null => {
+  const fileNode = graph.nodes.find((node) => node.id === `file:${file}`) ?? null;
+  if (!symbol) return fileNode;
+
+  const sameFile = graph.nodes.filter((node) => node.file === file);
+  const exactSymbol =
+    sameFile.find(
+      (node) =>
+        (node.kind === "function" || node.kind === "class" || node.kind === "method") &&
+        (node.name === symbol || node.id.includes(`#${symbol}@`) || node.id.includes(`.${symbol}@`)),
+    ) ?? null;
+  if (exactSymbol) return exactSymbol;
+
+  const exported = sameFile.find((node) => node.kind === "exported-symbol" && node.name === symbol) ?? null;
+  return exported ?? fileNode;
+};

--- a/src/graph/query/impact.ts
+++ b/src/graph/query/impact.ts
@@ -1,0 +1,109 @@
+import { basename } from "node:path";
+import type { Config } from "../../core/types.js";
+import type { Confidence, Edge, Graph } from "../schema.js";
+import type {
+  ImpactRadiusDependency,
+  ImpactRadiusInput,
+  ImpactRadiusResult,
+} from "../types.js";
+import { buildGraphIndex, projectNode, resolveTargetNode } from "./common.js";
+import { clipResultToBudget, limitByCount } from "./budget.js";
+
+const REVERSE_KINDS = new Set<Edge["kind"]>(["imports", "exports", "calls", "references"]);
+
+const confidenceRank = (confidence: Confidence): number =>
+  confidence === "definite" ? 0 : 1;
+
+const collectSuggestedTests = (graph: Graph, reachedFiles: Set<string>): string[] => {
+  const suggestions = new Set<string>();
+  for (const node of graph.nodes) {
+    if (node.kind !== "test-file" || !node.file) continue;
+    for (const file of reachedFiles) {
+      const base = basename(file).replace(/\.[^.]+$/, "");
+      const testBase = basename(node.file).replace(/\.(test|spec)\.[^.]+$/, "");
+      if (base === testBase) suggestions.add(node.file);
+    }
+  }
+  return [...suggestions].sort();
+};
+
+export const impactRadius = (
+  graph: Graph,
+  input: ImpactRadiusInput,
+  cfg: Config,
+  stale: boolean,
+  stale_files: string[],
+): ImpactRadiusResult => {
+  const maxDepth = Math.max(1, Math.min(3, input.max_depth ?? 2));
+  const index = buildGraphIndex(graph);
+  const seeds = new Set<string>();
+
+  for (const changed of input.changed) {
+    const fileNode = resolveTargetNode(graph, changed.file, undefined);
+    if (fileNode) seeds.add(fileNode.id);
+    for (const symbol of changed.symbols ?? []) {
+      const target = resolveTargetNode(graph, changed.file, symbol);
+      if (target) seeds.add(target.id);
+    }
+  }
+  if (seeds.size === 0) return { ok: false, reason: "target-not-found" };
+
+  const visited = new Map<string, { depth: number; confidence: Confidence }>();
+  const queue: Array<{ id: string; depth: number; confidence: Confidence }> = [...seeds].map(
+    (id) => ({ id, depth: 0, confidence: "definite" }),
+  );
+  const reverse_deps: ImpactRadiusDependency[] = [];
+  const reachedFiles = new Set<string>();
+
+  while (queue.length > 0 && visited.size < 512) {
+    const current = queue.shift()!;
+    const seen = visited.get(current.id);
+    if (seen && seen.depth <= current.depth && confidenceRank(seen.confidence) <= confidenceRank(current.confidence)) {
+      continue;
+    }
+    visited.set(current.id, { depth: current.depth, confidence: current.confidence });
+
+    const incoming = index.incoming.get(current.id) ?? [];
+    for (const edge of incoming) {
+      if (!REVERSE_KINDS.has(edge.kind)) continue;
+      const source = index.nodesById.get(edge.from);
+      if (!source) continue;
+      const nextDepth = current.depth + 1;
+      if (nextDepth > maxDepth) continue;
+      const nextConfidence: Confidence =
+        current.confidence === "definite" && edge.confidence === "definite" ? "definite" : "inferred";
+      queue.push({ id: source.id, depth: nextDepth, confidence: nextConfidence });
+
+      if (!seeds.has(source.id)) {
+        reverse_deps.push({
+          ...projectNode(source),
+          depth: nextDepth,
+          confidence: nextConfidence,
+        });
+        if (source.file) reachedFiles.add(source.file);
+      }
+    }
+  }
+
+  reverse_deps.sort((a, b) => {
+    if (a.depth !== b.depth) return a.depth - b.depth;
+    const conf = confidenceRank(a.confidence) - confidenceRank(b.confidence);
+    if (conf !== 0) return conf;
+    return a.id.localeCompare(b.id);
+  });
+
+  const suggested_tests = limitByCount(collectSuggestedTests(graph, reachedFiles), 20);
+  return clipResultToBudget(
+    {
+      ok: true,
+      stale,
+      stale_files,
+      data: {
+        reverse_deps: limitByCount(reverse_deps, 80),
+        suggested_tests,
+        summary: `reverse deps: ${reverse_deps.length}, suggested tests: ${suggested_tests.length}`,
+      },
+    },
+    cfg.graph.query_budget_bytes.get_impact_radius,
+  );
+};

--- a/src/graph/query/minimal.ts
+++ b/src/graph/query/minimal.ts
@@ -1,0 +1,93 @@
+import type { Config } from "../../core/types.js";
+import type { Graph, Edge } from "../schema.js";
+import type {
+  MinimalContextInput,
+  MinimalContextNeighbor,
+  MinimalContextResult,
+} from "../types.js";
+import { buildGraphIndex, projectNode, resolveTargetNode } from "./common.js";
+import { clipResultToBudget, limitByCount } from "./budget.js";
+
+const EDGE_PRIORITY: Record<Edge["kind"], number> = {
+  imports: 0,
+  exports: 1,
+  contains: 2,
+  calls: 3,
+  references: 4,
+  tests: 5,
+};
+
+export const minimalContext = (
+  graph: Graph,
+  input: MinimalContextInput,
+  cfg: Config,
+  stale: boolean,
+  stale_files: string[],
+): MinimalContextResult => {
+  const target = resolveTargetNode(graph, input.target.file, input.target.symbol);
+  if (!target) return { ok: false, reason: "target-not-found" };
+
+  const depthLimit = Math.max(1, Math.min(2, input.depth ?? 1));
+  const index = buildGraphIndex(graph);
+  const visited = new Set<string>([target.id]);
+  const queue: Array<{ id: string; depth: number }> = [{ id: target.id, depth: 0 }];
+  const neighbors: MinimalContextNeighbor[] = [];
+
+  while (queue.length > 0 && visited.size < 64) {
+    const current = queue.shift()!;
+    if (current.depth >= depthLimit) continue;
+    const outgoing = index.outgoing.get(current.id) ?? [];
+    const incoming = index.incoming.get(current.id) ?? [];
+
+    for (const edge of outgoing) {
+      const node = index.nodesById.get(edge.to);
+      if (!node || visited.has(node.id)) continue;
+      visited.add(node.id);
+      queue.push({ id: node.id, depth: current.depth + 1 });
+      neighbors.push({
+        ...projectNode(node),
+        edge_kind: edge.kind,
+        direction: "out",
+        confidence: edge.confidence,
+        depth: current.depth + 1,
+      });
+    }
+
+    for (const edge of incoming) {
+      const node = index.nodesById.get(edge.from);
+      if (!node || visited.has(node.id)) continue;
+      visited.add(node.id);
+      queue.push({ id: node.id, depth: current.depth + 1 });
+      neighbors.push({
+        ...projectNode(node),
+        edge_kind: edge.kind,
+        direction: "in",
+        confidence: edge.confidence,
+        depth: current.depth + 1,
+      });
+    }
+  }
+
+  neighbors.sort((a, b) => {
+    const conf = Number(a.confidence === "inferred") - Number(b.confidence === "inferred");
+    if (conf !== 0) return conf;
+    const edge = EDGE_PRIORITY[a.edge_kind as Edge["kind"]] - EDGE_PRIORITY[b.edge_kind as Edge["kind"]];
+    if (edge !== 0) return edge;
+    if (a.depth !== b.depth) return a.depth - b.depth;
+    return a.id.localeCompare(b.id);
+  });
+
+  return clipResultToBudget(
+    {
+      ok: true,
+      stale,
+      stale_files,
+      data: {
+        focal: projectNode(target),
+        neighbors: limitByCount(neighbors, 40),
+        hint: `If this is insufficient, try get_impact_radius or Read ${input.target.file}`,
+      },
+    },
+    cfg.graph.query_budget_bytes.get_minimal_context,
+  );
+};

--- a/src/graph/query/review.ts
+++ b/src/graph/query/review.ts
@@ -1,0 +1,61 @@
+import type { Config } from "../../core/types.js";
+import type { Graph } from "../schema.js";
+import type { ReviewContextInput, ReviewContextResult } from "../types.js";
+import { buildGraphIndex } from "./common.js";
+import { clipResultToBudget, limitByCount } from "./budget.js";
+
+export const reviewContext = (
+  graph: Graph,
+  input: ReviewContextInput,
+  cfg: Config,
+  stale: boolean,
+  stale_files: string[],
+): ReviewContextResult => {
+  const index = buildGraphIndex(graph);
+  const changed_files = input.files.filter((file) => index.nodesById.has(`file:${file}`)).sort();
+  if (changed_files.length === 0) return { ok: false, reason: "target-not-found" };
+
+  const exports_touched = graph.nodes.filter(
+    (node) => node.kind === "exported-symbol" && node.file && changed_files.includes(node.file),
+  ).length;
+
+  const fanout_summary = changed_files.map((file) => {
+    const fileId = `file:${file}`;
+    const imports = (index.outgoing.get(fileId) ?? []).filter((edge) => edge.kind === "imports").length;
+    const imported_by = (index.incoming.get(fileId) ?? []).filter((edge) => edge.kind === "imports").length;
+    return { file, imported_by, imports };
+  });
+
+  const hotspots = [...index.byFile.entries()]
+    .map(([file, nodes]) => {
+      const fileId = `file:${file}`;
+      const imported_by = (index.incoming.get(fileId) ?? []).filter((edge) => edge.kind === "imports").length;
+      const calls_in = nodes.reduce(
+        (sum, node) => sum + (index.incoming.get(node.id) ?? []).filter((edge) => edge.kind === "calls").length,
+        0,
+      );
+      const score = imported_by + calls_in;
+      return {
+        file,
+        score,
+        reason: `imports in: ${imported_by}, calls in: ${calls_in}`,
+      };
+    })
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score || a.file.localeCompare(b.file));
+
+  return clipResultToBudget(
+    {
+      ok: true,
+      stale,
+      stale_files,
+      data: {
+        changed_files,
+        exports_touched,
+        fanout_summary: limitByCount(fanout_summary, changed_files.length),
+        hotspots: limitByCount(hotspots, 5),
+      },
+    },
+    cfg.graph.query_budget_bytes.get_review_context,
+  );
+};

--- a/src/graph/repo-id.ts
+++ b/src/graph/repo-id.ts
@@ -1,0 +1,26 @@
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { sha256String } from "./hash.js";
+
+export interface RepoIdentity {
+  repoId: string;
+  repoPath: string;
+}
+
+const resolveGitRoot = (cwd: string): string | null => {
+  try {
+    const out = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return out.length > 0 ? resolve(out) : null;
+  } catch {
+    return null;
+  }
+};
+
+export const resolveRepoId = (cwd: string): RepoIdentity => {
+  const repoPath = resolveGitRoot(cwd) ?? resolve(cwd);
+  return { repoId: sha256String(resolve(repoPath)), repoPath: resolve(repoPath) };
+};

--- a/src/graph/resolve.ts
+++ b/src/graph/resolve.ts
@@ -1,0 +1,78 @@
+import { dirname, posix } from "node:path";
+
+export interface ResolveImportTarget {
+  kind: "file" | "external-module" | "missing-file";
+  target: string;
+  message?: string;
+}
+
+const PROBE_EXTS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"];
+
+// TS NodeNext ESM convention: authors write `.js` in imports but the actual
+// source is `.ts`. Map each runtime extension to the TS equivalents we should try.
+const JS_TO_TS_EXTS: Record<string, string[]> = {
+  ".js": [".ts", ".tsx"],
+  ".jsx": [".tsx"],
+  ".mjs": [".mts"],
+  ".cjs": [".cts"],
+};
+
+const cleanRepoRelative = (input: string): string | null => {
+  const normalized = posix.normalize(input);
+  if (normalized === "." || normalized.length === 0) return null;
+  if (normalized.startsWith("../")) return null;
+  return normalized.startsWith("./") ? normalized.slice(2) : normalized;
+};
+
+export const resolveSpecifier = (
+  importerFile: string,
+  specifier: string,
+  files: ReadonlySet<string>,
+): ResolveImportTarget => {
+  if (!specifier.startsWith(".") && !specifier.startsWith("/")) {
+    return { kind: "external-module", target: specifier };
+  }
+
+  const base = specifier.startsWith("/")
+    ? specifier.slice(1)
+    : posix.join(dirname(importerFile), specifier);
+  const normalized = cleanRepoRelative(base);
+  if (!normalized) {
+    return {
+      kind: "missing-file",
+      target: base.replace(/^\/+/, ""),
+      message: `specifier escapes repo root: ${specifier}`,
+    };
+  }
+
+  const candidates = new Set<string>();
+  candidates.add(normalized);
+  const currentExt = PROBE_EXTS.find((ext) => normalized.endsWith(ext));
+  if (currentExt) {
+    // Specifier already has an extension. If it's a runtime ext (.js/.jsx/.mjs/.cjs),
+    // also try the TS equivalents — common in TS NodeNext projects.
+    const swaps = JS_TO_TS_EXTS[currentExt] ?? [];
+    const base = normalized.slice(0, -currentExt.length);
+    for (const tsExt of swaps) {
+      candidates.add(base + tsExt);
+    }
+  } else {
+    for (const ext of PROBE_EXTS) {
+      candidates.add(`${normalized}${ext}`);
+      candidates.add(posix.join(normalized, `index${ext}`));
+    }
+  }
+
+  for (const candidate of candidates) {
+    if (files.has(candidate)) return { kind: "file", target: candidate };
+  }
+
+  const fallback =
+    [...candidates].find((candidate) => PROBE_EXTS.some((ext) => candidate.endsWith(ext))) ??
+    normalized;
+  return {
+    kind: "missing-file",
+    target: fallback,
+    message: `could not resolve ${specifier} from ${importerFile}`,
+  };
+};

--- a/src/graph/schema.ts
+++ b/src/graph/schema.ts
@@ -1,0 +1,211 @@
+export const GRAPH_SCHEMA_VERSION = 1;
+
+export type NodeKind =
+  | "file"
+  | "external-module"
+  | "function"
+  | "class"
+  | "method"
+  | "exported-symbol"
+  | "imported-symbol"
+  | "test-file";
+
+export type EdgeKind =
+  | "imports"
+  | "exports"
+  | "contains"
+  | "calls"
+  | "references"
+  | "tests";
+
+export type Confidence = "definite" | "inferred";
+
+export interface Node {
+  id: string;
+  kind: NodeKind;
+  name: string;
+  file?: string;
+  range?: { start: number; end: number; line: number };
+  exported?: boolean;
+}
+
+export interface Edge {
+  from: string;
+  to: string;
+  kind: EdgeKind;
+  confidence: Confidence;
+  via?: string;
+}
+
+export interface Graph {
+  schema_version: number;
+  repo_id: string;
+  nodes: Node[];
+  edges: Edge[];
+  parse_errors: { file: string; message: string }[];
+}
+
+export interface GraphMeta {
+  schema_version: number;
+  repo_id: string;
+  repo_path: string;
+  built_at: string;
+  tokenomy_version: string;
+  node_count: number;
+  edge_count: number;
+  file_hashes: Record<string, string>;
+  file_mtimes: Record<string, number>;
+  soft_cap: number;
+  hard_cap: number;
+  parse_error_count: number;
+}
+
+export interface GraphBuildLogEntry {
+  ts: string;
+  repo_id: string;
+  repo_path: string;
+  built: boolean;
+  node_count: number;
+  edge_count: number;
+  parse_error_count: number;
+  duration_ms: number;
+  reason?: string;
+}
+
+export const createFileNode = (file: string): Node => ({
+  id: `file:${file}`,
+  kind: "file",
+  name: file,
+  file,
+});
+
+export const createExternalModuleNode = (specifier: string): Node => ({
+  id: `ext:${specifier}`,
+  kind: "external-module",
+  name: specifier,
+});
+
+const symbolRange = (
+  start: number,
+  end: number,
+  line: number,
+): NonNullable<Node["range"]> => ({ start, end, line });
+
+export const createFunctionNode = (
+  file: string,
+  name: string,
+  line: number,
+  n: number,
+  start: number,
+  end: number,
+): Node => ({
+  id: `sym:${file}#${name}@${line}:${n}`,
+  kind: "function",
+  name,
+  file,
+  range: symbolRange(start, end, line),
+});
+
+export const createClassNode = (
+  file: string,
+  name: string,
+  line: number,
+  n: number,
+  start: number,
+  end: number,
+): Node => ({
+  id: `sym:${file}#${name}@${line}:${n}`,
+  kind: "class",
+  name,
+  file,
+  range: symbolRange(start, end, line),
+});
+
+export const createMethodNode = (
+  file: string,
+  className: string,
+  name: string,
+  line: number,
+  n: number,
+  start: number,
+  end: number,
+): Node => ({
+  id: `sym:${file}#${className}.${name}@${line}:${n}`,
+  kind: "method",
+  name,
+  file,
+  range: symbolRange(start, end, line),
+});
+
+export const createImportedSymbolNode = (
+  file: string,
+  name: string,
+  line: number,
+  n: number,
+): Node => ({
+  id: `imp:${file}#${name}@${line}:${n}`,
+  kind: "imported-symbol",
+  name,
+  file,
+  range: symbolRange(0, 0, line),
+});
+
+export const createExportedSymbolNode = (file: string, name: string): Node => ({
+  id: `exp:${file}#${name}`,
+  kind: "exported-symbol",
+  name,
+  file,
+  exported: true,
+});
+
+export const createTestFileNode = (file: string): Node => ({
+  id: `test:${file}`,
+  kind: "test-file",
+  name: file,
+  file,
+});
+
+export const isFileLikeNode = (node: Node): boolean =>
+  node.kind === "file" || node.kind === "test-file";
+
+export const isSymbolNode = (node: Node): boolean =>
+  node.kind === "function" || node.kind === "class" || node.kind === "method";
+
+const compareNodes = (a: Node, b: Node): number => a.id.localeCompare(b.id);
+
+const compareEdges = (a: Edge, b: Edge): number =>
+  a.from.localeCompare(b.from) ||
+  a.to.localeCompare(b.to) ||
+  a.kind.localeCompare(b.kind) ||
+  a.confidence.localeCompare(b.confidence) ||
+  (a.via ?? "").localeCompare(b.via ?? "");
+
+const compareParseErrors = (
+  a: { file: string; message: string },
+  b: { file: string; message: string },
+): number => a.file.localeCompare(b.file) || a.message.localeCompare(b.message);
+
+export const normalizeGraph = (graph: Graph): Graph => {
+  const nodes = [...new Map(graph.nodes.map((node) => [node.id, node])).values()].sort(compareNodes);
+  const edges = [
+    ...new Map(
+      graph.edges.map((edge) => [
+        `${edge.from}\u0000${edge.to}\u0000${edge.kind}\u0000${edge.confidence}\u0000${edge.via ?? ""}`,
+        edge,
+      ]),
+    ).values(),
+  ].sort(compareEdges);
+  const parse_errors = [
+    ...new Map(
+      graph.parse_errors.map((err) => [`${err.file}\u0000${err.message}`, err]),
+    ).values(),
+  ].sort(compareParseErrors);
+
+  return {
+    schema_version: GRAPH_SCHEMA_VERSION,
+    repo_id: graph.repo_id,
+    nodes,
+    edges,
+    parse_errors,
+  };
+};

--- a/src/graph/stale.ts
+++ b/src/graph/stale.ts
@@ -1,0 +1,56 @@
+import { existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { Config } from "../core/types.js";
+import type { GraphMeta } from "./schema.js";
+import { enumerateGraphFiles } from "./enumerate.js";
+import { sha256FileSync } from "./hash.js";
+import type { FailOpen } from "./types.js";
+
+export interface StaleStatus {
+  ok: true;
+  stale: boolean;
+  stale_files: string[];
+}
+
+export type GraphStaleResult = StaleStatus | FailOpen;
+
+export const getGraphStaleStatus = (
+  repoPath: string,
+  meta: GraphMeta,
+  cfg: Config,
+): GraphStaleResult => {
+  const enumerated = enumerateGraphFiles(repoPath, cfg);
+  if (!enumerated.ok) return enumerated;
+
+  const current = new Set(enumerated.files);
+  const previous = new Set(Object.keys(meta.file_hashes));
+  const stale = new Set<string>();
+
+  for (const file of current) {
+    if (!previous.has(file)) stale.add(file);
+  }
+  for (const file of previous) {
+    if (!current.has(file)) stale.add(file);
+  }
+
+  for (const file of current) {
+    if (!previous.has(file)) continue;
+    const absPath = join(repoPath, ...file.split("/"));
+    if (!existsSync(absPath)) {
+      stale.add(file);
+      continue;
+    }
+    let currentMtime = 0;
+    try {
+      currentMtime = statSync(absPath).mtimeMs;
+    } catch {
+      stale.add(file);
+      continue;
+    }
+    if (meta.file_mtimes[file] === currentMtime) continue;
+    if (meta.file_hashes[file] !== sha256FileSync(absPath)) stale.add(file);
+  }
+
+  const stale_files = [...stale].sort();
+  return { ok: true, stale: stale_files.length > 0, stale_files };
+};

--- a/src/graph/store.ts
+++ b/src/graph/store.ts
@@ -1,0 +1,48 @@
+import { existsSync, readFileSync } from "node:fs";
+import { graphMetaPath, graphSnapshotPath } from "../core/paths.js";
+import { atomicWrite } from "../util/atomic.js";
+import { safeParse, stableStringify } from "../util/json.js";
+import { GRAPH_SCHEMA_VERSION, type Graph, type GraphMeta } from "./schema.js";
+
+export interface GraphStore {
+  loadGraph(repoId: string): Graph | null;
+  loadMeta(repoId: string): GraphMeta | null;
+  save(repoId: string, graph: Graph, meta: GraphMeta): void;
+}
+
+const isGraph = (value: unknown): value is Graph =>
+  !!value &&
+  typeof value === "object" &&
+  (value as { schema_version?: unknown }).schema_version === GRAPH_SCHEMA_VERSION &&
+  Array.isArray((value as { nodes?: unknown }).nodes) &&
+  Array.isArray((value as { edges?: unknown }).edges) &&
+  Array.isArray((value as { parse_errors?: unknown }).parse_errors);
+
+const isGraphMeta = (value: unknown): value is GraphMeta =>
+  !!value &&
+  typeof value === "object" &&
+  (value as { schema_version?: unknown }).schema_version === GRAPH_SCHEMA_VERSION &&
+  typeof (value as { repo_id?: unknown }).repo_id === "string" &&
+  typeof (value as { repo_path?: unknown }).repo_path === "string" &&
+  typeof (value as { built_at?: unknown }).built_at === "string";
+
+export class JsonGraphStore implements GraphStore {
+  loadGraph(repoId: string): Graph | null {
+    const path = graphSnapshotPath(repoId);
+    if (!existsSync(path)) return null;
+    const parsed = safeParse<unknown>(readFileSync(path, "utf8"));
+    return isGraph(parsed) ? parsed : null;
+  }
+
+  loadMeta(repoId: string): GraphMeta | null {
+    const path = graphMetaPath(repoId);
+    if (!existsSync(path)) return null;
+    const parsed = safeParse<unknown>(readFileSync(path, "utf8"));
+    return isGraphMeta(parsed) ? parsed : null;
+  }
+
+  save(repoId: string, graph: Graph, meta: GraphMeta): void {
+    atomicWrite(graphSnapshotPath(repoId), `${stableStringify(graph)}\n`, false);
+    atomicWrite(graphMetaPath(repoId), `${stableStringify(meta)}\n`, false);
+  }
+}

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -1,0 +1,119 @@
+import type { Confidence, EdgeKind, NodeKind } from "./schema.js";
+
+export interface FailOpen {
+  ok: false;
+  reason: string;
+  hint?: string;
+}
+
+export interface Ok<T> {
+  ok: true;
+  stale?: boolean;
+  stale_files?: string[];
+  data: T;
+  truncated?: { dropped_count: number };
+}
+
+export type QueryResult<T> = Ok<T> | FailOpen;
+
+export interface BuildGraphData {
+  repo_id: string;
+  built: boolean;
+  node_count: number;
+  edge_count: number;
+  parse_error_count: number;
+  duration_ms: number;
+  skipped_files: string[];
+}
+
+export interface GraphStatusData {
+  repo_id: string;
+  repo_path: string;
+  built_at: string;
+  file_count: number;
+  node_count: number;
+  edge_count: number;
+  parse_error_count: number;
+}
+
+export interface MinimalContextInput {
+  target: {
+    file: string;
+    symbol?: string;
+  };
+  depth?: number;
+}
+
+export interface MinimalContextNeighbor {
+  id: string;
+  kind: NodeKind;
+  name: string;
+  file?: string;
+  line?: number;
+  edge_kind: EdgeKind;
+  direction: "in" | "out";
+  confidence: Confidence;
+  depth: number;
+}
+
+export interface MinimalContextData {
+  focal: {
+    id: string;
+    kind: NodeKind;
+    name: string;
+    file?: string;
+    line?: number;
+  };
+  neighbors: MinimalContextNeighbor[];
+  hint: string;
+}
+
+export interface ImpactRadiusInput {
+  changed: Array<{ file: string; symbols?: string[] }>;
+  max_depth?: number;
+}
+
+export interface ImpactRadiusDependency {
+  id: string;
+  kind: NodeKind;
+  name: string;
+  file?: string;
+  line?: number;
+  depth: number;
+  confidence: Confidence;
+}
+
+export interface ImpactRadiusData {
+  reverse_deps: ImpactRadiusDependency[];
+  suggested_tests: string[];
+  summary: string;
+}
+
+export interface ReviewContextInput {
+  files: string[];
+}
+
+export interface ReviewContextFanout {
+  file: string;
+  imported_by: number;
+  imports: number;
+}
+
+export interface ReviewContextHotspot {
+  file: string;
+  score: number;
+  reason: string;
+}
+
+export interface ReviewContextData {
+  changed_files: string[];
+  exports_touched: number;
+  fanout_summary: ReviewContextFanout[];
+  hotspots: ReviewContextHotspot[];
+}
+
+export type BuildGraphResult = QueryResult<BuildGraphData>;
+export type GraphStatusResult = QueryResult<GraphStatusData>;
+export type MinimalContextResult = QueryResult<MinimalContextData>;
+export type ImpactRadiusResult = QueryResult<ImpactRadiusData>;
+export type ReviewContextResult = QueryResult<ReviewContextData>;

--- a/src/hook/pre-dispatch.ts
+++ b/src/hook/pre-dispatch.ts
@@ -1,7 +1,28 @@
+import { existsSync } from "node:fs";
 import type { Config, PreHookInput, PreHookOutput, SavingsLogEntry } from "../core/types.js";
 import { readBoundRule } from "../rules/read-bound.js";
 import { estimateTokens } from "../core/gate.js";
 import { appendSavingsLog } from "../core/log.js";
+import { graphMetaPath, tokenomyGraphRootDir } from "../core/paths.js";
+import { resolveRepoId } from "../graph/repo-id.js";
+
+const graphHint = (cwd: string, cfg: Config): string | null => {
+  if (!cfg.graph.enabled) return null;
+  // Cheap gate before we pay for resolveRepoId (git subprocess):
+  // if no graphs dir exists at all, bail without spawning git.
+  if (!existsSync(tokenomyGraphRootDir())) return null;
+  try {
+    const { repoId } = resolveRepoId(cwd);
+    if (!existsSync(graphMetaPath(repoId))) return null;
+    return (
+      "[tokenomy: a local code graph snapshot exists for this repo. " +
+      "If the `tokenomy-graph` MCP server is connected, prefer `get_minimal_context`, " +
+      "`get_impact_radius`, or `get_review_context` before retrying broad `Read` calls.]"
+    );
+  } catch {
+    return null;
+  }
+};
 
 export const preDispatch = (
   input: PreHookInput,
@@ -29,11 +50,14 @@ export const preDispatch = (
   };
   appendSavingsLog(cfg.log_path, entry);
 
+  const hint = graphHint(input.cwd, cfg);
+  const additionalContext = [r.additionalContext, hint].filter(Boolean).join(" ");
+
   return {
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       updatedInput: r.updatedInput,
-      ...(r.additionalContext ? { additionalContext: r.additionalContext } : {}),
+      ...(additionalContext ? { additionalContext } : {}),
     },
   };
 };

--- a/src/mcp/budget-clip.ts
+++ b/src/mcp/budget-clip.ts
@@ -1,0 +1,7 @@
+import type { QueryResult } from "../graph/types.js";
+import { clipResultToBudget } from "../graph/query/budget.js";
+
+export const clipToolResultToBudget = <T>(
+  result: QueryResult<T>,
+  budgetBytes: number,
+): QueryResult<T> => clipResultToBudget(result, budgetBytes);

--- a/src/mcp/handlers.ts
+++ b/src/mcp/handlers.ts
@@ -1,0 +1,153 @@
+import { loadConfig } from "../core/config.js";
+import { buildGraph } from "../graph/build.js";
+import type { GraphQueryContext } from "../graph/query/common.js";
+import { loadGraphContext } from "../graph/query/common.js";
+import { impactRadius } from "../graph/query/impact.js";
+import { minimalContext } from "../graph/query/minimal.js";
+import { reviewContext } from "../graph/query/review.js";
+import type {
+  BuildGraphResult,
+  ImpactRadiusInput,
+  MinimalContextInput,
+  QueryResult,
+  ReviewContextInput,
+} from "../graph/types.js";
+import { clipToolResultToBudget } from "./budget-clip.js";
+
+const asObject = (value: unknown): Record<string, unknown> =>
+  value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+
+const fail = (reason: string, hint?: string) => ({ ok: false as const, reason, ...(hint ? { hint } : {}) });
+
+const parseMinimalContextInput = (args: Record<string, unknown>): MinimalContextInput | null => {
+  const target = asObject(args["target"]);
+  if (typeof target["file"] !== "string" || target["file"].length === 0) return null;
+  const depth = typeof args["depth"] === "number" ? args["depth"] : undefined;
+  return {
+    target: {
+      file: target["file"],
+      ...(typeof target["symbol"] === "string" ? { symbol: target["symbol"] } : {}),
+    },
+    ...(depth !== undefined ? { depth } : {}),
+  };
+};
+
+const parseImpactRadiusInput = (args: Record<string, unknown>): ImpactRadiusInput | null => {
+  const changed = Array.isArray(args["changed"]) ? args["changed"] : null;
+  if (!changed || changed.length === 0) return null;
+  const normalized = changed
+    .map((entry) => {
+      const value = asObject(entry);
+      if (typeof value["file"] !== "string" || value["file"].length === 0) return null;
+      const symbols = Array.isArray(value["symbols"])
+        ? value["symbols"].filter((symbol): symbol is string => typeof symbol === "string")
+        : undefined;
+      return {
+        file: value["file"],
+        ...(symbols && symbols.length > 0 ? { symbols } : {}),
+      };
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+  if (normalized.length === 0) return null;
+  return {
+    changed: normalized,
+    ...(typeof args["max_depth"] === "number" ? { max_depth: args["max_depth"] } : {}),
+  };
+};
+
+const parseReviewContextInput = (args: Record<string, unknown>): ReviewContextInput | null => {
+  const files = Array.isArray(args["files"])
+    ? args["files"].filter((file): file is string => typeof file === "string" && file.length > 0)
+    : [];
+  return files.length > 0 ? { files } : null;
+};
+
+const withGraphContext = <T>(
+  cwd: string,
+  run: (config: ReturnType<typeof loadConfig>, graphContext: GraphQueryContext) => QueryResult<T>,
+): QueryResult<T> => {
+  const config = loadConfig(cwd);
+  const graphContext = loadGraphContext(cwd, config);
+  if (!graphContext.ok) return graphContext;
+  return run(config, graphContext.data);
+};
+
+const withBudget = <T>(
+  result: QueryResult<T>,
+  budgetBytes: number,
+): QueryResult<T> => clipToolResultToBudget(result, budgetBytes);
+
+export const dispatchGraphTool = async (
+  name: string,
+  rawArgs: unknown,
+  cwd: string,
+): Promise<QueryResult<unknown>> => {
+  const args = asObject(rawArgs);
+
+  if (name === "build_or_update_graph") {
+    const target = typeof args["path"] === "string" ? args["path"] : cwd;
+    const config = loadConfig(target);
+    if (!config.graph.enabled) return fail("graph-disabled");
+    const result: BuildGraphResult = await buildGraph({
+      cwd: target,
+      force: args["force"] === true,
+      config,
+    });
+    return withBudget(result, config.graph.query_budget_bytes.build_or_update_graph);
+  }
+
+  if (name === "get_minimal_context") {
+    const input = parseMinimalContextInput(args);
+    if (!input) return fail("invalid-input", "Expected { target: { file, symbol? }, depth? }.");
+    return withGraphContext(cwd, (config, graphContext) =>
+      withBudget(
+        minimalContext(
+          graphContext.graph,
+          input,
+          config,
+          graphContext.stale,
+          graphContext.stale_files,
+        ),
+        config.graph.query_budget_bytes.get_minimal_context,
+      ),
+    );
+  }
+
+  if (name === "get_impact_radius") {
+    const input = parseImpactRadiusInput(args);
+    if (!input) return fail("invalid-input", "Expected { changed: [{ file, symbols? }], max_depth? }.");
+    return withGraphContext(cwd, (config, graphContext) =>
+      withBudget(
+        impactRadius(
+          graphContext.graph,
+          input,
+          config,
+          graphContext.stale,
+          graphContext.stale_files,
+        ),
+        config.graph.query_budget_bytes.get_impact_radius,
+      ),
+    );
+  }
+
+  if (name === "get_review_context") {
+    const input = parseReviewContextInput(args);
+    if (!input) return fail("invalid-input", "Expected { files: string[] }.");
+    return withGraphContext(cwd, (config, graphContext) =>
+      withBudget(
+        reviewContext(
+          graphContext.graph,
+          input,
+          config,
+          graphContext.stale,
+          graphContext.stale_files,
+        ),
+        config.graph.query_budget_bytes.get_review_context,
+      ),
+    );
+  }
+
+  return fail("unsupported-tool");
+};

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -1,0 +1,95 @@
+export interface JsonSchema {
+  type?: string;
+  description?: string;
+  properties?: Record<string, JsonSchema>;
+  items?: JsonSchema;
+  required?: string[];
+  additionalProperties?: boolean;
+  enum?: Array<string | number | boolean>;
+  minimum?: number;
+  maximum?: number;
+}
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: JsonSchema;
+}
+
+export const TOOL_DEFS: ToolDefinition[] = [
+  {
+    name: "build_or_update_graph",
+    description: "Build or refresh the local Tokenomy code graph for the current repository.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        force: { type: "boolean" },
+        path: { type: "string" },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_minimal_context",
+    description: "Return the smallest useful neighborhood around a file or symbol.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        target: {
+          type: "object",
+          properties: {
+            file: { type: "string" },
+            symbol: { type: "string" },
+          },
+          required: ["file"],
+          additionalProperties: false,
+        },
+        depth: { type: "number", minimum: 1, maximum: 2 },
+      },
+      required: ["target"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_impact_radius",
+    description: "Return reverse dependencies and suggested tests for changed files or symbols.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        changed: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              file: { type: "string" },
+              symbols: {
+                type: "array",
+                items: { type: "string" },
+              },
+            },
+            required: ["file"],
+            additionalProperties: false,
+          },
+        },
+        max_depth: { type: "number", minimum: 1, maximum: 3 },
+      },
+      required: ["changed"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "get_review_context",
+    description: "Rank changed files and repo hotspots for code review.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        files: {
+          type: "array",
+          items: { type: "string" },
+        },
+      },
+      required: ["files"],
+      additionalProperties: false,
+    },
+  },
+];

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,37 @@
+import { TOKENOMY_VERSION } from "../core/version.js";
+import { stableStringify } from "../util/json.js";
+import { dispatchGraphTool } from "./handlers.js";
+import { TOOL_DEFS } from "./schemas.js";
+
+export const startGraphServer = async (cwd: string): Promise<void> => {
+  const [{ Server }, { StdioServerTransport }, { CallToolRequestSchema, ListToolsRequestSchema }] =
+    await Promise.all([
+      import("@modelcontextprotocol/sdk/server/index.js"),
+      import("@modelcontextprotocol/sdk/server/stdio.js"),
+      import("@modelcontextprotocol/sdk/types.js"),
+    ]);
+
+  const server = new Server(
+    { name: "tokenomy-graph", version: TOKENOMY_VERSION },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOL_DEFS }));
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const result = await dispatchGraphTool(
+      request.params.name,
+      request.params.arguments ?? {},
+      cwd,
+    );
+    return {
+      content: [{ type: "text", text: stableStringify(result) }],
+      isError: !result.ok,
+    };
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  await new Promise<void>((resolve) => {
+    transport.onclose = () => resolve();
+  });
+};

--- a/src/parsers/ts/extract.ts
+++ b/src/parsers/ts/extract.ts
@@ -1,0 +1,715 @@
+import { readFileSync } from "node:fs";
+import type * as TS from "typescript";
+import {
+  createClassNode,
+  createExportedSymbolNode,
+  createExternalModuleNode,
+  createFileNode,
+  createFunctionNode,
+  createImportedSymbolNode,
+  createMethodNode,
+  createTestFileNode,
+  type Confidence,
+  type Edge,
+  type Graph,
+  type Node,
+} from "../../graph/schema.js";
+import { resolveSpecifier } from "../../graph/resolve.js";
+import { scriptKindFor } from "./script-kind.js";
+
+export interface ExtractFileResult {
+  nodes: Node[];
+  edges: Edge[];
+  parse_errors: Graph["parse_errors"];
+}
+
+interface ExtractionState {
+  readonly filePath: string;
+  readonly fileNodeId: string;
+  readonly files: ReadonlySet<string>;
+  readonly sourceFile: TS.SourceFile;
+  readonly ts: typeof TS;
+  readonly nodes: Node[];
+  readonly edges: Edge[];
+  readonly parse_errors: Graph["parse_errors"];
+  readonly importedByName: Map<string, string>;
+  readonly fileImportEdgeKeys: Set<string>;
+  readonly testEdgeKeys: Set<string>;
+  readonly localSymbolByName: Map<string, string>;
+  readonly classMethodsByName: Map<string, Map<string, string>>;
+  readonly symbolNodeIdsByAst: WeakMap<TS.Node, string>;
+  readonly classNodeIdsByAst: WeakMap<TS.Node, string>;
+  readonly methodNodeIdsByAst: WeakMap<TS.Node, string>;
+  readonly functionExpressionIdsByAst: WeakMap<TS.Node, string>;
+  readonly exportedSymbolByName: Map<string, string>;
+  readonly pendingLocalExports: Array<{ exportNodeId: string; localName: string }>;
+  readonly nextLineSlot: (name: string, line: number) => number;
+  readonly testNodeId?: string;
+}
+
+interface TraversalContext {
+  ownerId: string;
+  className?: string;
+  classMethods?: Map<string, string>;
+  shadowed: Set<string>;
+}
+
+const isTestFile = (path: string): boolean =>
+  /(^|\/)__tests__\//.test(path) || /\.(test|spec)\.[^.]+$/.test(path);
+
+const lineOf = (sourceFile: TS.SourceFile, node: TS.Node): number =>
+  sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+
+const withLineCounter = () => {
+  const seen = new Map<string, number>();
+  return (name: string, line: number): number => {
+    const key = `${name}@${line}`;
+    const next = seen.get(key) ?? 0;
+    seen.set(key, next + 1);
+    return next;
+  };
+};
+
+const hasModifier = (
+  node: TS.Node & { modifiers?: TS.NodeArray<TS.ModifierLike> },
+  ts: typeof TS,
+  modifier: TS.SyntaxKind,
+): boolean => !!node.modifiers?.some((candidate) => candidate.kind === modifier);
+
+const isStringLiteralLike = (
+  node: TS.Expression | undefined,
+  ts: typeof TS,
+): node is TS.StringLiteral | TS.NoSubstitutionTemplateLiteral =>
+  !!node && (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node));
+
+const isRequireCall = (node: TS.CallExpression, ts: typeof TS): boolean =>
+  ts.isIdentifier(node.expression) &&
+  node.expression.text === "require" &&
+  node.arguments.length === 1 &&
+  isStringLiteralLike(node.arguments[0], ts);
+
+const addContainsEdge = (state: ExtractionState, from: string, to: string): void => {
+  state.edges.push({ from, to, kind: "contains", confidence: "definite" });
+};
+
+const addEdge = (
+  state: ExtractionState,
+  from: string,
+  to: string,
+  kind: Edge["kind"],
+  confidence: Confidence,
+  via?: string,
+): void => {
+  state.edges.push({ from, to, kind, confidence, ...(via ? { via } : {}) });
+};
+
+const addNode = (state: ExtractionState, node: Node): void => {
+  state.nodes.push(node);
+};
+
+const resolveTarget = (
+  state: ExtractionState,
+  specifier: string,
+): { id: string; kind: "file" | "external-module" } => {
+  const target = resolveSpecifier(state.filePath, specifier, state.files);
+  if (target.kind === "external-module") {
+    addNode(state, createExternalModuleNode(target.target));
+    return { id: `ext:${target.target}`, kind: "external-module" };
+  }
+
+  addNode(state, createFileNode(target.target));
+  if (target.kind === "missing-file" && target.message) {
+    state.parse_errors.push({ file: state.filePath, message: target.message });
+  }
+  return { id: `file:${target.target}`, kind: "file" };
+};
+
+const addFileImportEdge = (
+  state: ExtractionState,
+  specifier: string,
+  confidence: Confidence,
+): { id: string; kind: "file" | "external-module" } => {
+  const target = resolveTarget(state, specifier);
+  const fileImportKey = `${state.fileNodeId}\u0000${target.id}\u0000${confidence}`;
+  if (!state.fileImportEdgeKeys.has(fileImportKey)) {
+    state.fileImportEdgeKeys.add(fileImportKey);
+    addEdge(state, state.fileNodeId, target.id, "imports", confidence, specifier);
+  }
+  if (state.testNodeId && target.kind === "file") {
+    const testKey = `${state.testNodeId}\u0000${target.id}`;
+    if (!state.testEdgeKeys.has(testKey)) {
+      state.testEdgeKeys.add(testKey);
+      addEdge(state, state.testNodeId, target.id, "tests", "definite", specifier);
+    }
+  }
+  return target;
+};
+
+const addImportSymbol = (
+  state: ExtractionState,
+  localName: string,
+  line: number,
+  specifier: string,
+  confidence: Confidence,
+): string => {
+  const slot = state.nextLineSlot(localName, line);
+  const node = createImportedSymbolNode(state.filePath, localName, line, slot);
+  addNode(state, node);
+  addContainsEdge(state, state.fileNodeId, node.id);
+  state.importedByName.set(localName, node.id);
+
+  const target = resolveTarget(state, specifier);
+  addEdge(state, node.id, target.id, "imports", confidence, specifier);
+  addFileImportEdge(state, specifier, confidence);
+  return node.id;
+};
+
+const addExportSymbol = (state: ExtractionState, exportName: string): string => {
+  const node = createExportedSymbolNode(state.filePath, exportName);
+  addNode(state, node);
+  addContainsEdge(state, state.fileNodeId, node.id);
+  state.exportedSymbolByName.set(exportName, node.id);
+  return node.id;
+};
+
+const addTopLevelFunction = (
+  state: ExtractionState,
+  node:
+    | TS.FunctionDeclaration
+    | TS.VariableDeclaration
+    | TS.ArrowFunction
+    | TS.FunctionExpression,
+  name: string,
+): string => {
+  const line = lineOf(state.sourceFile, node);
+  const slot = state.nextLineSlot(name, line);
+  const fn = createFunctionNode(
+    state.filePath,
+    name,
+    line,
+    slot,
+    node.getStart(state.sourceFile),
+    node.end,
+  );
+  addNode(state, fn);
+  addContainsEdge(state, state.fileNodeId, fn.id);
+  state.localSymbolByName.set(name, fn.id);
+  state.symbolNodeIdsByAst.set(node, fn.id);
+  return fn.id;
+};
+
+const addClassNode = (
+  state: ExtractionState,
+  node: TS.ClassDeclaration,
+  name: string,
+): string => {
+  const line = lineOf(state.sourceFile, node);
+  const slot = state.nextLineSlot(name, line);
+  const classNode = createClassNode(
+    state.filePath,
+    name,
+    line,
+    slot,
+    node.getStart(state.sourceFile),
+    node.end,
+  );
+  addNode(state, classNode);
+  addContainsEdge(state, state.fileNodeId, classNode.id);
+  state.localSymbolByName.set(name, classNode.id);
+  state.symbolNodeIdsByAst.set(node, classNode.id);
+  state.classNodeIdsByAst.set(node, classNode.id);
+  state.classMethodsByName.set(name, new Map());
+  return classNode.id;
+};
+
+const addMethodNodeForClass = (
+  state: ExtractionState,
+  className: string,
+  classId: string,
+  node: TS.MethodDeclaration,
+): void => {
+  if (!node.name || !state.ts.isIdentifier(node.name)) return;
+  const methodName = node.name.text;
+  const line = lineOf(state.sourceFile, node);
+  const slot = state.nextLineSlot(`${className}.${methodName}`, line);
+  const methodNode = createMethodNode(
+    state.filePath,
+    className,
+    methodName,
+    line,
+    slot,
+    node.getStart(state.sourceFile),
+    node.end,
+  );
+  addNode(state, methodNode);
+  addContainsEdge(state, classId, methodNode.id);
+  state.symbolNodeIdsByAst.set(node, methodNode.id);
+  state.methodNodeIdsByAst.set(node, methodNode.id);
+  state.classMethodsByName.get(className)?.set(methodName, methodNode.id);
+};
+
+const addVariableFunctionIfPresent = (
+  state: ExtractionState,
+  node: TS.VariableDeclaration,
+  exported: boolean,
+): void => {
+  if (!state.ts.isIdentifier(node.name) || !node.initializer) return;
+  if (!state.ts.isArrowFunction(node.initializer) && !state.ts.isFunctionExpression(node.initializer)) {
+    return;
+  }
+
+  const fnId = addTopLevelFunction(state, node.initializer, node.name.text);
+  state.functionExpressionIdsByAst.set(node.initializer, fnId);
+  if (exported) {
+    const expId = addExportSymbol(state, node.name.text);
+    addEdge(state, expId, fnId, "exports", "definite");
+  }
+};
+
+const processImportDeclaration = (state: ExtractionState, node: TS.ImportDeclaration): void => {
+  const specifier =
+    isStringLiteralLike(node.moduleSpecifier, state.ts) ? node.moduleSpecifier.text : null;
+  if (!specifier || node.importClause?.isTypeOnly) return;
+
+  const line = lineOf(state.sourceFile, node);
+  const importClause = node.importClause;
+  if (!importClause?.name && !importClause?.namedBindings) {
+    addFileImportEdge(state, specifier, "definite");
+    return;
+  }
+
+  if (importClause?.name) addImportSymbol(state, importClause.name.text, line, specifier, "definite");
+  if (importClause?.namedBindings && state.ts.isNamespaceImport(importClause.namedBindings)) {
+    addImportSymbol(
+      state,
+      importClause.namedBindings.name.text,
+      line,
+      specifier,
+      "definite",
+    );
+  }
+  if (importClause?.namedBindings && state.ts.isNamedImports(importClause.namedBindings)) {
+    for (const element of importClause.namedBindings.elements) {
+      if (element.isTypeOnly) continue;
+      addImportSymbol(state, element.name.text, line, specifier, "definite");
+    }
+  }
+};
+
+const processImportEqualsDeclaration = (
+  state: ExtractionState,
+  node: TS.ImportEqualsDeclaration,
+): void => {
+  if (!state.ts.isExternalModuleReference(node.moduleReference)) return;
+  if (!isStringLiteralLike(node.moduleReference.expression, state.ts)) return;
+  addImportSymbol(
+    state,
+    node.name.text,
+    lineOf(state.sourceFile, node),
+    node.moduleReference.expression.text,
+    "inferred",
+  );
+};
+
+const processExportDeclaration = (state: ExtractionState, node: TS.ExportDeclaration): void => {
+  const specifier =
+    node.moduleSpecifier && isStringLiteralLike(node.moduleSpecifier, state.ts)
+      ? node.moduleSpecifier.text
+      : null;
+  if (node.isTypeOnly) return;
+
+  if (!node.exportClause) {
+    if (specifier) {
+      const target = resolveTarget(state, specifier);
+      addEdge(state, state.fileNodeId, target.id, "exports", "inferred", specifier);
+      addFileImportEdge(state, specifier, "definite");
+    }
+    return;
+  }
+
+  if (!state.ts.isNamedExports(node.exportClause)) return;
+  for (const element of node.exportClause.elements) {
+    if (element.isTypeOnly) continue;
+    const exportName = element.name.text;
+    const localName = element.propertyName?.text ?? element.name.text;
+    const exportNodeId = addExportSymbol(state, exportName);
+    if (specifier) {
+      const target = resolveTarget(state, specifier);
+      addEdge(state, exportNodeId, target.id, "exports", "definite", specifier);
+      addFileImportEdge(state, specifier, "definite");
+    } else {
+      state.pendingLocalExports.push({ exportNodeId, localName });
+    }
+  }
+};
+
+const processExportAssignment = (state: ExtractionState, node: TS.ExportAssignment): void => {
+  const exportNodeId = addExportSymbol(state, "default");
+  if (state.ts.isIdentifier(node.expression)) {
+    state.pendingLocalExports.push({ exportNodeId, localName: node.expression.text });
+  }
+};
+
+const processTopLevelDeclaration = (
+  state: ExtractionState,
+  stmt: TS.Statement,
+): void => {
+  if (state.ts.isFunctionDeclaration(stmt) && stmt.name) {
+    const fnId = addTopLevelFunction(state, stmt, stmt.name.text);
+    if (hasModifier(stmt, state.ts, state.ts.SyntaxKind.ExportKeyword)) {
+      const expId = addExportSymbol(state, stmt.name.text);
+      addEdge(state, expId, fnId, "exports", "definite");
+    }
+    return;
+  }
+
+  if (state.ts.isClassDeclaration(stmt) && stmt.name) {
+    const className = stmt.name.text;
+    const classId = addClassNode(state, stmt, className);
+    for (const member of stmt.members) {
+      if (state.ts.isMethodDeclaration(member)) {
+        addMethodNodeForClass(state, className, classId, member);
+      }
+    }
+    if (hasModifier(stmt, state.ts, state.ts.SyntaxKind.ExportKeyword)) {
+      const expId = addExportSymbol(state, className);
+      addEdge(state, expId, classId, "exports", "definite");
+    }
+    return;
+  }
+
+  if (state.ts.isVariableStatement(stmt)) {
+    const exported = hasModifier(stmt, state.ts, state.ts.SyntaxKind.ExportKeyword);
+    for (const decl of stmt.declarationList.declarations) {
+      addVariableFunctionIfPresent(state, decl, exported);
+    }
+  }
+};
+
+const resolveLocalTarget = (state: ExtractionState, name: string): string | null =>
+  state.localSymbolByName.get(name) ??
+  state.importedByName.get(name) ??
+  null;
+
+const finalizePendingExports = (state: ExtractionState): void => {
+  for (const pending of state.pendingLocalExports) {
+    const target = resolveLocalTarget(state, pending.localName);
+    if (target) addEdge(state, pending.exportNodeId, target, "exports", "definite");
+  }
+};
+
+const addBindingNames = (name: TS.BindingName, out: Set<string>, ts: typeof TS): void => {
+  if (ts.isIdentifier(name)) {
+    out.add(name.text);
+    return;
+  }
+  for (const element of name.elements) {
+    if (ts.isOmittedExpression(element)) continue;
+    addBindingNames(element.name, out, ts);
+  }
+};
+
+const collectLocalNames = (root: TS.Node, ts: typeof TS): Set<string> => {
+  const names = new Set<string>();
+
+  const walk = (node: TS.Node): void => {
+    if (
+      node !== root &&
+      (ts.isFunctionDeclaration(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isArrowFunction(node) ||
+        ts.isClassDeclaration(node) ||
+        ts.isMethodDeclaration(node))
+    ) {
+      return;
+    }
+    if (ts.isParameter(node)) {
+      addBindingNames(node.name, names, ts);
+    }
+    if (ts.isVariableDeclaration(node)) {
+      addBindingNames(node.name, names, ts);
+    }
+    if (ts.isFunctionDeclaration(node) && node.name) names.add(node.name.text);
+    if (ts.isClassDeclaration(node) && node.name) names.add(node.name.text);
+    if (ts.isCatchClause(node) && node.variableDeclaration) {
+      addBindingNames(node.variableDeclaration.name, names, ts);
+    }
+    ts.forEachChild(node, walk);
+  };
+
+  ts.forEachChild(root, walk);
+  return names;
+};
+
+const resolveIdentifierTarget = (
+  state: ExtractionState,
+  name: string,
+  ctx: TraversalContext,
+): { id: string; confidence: Confidence } | null => {
+  if (ctx.shadowed.has(name)) return null;
+  const imported = state.importedByName.get(name);
+  if (imported) return { id: imported, confidence: "inferred" };
+  const local = state.localSymbolByName.get(name);
+  if (local) return { id: local, confidence: "definite" };
+  return null;
+};
+
+const resolvePropertyAccessTarget = (
+  state: ExtractionState,
+  node: TS.PropertyAccessExpression,
+  ctx: TraversalContext,
+): { id: string; confidence: Confidence } | null => {
+  if (
+    node.expression.kind === state.ts.SyntaxKind.ThisKeyword &&
+    ctx.classMethods?.has(node.name.text)
+  ) {
+    return { id: ctx.classMethods.get(node.name.text)!, confidence: "definite" };
+  }
+  if (state.ts.isIdentifier(node.expression)) {
+    if (ctx.shadowed.has(node.expression.text)) return null;
+    const imported = state.importedByName.get(node.expression.text);
+    if (imported) return { id: imported, confidence: "inferred" };
+  }
+  return null;
+};
+
+const resolveCallTarget = (
+  state: ExtractionState,
+  expression: TS.LeftHandSideExpression,
+  ctx: TraversalContext,
+): { id: string; confidence: Confidence } | null => {
+  if (state.ts.isIdentifier(expression)) {
+    return resolveIdentifierTarget(state, expression.text, ctx);
+  }
+  if (state.ts.isPropertyAccessExpression(expression)) {
+    return resolvePropertyAccessTarget(state, expression, ctx);
+  }
+  return null;
+};
+
+const shouldSkipIdentifierReference = (
+  ts: typeof TS,
+  parent: TS.Node | undefined,
+  node: TS.Identifier,
+): boolean => {
+  if (!parent) return false;
+  if (
+    (ts.isFunctionDeclaration(parent) ||
+      ts.isClassDeclaration(parent) ||
+      ts.isMethodDeclaration(parent) ||
+      ts.isVariableDeclaration(parent) ||
+      ts.isParameter(parent) ||
+      ts.isImportSpecifier(parent) ||
+      ts.isImportClause(parent) ||
+      ts.isNamespaceImport(parent) ||
+      ts.isImportEqualsDeclaration(parent) ||
+      ts.isExportSpecifier(parent)) &&
+    "name" in parent &&
+    (parent as { name?: TS.Node }).name === node
+  ) {
+    return true;
+  }
+  if (ts.isPropertyAccessExpression(parent) && parent.name === node) return true;
+  if (ts.isCallExpression(parent) && parent.expression === node) return true;
+  if (ts.isPropertyAssignment(parent) && parent.name === node) return true;
+  return false;
+};
+
+const walkSemantic = (
+  state: ExtractionState,
+  node: TS.Node,
+  parent: TS.Node | undefined,
+  ctx: TraversalContext,
+): void => {
+  let nextContext = ctx;
+
+  if (state.ts.isClassDeclaration(node) && node.name) {
+    nextContext = {
+      ownerId: state.classNodeIdsByAst.get(node) ?? ctx.ownerId,
+      className: node.name.text,
+      classMethods: state.classMethodsByName.get(node.name.text),
+      shadowed: new Set(ctx.shadowed),
+    };
+  } else if (state.ts.isMethodDeclaration(node)) {
+    const ownerId = state.methodNodeIdsByAst.get(node);
+    if (ownerId) {
+      nextContext = {
+        ownerId,
+        className: ctx.className,
+        classMethods: ctx.classMethods,
+        shadowed: collectLocalNames(node, state.ts),
+      };
+    }
+  } else if (state.ts.isFunctionDeclaration(node) || state.ts.isFunctionExpression(node) || state.ts.isArrowFunction(node)) {
+    const ownerId =
+      state.symbolNodeIdsByAst.get(node) ??
+      state.functionExpressionIdsByAst.get(node) ??
+      ctx.ownerId;
+    if (ownerId !== ctx.ownerId || state.functionExpressionIdsByAst.has(node)) {
+      nextContext = {
+        ownerId,
+        className: ctx.className,
+        classMethods: ctx.classMethods,
+        shadowed: collectLocalNames(node, state.ts),
+      };
+    }
+  } else if (
+    state.ts.isVariableDeclaration(node) &&
+    node.initializer &&
+    (state.ts.isArrowFunction(node.initializer) || state.ts.isFunctionExpression(node.initializer))
+  ) {
+    const ownerId = state.functionExpressionIdsByAst.get(node.initializer);
+    if (ownerId) {
+      nextContext = {
+        ownerId,
+        className: ctx.className,
+        classMethods: ctx.classMethods,
+        shadowed: collectLocalNames(node.initializer, state.ts),
+      };
+    }
+  }
+
+  if (state.ts.isCallExpression(node)) {
+    if (isRequireCall(node, state.ts)) {
+      const specifierArg = node.arguments[0];
+      let localName: string | null = null;
+      let localNameLine: number | null = null;
+      if (parent && state.ts.isVariableDeclaration(parent) && state.ts.isIdentifier(parent.name)) {
+        localName = parent.name.text;
+        localNameLine = lineOf(state.sourceFile, parent);
+      }
+      if (
+        localName &&
+        localNameLine !== null &&
+        specifierArg &&
+        isStringLiteralLike(specifierArg, state.ts) &&
+        !state.importedByName.has(localName)
+      ) {
+        addImportSymbol(
+          state,
+          localName,
+          localNameLine,
+          specifierArg.text,
+          "inferred",
+        );
+      } else if (specifierArg && isStringLiteralLike(specifierArg, state.ts)) {
+        addFileImportEdge(state, specifierArg.text, "inferred");
+      }
+    }
+    const callTarget = resolveCallTarget(state, node.expression, nextContext);
+    if (callTarget) addEdge(state, nextContext.ownerId, callTarget.id, "calls", callTarget.confidence);
+    if (
+      node.expression.kind === state.ts.SyntaxKind.ImportKeyword &&
+      isStringLiteralLike(node.arguments[0], state.ts)
+    ) {
+      addFileImportEdge(state, node.arguments[0].text, "inferred");
+    }
+  }
+
+  if (
+    state.ts.isIdentifier(node) &&
+    !shouldSkipIdentifierReference(state.ts, parent, node)
+  ) {
+    const target = resolveIdentifierTarget(state, node.text, nextContext);
+    if (target) addEdge(state, nextContext.ownerId, target.id, "references", target.confidence);
+  }
+
+  if (state.ts.isPropertyAccessExpression(node) && (!parent || !state.ts.isCallExpression(parent) || parent.expression !== node)) {
+    const target = resolvePropertyAccessTarget(state, node, nextContext);
+    if (target) addEdge(state, nextContext.ownerId, target.id, "references", target.confidence);
+  }
+
+  state.ts.forEachChild(node, (child) => walkSemantic(state, child, node, nextContext));
+};
+
+export const extractTsFileGraph = (
+  filePath: string,
+  sourceText: string,
+  files: ReadonlySet<string>,
+  ts: typeof TS,
+): ExtractFileResult => {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    false,
+    scriptKindFor(filePath, ts),
+  );
+
+  const state: ExtractionState = {
+    filePath,
+    fileNodeId: `file:${filePath}`,
+    files,
+    sourceFile,
+    ts,
+    nodes: [createFileNode(filePath)],
+    edges: [],
+    parse_errors: [],
+    importedByName: new Map(),
+    fileImportEdgeKeys: new Set(),
+    testEdgeKeys: new Set(),
+    localSymbolByName: new Map(),
+    classMethodsByName: new Map(),
+    symbolNodeIdsByAst: new WeakMap(),
+    classNodeIdsByAst: new WeakMap(),
+    methodNodeIdsByAst: new WeakMap(),
+    functionExpressionIdsByAst: new WeakMap(),
+    exportedSymbolByName: new Map(),
+    pendingLocalExports: [],
+    nextLineSlot: withLineCounter(),
+    ...(isTestFile(filePath) ? { testNodeId: `test:${filePath}` } : {}),
+  };
+
+  if (state.testNodeId) {
+    addNode(state, createTestFileNode(filePath));
+    addEdge(state, state.testNodeId, state.fileNodeId, "tests", "definite");
+  }
+
+  const parseDiagnostics =
+    (sourceFile as TS.SourceFile & { parseDiagnostics?: readonly TS.DiagnosticWithLocation[] })
+      .parseDiagnostics ?? [];
+  for (const diag of parseDiagnostics) {
+    state.parse_errors.push({
+      file: filePath,
+      message: ts.flattenDiagnosticMessageText(diag.messageText, "\n"),
+    });
+  }
+
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      processImportDeclaration(state, stmt);
+      continue;
+    }
+    if (ts.isImportEqualsDeclaration(stmt)) {
+      processImportEqualsDeclaration(state, stmt);
+      continue;
+    }
+    if (ts.isExportDeclaration(stmt)) {
+      processExportDeclaration(state, stmt);
+      continue;
+    }
+    if (ts.isExportAssignment(stmt)) {
+      processExportAssignment(state, stmt);
+      continue;
+    }
+    processTopLevelDeclaration(state, stmt);
+  }
+
+  finalizePendingExports(state);
+  walkSemantic(state, sourceFile, undefined, {
+    ownerId: state.fileNodeId,
+    shadowed: new Set(),
+  });
+
+  return {
+    nodes: state.nodes,
+    edges: state.edges,
+    parse_errors: state.parse_errors,
+  };
+};
+
+export const extractTsFileGraphFromDisk = (
+  filePath: string,
+  files: ReadonlySet<string>,
+  ts: typeof TS,
+): ExtractFileResult => extractTsFileGraph(filePath, readFileSync(filePath, "utf8"), files, ts);

--- a/src/parsers/ts/loader.ts
+++ b/src/parsers/ts/loader.ts
@@ -1,0 +1,58 @@
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
+import type * as TS from "typescript";
+import type { FailOpen } from "../../graph/types.js";
+
+export interface TypescriptLoaded {
+  ok: true;
+  ts: typeof TS;
+}
+
+export type TypescriptLoadResult = TypescriptLoaded | FailOpen;
+
+let cachedPath: string | null = null;
+let cachedModule: typeof TS | null = null;
+
+const importResolved = async (resolvedPath: string): Promise<typeof TS> => {
+  const imported = (await import(pathToFileURL(resolvedPath).href)) as typeof TS;
+  return imported;
+};
+
+export const loadTypescript = async (
+  cwd: string,
+  options: { allowProcessResolver?: boolean } = {},
+): Promise<TypescriptLoadResult> => {
+  const allowProcessResolver =
+    options.allowProcessResolver ?? process.env["TOKENOMY_DISABLE_GRAPH_TYPESCRIPT_FALLBACK"] !== "1";
+  const requireFromHere = createRequire(import.meta.url);
+
+  try {
+    const resolved = requireFromHere.resolve("typescript", { paths: [cwd] });
+    if (cachedPath === resolved && cachedModule) return { ok: true, ts: cachedModule };
+    const ts = await importResolved(resolved);
+    cachedPath = resolved;
+    cachedModule = ts;
+    return { ok: true, ts };
+  } catch {
+    // fall through
+  }
+
+  if (allowProcessResolver) {
+    try {
+      if (cachedPath === "process" && cachedModule) return { ok: true, ts: cachedModule };
+      const imported = (await import("typescript")) as typeof TS;
+      cachedPath = "process";
+      cachedModule = imported;
+      return { ok: true, ts: imported };
+    } catch {
+      // fall through
+    }
+  }
+
+  return {
+    ok: false,
+    reason: "typescript-not-installed",
+    hint:
+      "Install `typescript` in the target repo or alongside Tokenomy, then re-run `tokenomy graph build`.",
+  };
+};

--- a/src/parsers/ts/script-kind.ts
+++ b/src/parsers/ts/script-kind.ts
@@ -1,0 +1,8 @@
+import type * as TS from "typescript";
+
+export const scriptKindFor = (path: string, ts: typeof TS): TS.ScriptKind => {
+  if (path.endsWith(".tsx")) return ts.ScriptKind.TSX;
+  if (path.endsWith(".ts")) return ts.ScriptKind.TS;
+  if (path.endsWith(".jsx")) return ts.ScriptKind.JSX;
+  return ts.ScriptKind.JS;
+};

--- a/src/parsers/ts/walk.ts
+++ b/src/parsers/ts/walk.ts
@@ -1,0 +1,11 @@
+import type * as TS from "typescript";
+
+export const walkTs = (
+  node: TS.Node,
+  ts: typeof TS,
+  visit: (current: TS.Node) => boolean | void,
+): void => {
+  const descend = visit(node);
+  if (descend === false) return;
+  ts.forEachChild(node, (child) => walkTs(child, ts, visit));
+};

--- a/src/util/settings-patch.ts
+++ b/src/util/settings-patch.ts
@@ -11,12 +11,21 @@ interface HookMatcherEntry {
   [k: string]: unknown;
 }
 
+interface McpServerEntry {
+  command?: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  [k: string]: unknown;
+}
+
 interface SettingsShape {
   hooks?: {
     PostToolUse?: HookMatcherEntry[];
     PreToolUse?: HookMatcherEntry[];
     [event: string]: HookMatcherEntry[] | undefined;
   };
+  mcpServers?: Record<string, McpServerEntry>;
   [k: string]: unknown;
 }
 
@@ -128,4 +137,34 @@ export const hasOverlappingMcpHook = (
   return false;
 };
 
-export type { SettingsShape, HookMatcherEntry, HookCommandEntry };
+export const upsertMcpServer = (
+  settings: SettingsShape,
+  name: string,
+  server: McpServerEntry,
+): SettingsShape => ({
+  ...settings,
+  mcpServers: {
+    ...(settings.mcpServers ?? {}),
+    [name]: server,
+  },
+});
+
+export const removeMcpServerByName = (
+  settings: SettingsShape,
+  name: string,
+): SettingsShape => {
+  if (!settings.mcpServers?.[name]) return settings;
+  const nextServers = { ...(settings.mcpServers ?? {}) };
+  delete nextServers[name];
+  const next: SettingsShape = { ...settings };
+  if (Object.keys(nextServers).length === 0) delete next.mcpServers;
+  else next.mcpServers = nextServers;
+  return next;
+};
+
+export const getMcpServer = (
+  settings: SettingsShape,
+  name: string,
+): McpServerEntry | undefined => settings.mcpServers?.[name];
+
+export type { SettingsShape, HookMatcherEntry, HookCommandEntry, McpServerEntry };

--- a/tests/fixtures/graph-fixture-repo/src/bar.ts
+++ b/tests/fixtures/graph-fixture-repo/src/bar.ts
@@ -1,0 +1,3 @@
+export function bar(): string {
+  return "bar";
+}

--- a/tests/fixtures/graph-fixture-repo/src/baz.js
+++ b/tests/fixtures/graph-fixture-repo/src/baz.js
@@ -1,0 +1,5 @@
+const dep = require("./dep");
+
+export default function baz() {
+  return dep.value;
+}

--- a/tests/fixtures/graph-fixture-repo/src/dep.js
+++ b/tests/fixtures/graph-fixture-repo/src/dep.js
@@ -1,0 +1,1 @@
+module.exports = { value: "dep" };

--- a/tests/fixtures/graph-fixture-repo/src/dynamic.ts
+++ b/tests/fixtures/graph-fixture-repo/src/dynamic.ts
@@ -1,0 +1,3 @@
+export async function loadFoo() {
+  return import("./foo");
+}

--- a/tests/fixtures/graph-fixture-repo/src/foo.ts
+++ b/tests/fixtures/graph-fixture-repo/src/foo.ts
@@ -1,0 +1,3 @@
+import baz from "./baz";
+
+export const foo = () => baz();

--- a/tests/fixtures/graph-fixture-repo/src/index.ts
+++ b/tests/fixtures/graph-fixture-repo/src/index.ts
@@ -1,0 +1,4 @@
+export { foo } from "./foo";
+import { bar } from "./bar";
+
+export default bar;

--- a/tests/fixtures/graph-fixture-repo/src/reexport.ts
+++ b/tests/fixtures/graph-fixture-repo/src/reexport.ts
@@ -1,0 +1,2 @@
+export * from "./bar";
+export { foo as renamedFoo } from "./foo";

--- a/tests/fixtures/graph-fixture-repo/test/foo.test.ts
+++ b/tests/fixtures/graph-fixture-repo/test/foo.test.ts
@@ -1,0 +1,3 @@
+import { foo } from "../src/foo";
+
+export const spec = () => foo();

--- a/tests/integration/graph-build-cli.test.ts
+++ b/tests/integration/graph-build-cli.test.ts
@@ -1,0 +1,89 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
+import { once } from "node:events";
+import {
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { graphSnapshotPath } from "../../src/core/paths.js";
+import { resolveRepoId } from "../../src/graph/repo-id.js";
+
+const CLI = join(fileURLToPath(new URL("../..", import.meta.url)), "dist/cli/entry.js");
+const FIXTURE = join(
+  fileURLToPath(new URL("../..", import.meta.url)),
+  "tests/fixtures/graph-fixture-repo",
+);
+
+const runCli = async (
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<{ code: number | null; stdout: string; stderr: string }> => {
+  if (!existsSync(CLI)) throw new Error(`CLI not built: ${CLI}. Run 'npm run build' first.`);
+  const child = spawn(process.execPath, [CLI, ...args], { stdio: ["ignore", "pipe", "pipe"], env });
+  const out: Buffer[] = [];
+  const err: Buffer[] = [];
+  child.stdout.on("data", (chunk: Buffer) => out.push(chunk));
+  child.stderr.on("data", (chunk: Buffer) => err.push(chunk));
+  const [code] = (await once(child, "exit")) as [number | null];
+  return {
+    code,
+    stdout: Buffer.concat(out).toString("utf8"),
+    stderr: Buffer.concat(err).toString("utf8"),
+  };
+};
+
+const setupFixtureRepo = (): { home: string; repo: string; restore: () => void } => {
+  const home = mkdtempSync(join(tmpdir(), "tokenomy-graph-home-"));
+  const repo = mkdtempSync(join(tmpdir(), "tokenomy-graph-repo-"));
+  cpSync(FIXTURE, repo, { recursive: true });
+  execFileSync("git", ["init"], { cwd: repo, stdio: "ignore" });
+  execFileSync("git", ["add", "."], { cwd: repo, stdio: "ignore" });
+  const prev = process.env["HOME"];
+  process.env["HOME"] = home;
+  return {
+    home,
+    repo,
+    restore: () => {
+      if (prev === undefined) delete process.env["HOME"];
+      else process.env["HOME"] = prev;
+      rmSync(home, { recursive: true, force: true });
+      rmSync(repo, { recursive: true, force: true });
+    },
+  };
+};
+
+test("graph build cli: writes snapshot/meta and reuses fresh graph on second build", async () => {
+  const setup = setupFixtureRepo();
+  try {
+    const env = { ...process.env, HOME: setup.home };
+    const first = await runCli(["graph", "build", `--path=${setup.repo}`], env);
+    assert.equal(first.code, 0, first.stderr);
+    const parsed1 = JSON.parse(first.stdout);
+    assert.equal(parsed1.ok, true);
+    assert.equal(parsed1.data.built, true);
+    assert.ok(parsed1.data.node_count >= 25);
+    assert.ok(parsed1.data.edge_count >= 23);
+
+    const { repoId } = resolveRepoId(setup.repo);
+    const snapshot = graphSnapshotPath(repoId);
+    assert.equal(existsSync(snapshot), true);
+    const before = readFileSync(snapshot, "utf8");
+
+    const second = await runCli(["graph", "build", `--path=${setup.repo}`], env);
+    assert.equal(second.code, 0, second.stderr);
+    const parsed2 = JSON.parse(second.stdout);
+    assert.equal(parsed2.ok, true);
+    assert.equal(parsed2.data.built, false);
+    assert.ok(parsed2.data.duration_ms <= parsed1.data.duration_ms);
+    assert.equal(readFileSync(snapshot, "utf8"), before);
+  } finally {
+    setup.restore();
+  }
+});

--- a/tests/integration/graph-mcp.test.ts
+++ b/tests/integration/graph-mcp.test.ts
@@ -1,0 +1,71 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { cpSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const CLI = join(fileURLToPath(new URL("../..", import.meta.url)), "dist/cli/entry.js");
+const FIXTURE = join(
+  fileURLToPath(new URL("../..", import.meta.url)),
+  "tests/fixtures/graph-fixture-repo",
+);
+
+test("graph mcp server: exposes tools and returns focused context", async () => {
+  const home = mkdtempSync(join(tmpdir(), "tokenomy-graph-home-"));
+  const repo = mkdtempSync(join(tmpdir(), "tokenomy-graph-repo-"));
+  try {
+    cpSync(FIXTURE, repo, { recursive: true });
+    execFileSync("git", ["init"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["add", "."], { cwd: repo, stdio: "ignore" });
+
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [CLI, "graph", "serve", "--path", repo],
+      env: { ...process.env, HOME: home } as Record<string, string>,
+    });
+    const client = new Client({ name: "tokenomy-test", version: "1.0.0" });
+    await client.connect(transport);
+
+    const tools = await client.listTools();
+    assert.deepEqual(
+      tools.tools.map((tool) => tool.name).sort(),
+      [
+        "build_or_update_graph",
+        "get_impact_radius",
+        "get_minimal_context",
+        "get_review_context",
+      ],
+    );
+
+    const built = await client.callTool({ name: "build_or_update_graph", arguments: {} });
+    const builtPayload = JSON.parse(built.content[0]!.text);
+    assert.equal(builtPayload.ok, true);
+    assert.equal(builtPayload.data.built, true);
+
+    const minimal = await client.callTool({
+      name: "get_minimal_context",
+      arguments: { target: { file: "src/index.ts" }, depth: 1 },
+    });
+    const minimalPayload = JSON.parse(minimal.content[0]!.text);
+    assert.equal(minimalPayload.ok, true);
+    assert.equal(minimalPayload.data.focal.id, "file:src/index.ts");
+    assert.ok(Array.isArray(minimalPayload.data.neighbors));
+
+    const review = await client.callTool({
+      name: "get_review_context",
+      arguments: { files: ["src/index.ts", "src/foo.ts"] },
+    });
+    const reviewPayload = JSON.parse(review.content[0]!.text);
+    assert.equal(reviewPayload.ok, true);
+    assert.deepEqual(reviewPayload.data.changed_files, ["src/foo.ts", "src/index.ts"]);
+
+    await transport.close();
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});

--- a/tests/integration/graph-status-cli.test.ts
+++ b/tests/integration/graph-status-cli.test.ts
@@ -1,0 +1,64 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
+import { once } from "node:events";
+import { cpSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CLI = join(fileURLToPath(new URL("../..", import.meta.url)), "dist/cli/entry.js");
+const FIXTURE = join(
+  fileURLToPath(new URL("../..", import.meta.url)),
+  "tests/fixtures/graph-fixture-repo",
+);
+
+const runCli = async (
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<{ code: number | null; stdout: string; stderr: string }> => {
+  if (!existsSync(CLI)) throw new Error(`CLI not built: ${CLI}. Run 'npm run build' first.`);
+  const child = spawn(process.execPath, [CLI, ...args], { stdio: ["ignore", "pipe", "pipe"], env });
+  const out: Buffer[] = [];
+  const err: Buffer[] = [];
+  child.stdout.on("data", (chunk: Buffer) => out.push(chunk));
+  child.stderr.on("data", (chunk: Buffer) => err.push(chunk));
+  const [code] = (await once(child, "exit")) as [number | null];
+  return {
+    code,
+    stdout: Buffer.concat(out).toString("utf8"),
+    stderr: Buffer.concat(err).toString("utf8"),
+  };
+};
+
+test("graph status cli: reports stale files after fixture edit", async () => {
+  const home = mkdtempSync(join(tmpdir(), "tokenomy-graph-home-"));
+  const repo = mkdtempSync(join(tmpdir(), "tokenomy-graph-repo-"));
+  const prev = process.env["HOME"];
+  process.env["HOME"] = home;
+  try {
+    cpSync(FIXTURE, repo, { recursive: true });
+    execFileSync("git", ["init"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["add", "."], { cwd: repo, stdio: "ignore" });
+    const env = { ...process.env, HOME: home };
+
+    const built = await runCli(["graph", "build", `--path=${repo}`], env);
+    assert.equal(built.code, 0, built.stderr);
+
+    writeFileSync(join(repo, "src", "foo.ts"), "import baz from \"./baz\";\nexport const foo = () => baz() + 1;\n");
+
+    const status = await runCli(["graph", "status", `--path=${repo}`], env);
+    assert.equal(status.code, 0, status.stderr);
+    const parsed = JSON.parse(status.stdout);
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.stale, true);
+    assert.deepEqual(parsed.stale_files, ["src/foo.ts"]);
+    assert.equal(typeof parsed.data.repo_id, "string");
+    assert.equal(typeof parsed.data.built_at, "string");
+  } finally {
+    if (prev === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = prev;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});

--- a/tests/integration/init-uninstall.test.ts
+++ b/tests/integration/init-uninstall.test.ts
@@ -9,7 +9,7 @@ import {
   readFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { runInit } from "../../src/cli/init.js";
 import { runUninstall } from "../../src/cli/uninstall.js";
 import {
@@ -116,6 +116,28 @@ test("uninstall --purge removes ~/.tokenomy/", () => {
     runInit({});
     runUninstall({ purge: true });
     assert.equal(existsSync(join(h.home, ".tokenomy")), false);
+  } finally {
+    h.restore();
+  }
+});
+
+test("init --graph-path registers tokenomy-graph and uninstall removes it", () => {
+  const h = setupHome();
+  try {
+    mkdirSync(join(h.home, ".claude"), { recursive: true });
+    const repo = join(h.home, "repo");
+    mkdirSync(repo, { recursive: true });
+
+    runInit({ graphPath: repo });
+    const settings = JSON.parse(readFileSync(claudeSettingsPath(), "utf8"));
+    assert.deepEqual(settings.mcpServers["tokenomy-graph"], {
+      command: "tokenomy",
+      args: ["graph", "serve", "--path", resolve(repo)],
+    });
+
+    runUninstall({ backup: false });
+    const after = JSON.parse(readFileSync(claudeSettingsPath(), "utf8"));
+    assert.equal(after.mcpServers, undefined);
   } finally {
     h.restore();
   }

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -24,6 +24,11 @@ test("config: defaults when no files exist (conservative aggression ×2)", () =>
     assert.equal(cfg.aggression, DEFAULT_CONFIG.aggression);
     assert.equal(cfg.gate.always_trim_above_bytes, DEFAULT_CONFIG.gate.always_trim_above_bytes * 2);
     assert.equal(cfg.mcp.max_text_bytes, DEFAULT_CONFIG.mcp.max_text_bytes * 2);
+    assert.equal(cfg.graph.build_timeout_ms, DEFAULT_CONFIG.graph.build_timeout_ms * 2);
+    assert.equal(
+      cfg.graph.query_budget_bytes.get_minimal_context,
+      DEFAULT_CONFIG.graph.query_budget_bytes.get_minimal_context * 2,
+    );
   });
 });
 
@@ -45,6 +50,10 @@ test("config: global file controls aggression; project overrides thresholds; agg
     assert.equal(cfg.mcp.max_text_bytes, 1000);
     assert.equal(cfg.mcp.per_block_head, 100);
     assert.equal(cfg.mcp.per_block_tail, 50);
+    assert.equal(
+      cfg.graph.query_budget_bytes.get_review_context,
+      512,
+    );
   });
 });
 

--- a/tests/unit/graph-enumerate.test.ts
+++ b/tests/unit/graph-enumerate.test.ts
@@ -1,0 +1,46 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_CONFIG } from "../../src/core/config.js";
+import { enumerateGraphFiles } from "../../src/graph/enumerate.js";
+
+test("graph enumerate: git mode respects .gitignore and filters TS/JS files", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tokenomy-graph-enum-"));
+  try {
+    execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, ".gitignore"), "ignored.ts\n");
+    writeFileSync(join(dir, "src", "keep.ts"), "export const keep = true;\n");
+    writeFileSync(join(dir, "ignored.ts"), "export const ignored = true;\n");
+    writeFileSync(join(dir, "notes.txt"), "ignore me\n");
+    execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
+
+    const result = enumerateGraphFiles(dir, DEFAULT_CONFIG);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(result.files, ["src/keep.ts"]);
+    assert.equal(result.source, "git");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("graph enumerate: hard cap fails cleanly", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tokenomy-graph-enum-"));
+  try {
+    mkdirSync(join(dir, "src"), { recursive: true });
+    for (let i = 0; i < 4; i++) {
+      writeFileSync(join(dir, "src", `f${i}.ts`), `export const f${i} = ${i};\n`);
+    }
+    const result = enumerateGraphFiles(dir, {
+      ...DEFAULT_CONFIG,
+      graph: { ...DEFAULT_CONFIG.graph, hard_max_files: 3 },
+    });
+    assert.deepEqual(result, { ok: false, reason: "repo-too-large" });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/graph-repo-id.test.ts
+++ b/tests/unit/graph-repo-id.test.ts
@@ -1,0 +1,33 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { sha256String } from "../../src/graph/hash.js";
+import { resolveRepoId } from "../../src/graph/repo-id.js";
+
+test("graph repo id: uses git root when cwd is nested", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tokenomy-repo-id-"));
+  try {
+    execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+    mkdirSync(join(dir, "nested", "deeper"), { recursive: true });
+    const result = resolveRepoId(join(dir, "nested", "deeper"));
+    const canonical = realpathSync(dir);
+    assert.equal(result.repoPath, canonical);
+    assert.equal(result.repoId, sha256String(canonical));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("graph repo id: falls back to cwd outside git", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tokenomy-repo-id-"));
+  try {
+    const result = resolveRepoId(dir);
+    assert.equal(result.repoPath, resolve(dir));
+    assert.equal(result.repoId, sha256String(resolve(dir)));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/graph-resolve.test.ts
+++ b/tests/unit/graph-resolve.test.ts
@@ -1,0 +1,71 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveSpecifier } from "../../src/graph/resolve.js";
+
+const FILES = new Set([
+  "src/foo.ts",
+  "src/bar/index.ts",
+  "src/absolute.ts",
+  "src/dep.js",
+]);
+
+test("graph resolve: relative specifier probes extensions", () => {
+  assert.deepEqual(resolveSpecifier("src/main.ts", "./foo", FILES), {
+    kind: "file",
+    target: "src/foo.ts",
+  });
+});
+
+test("graph resolve: absolute specifier stays inside repo", () => {
+  assert.deepEqual(resolveSpecifier("src/main.ts", "/src/absolute.ts", FILES), {
+    kind: "file",
+    target: "src/absolute.ts",
+  });
+});
+
+test("graph resolve: directory specifier probes index files", () => {
+  assert.deepEqual(resolveSpecifier("src/main.ts", "./bar", FILES), {
+    kind: "file",
+    target: "src/bar/index.ts",
+  });
+});
+
+test("graph resolve: bare and node built-ins become external modules", () => {
+  assert.deepEqual(resolveSpecifier("src/main.ts", "react", FILES), {
+    kind: "external-module",
+    target: "react",
+  });
+  assert.deepEqual(resolveSpecifier("src/main.ts", "node:fs", FILES), {
+    kind: "external-module",
+    target: "node:fs",
+  });
+});
+
+test("graph resolve: missing relative import returns best-guess file target", () => {
+  const result = resolveSpecifier("src/main.ts", "./missing", FILES);
+  assert.equal(result.kind, "missing-file");
+  assert.equal(result.target, "src/missing.ts");
+});
+
+test("graph resolve: .js specifier maps to .ts source (TS NodeNext ESM)", () => {
+  assert.deepEqual(resolveSpecifier("src/main.ts", "./foo.js", FILES), {
+    kind: "file",
+    target: "src/foo.ts",
+  });
+});
+
+test("graph resolve: .jsx specifier maps to .tsx source", () => {
+  const files = new Set(["src/Button.tsx"]);
+  assert.deepEqual(resolveSpecifier("src/main.ts", "./Button.jsx", files), {
+    kind: "file",
+    target: "src/Button.tsx",
+  });
+});
+
+test("graph resolve: .js specifier still resolves to literal .js when present", () => {
+  // dep.js exists in FILES; the .ts fallback should not override a real .js match
+  assert.deepEqual(resolveSpecifier("src/main.ts", "./dep.js", FILES), {
+    kind: "file",
+    target: "src/dep.js",
+  });
+});

--- a/tests/unit/graph-schema.test.ts
+++ b/tests/unit/graph-schema.test.ts
@@ -1,0 +1,43 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { stableStringify } from "../../src/util/json.js";
+import { GRAPH_SCHEMA_VERSION, normalizeGraph } from "../../src/graph/schema.js";
+
+test("graph schema: normalizeGraph sorts and dedupes deterministically", () => {
+  const graph = normalizeGraph({
+    schema_version: GRAPH_SCHEMA_VERSION,
+    repo_id: "repo",
+    nodes: [
+      { id: "file:src/b.ts", kind: "file", name: "src/b.ts", file: "src/b.ts" },
+      { id: "file:src/a.ts", kind: "file", name: "src/a.ts", file: "src/a.ts" },
+      { id: "file:src/a.ts", kind: "file", name: "src/a.ts", file: "src/a.ts" },
+    ],
+    edges: [
+      { from: "file:src/b.ts", to: "file:src/a.ts", kind: "imports", confidence: "definite" },
+      { from: "file:src/b.ts", to: "file:src/a.ts", kind: "imports", confidence: "definite" },
+      { from: "file:src/a.ts", to: "file:src/b.ts", kind: "imports", confidence: "inferred" },
+    ],
+    parse_errors: [
+      { file: "src/z.ts", message: "later" },
+      { file: "src/a.ts", message: "first" },
+      { file: "src/a.ts", message: "first" },
+    ],
+  });
+
+  assert.deepEqual(
+    graph.nodes.map((node) => node.id),
+    ["file:src/a.ts", "file:src/b.ts"],
+  );
+  assert.deepEqual(
+    graph.edges.map((edge) => `${edge.from}->${edge.to}:${edge.confidence}`),
+    [
+      "file:src/a.ts->file:src/b.ts:inferred",
+      "file:src/b.ts->file:src/a.ts:definite",
+    ],
+  );
+  assert.deepEqual(graph.parse_errors, [
+    { file: "src/a.ts", message: "first" },
+    { file: "src/z.ts", message: "later" },
+  ]);
+  assert.match(stableStringify(graph), /"repo_id": "repo"/);
+});

--- a/tests/unit/graph-stale.test.ts
+++ b/tests/unit/graph-stale.test.ts
@@ -1,0 +1,79 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_CONFIG } from "../../src/core/config.js";
+import { sha256FileSync } from "../../src/graph/hash.js";
+import { getGraphStaleStatus } from "../../src/graph/stale.js";
+import type { GraphMeta } from "../../src/graph/schema.js";
+
+const createMeta = (dir: string): GraphMeta => {
+  const file = join(dir, "src", "a.ts");
+  const st = statSync(file);
+  return {
+    schema_version: 1,
+    repo_id: "repo",
+    repo_path: dir,
+    built_at: "2026-04-17T00:00:00.000Z",
+    tokenomy_version: "0.1.0-alpha.4",
+    node_count: 1,
+    edge_count: 0,
+    file_hashes: { "src/a.ts": sha256FileSync(file) },
+    file_mtimes: { "src/a.ts": st.mtimeMs },
+    soft_cap: 2_000,
+    hard_cap: 5_000,
+    parse_error_count: 0,
+  };
+};
+
+test("graph stale: mtime change with same content is not stale; content change is stale", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "tokenomy-graph-stale-"));
+  try {
+    execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "a.ts"), "export const a = 1;\n");
+    execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
+    const meta = createMeta(dir);
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    writeFileSync(join(dir, "src", "a.ts"), "export const a = 1;\n");
+    const sameContent = getGraphStaleStatus(dir, meta, DEFAULT_CONFIG);
+    assert.equal(sameContent.ok, true);
+    if (!sameContent.ok) return;
+    assert.equal(sameContent.stale, false);
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    writeFileSync(join(dir, "src", "a.ts"), "export const a = 2;\n");
+    const changed = getGraphStaleStatus(dir, meta, DEFAULT_CONFIG);
+    assert.equal(changed.ok, true);
+    if (!changed.ok) return;
+    assert.equal(changed.stale, true);
+    assert.deepEqual(changed.stale_files, ["src/a.ts"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("graph stale: added and removed files are surfaced", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tokenomy-graph-stale-"));
+  try {
+    execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "a.ts"), "export const a = 1;\n");
+    execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
+    const meta = createMeta(dir);
+
+    writeFileSync(join(dir, "src", "b.ts"), "export const b = 1;\n");
+    rmSync(join(dir, "src", "a.ts"));
+
+    const status = getGraphStaleStatus(dir, meta, DEFAULT_CONFIG);
+    assert.equal(status.ok, true);
+    if (!status.ok) return;
+    assert.equal(status.stale, true);
+    assert.deepEqual(status.stale_files, ["src/a.ts", "src/b.ts"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/graph-store.test.ts
+++ b/tests/unit/graph-store.test.ts
@@ -1,0 +1,54 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { graphMetaPath, graphSnapshotPath } from "../../src/core/paths.js";
+import { GRAPH_SCHEMA_VERSION, type Graph, type GraphMeta } from "../../src/graph/schema.js";
+import { JsonGraphStore } from "../../src/graph/store.js";
+
+const withTempHome = (fn: (home: string) => void): void => {
+  const home = mkdtempSync(join(tmpdir(), "tokenomy-graph-store-"));
+  const prev = process.env["HOME"];
+  process.env["HOME"] = home;
+  try {
+    fn(home);
+  } finally {
+    if (prev === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = prev;
+    rmSync(home, { recursive: true, force: true });
+  }
+};
+
+test("graph store: saves and loads graph snapshot + meta atomically", () => {
+  withTempHome(() => {
+    const store = new JsonGraphStore();
+    const graph: Graph = {
+      schema_version: GRAPH_SCHEMA_VERSION,
+      repo_id: "repo",
+      nodes: [{ id: "file:src/a.ts", kind: "file", name: "src/a.ts", file: "src/a.ts" }],
+      edges: [],
+      parse_errors: [],
+    };
+    const meta: GraphMeta = {
+      schema_version: GRAPH_SCHEMA_VERSION,
+      repo_id: "repo",
+      repo_path: "/tmp/repo",
+      built_at: "2026-04-17T00:00:00.000Z",
+      tokenomy_version: "0.1.0-alpha.4",
+      node_count: 1,
+      edge_count: 0,
+      file_hashes: { "src/a.ts": "abc" },
+      file_mtimes: { "src/a.ts": 1 },
+      soft_cap: 2_000,
+      hard_cap: 5_000,
+      parse_error_count: 0,
+    };
+
+    store.save("repo", graph, meta);
+    assert.equal(existsSync(graphSnapshotPath("repo")), true);
+    assert.equal(existsSync(graphMetaPath("repo")), true);
+    assert.deepEqual(store.loadGraph("repo"), graph);
+    assert.deepEqual(store.loadMeta("repo"), meta);
+  });
+});

--- a/tests/unit/parsers-ts-extract-imports.test.ts
+++ b/tests/unit/parsers-ts-extract-imports.test.ts
@@ -1,0 +1,84 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { loadTypescript } from "../../src/parsers/ts/loader.js";
+import { extractTsFileGraph } from "../../src/parsers/ts/extract.js";
+
+test("parsers ts extract: named/default/namespace imports and re-exports become graph edges", async () => {
+  const tsLoaded = await loadTypescript(process.cwd());
+  assert.equal(tsLoaded.ok, true);
+  if (!tsLoaded.ok) return;
+
+  const source = `
+import thing, { foo as localFoo } from "./foo";
+import * as ns from "./bar";
+export { localFoo as renamed } from "./foo";
+export * from "./bar";
+export default thing;
+`;
+  const result = extractTsFileGraph(
+    "src/example.ts",
+    source,
+    new Set(["src/foo.ts", "src/bar.ts"]),
+    tsLoaded.ts,
+  );
+
+  const nodeIds = result.nodes.map((node) => node.id);
+  assert.ok(nodeIds.includes("file:src/example.ts"));
+  assert.ok(nodeIds.some((id) => id.startsWith("imp:src/example.ts#thing@")));
+  assert.ok(nodeIds.some((id) => id.startsWith("imp:src/example.ts#localFoo@")));
+  assert.ok(nodeIds.some((id) => id.startsWith("imp:src/example.ts#ns@")));
+  assert.ok(nodeIds.includes("exp:src/example.ts#renamed"));
+  assert.ok(nodeIds.includes("exp:src/example.ts#default"));
+
+  const importTargets = result.edges
+    .filter((edge) => edge.kind === "imports")
+    .map((edge) => edge.to)
+    .sort();
+  assert.deepEqual(importTargets, [
+    "file:src/bar.ts",
+    "file:src/bar.ts",
+    "file:src/foo.ts",
+    "file:src/foo.ts",
+    "file:src/foo.ts",
+  ]);
+
+  const exportTargets = result.edges
+    .filter((edge) => edge.kind === "exports")
+    .map((edge) => `${edge.to}:${edge.confidence}`)
+    .sort();
+  assert.deepEqual(exportTargets, [
+    "file:src/bar.ts:inferred",
+    "file:src/foo.ts:definite",
+    "imp:src/example.ts#thing@2:0:definite",
+  ]);
+});
+
+test("parsers ts extract: require and dynamic import are inferred imports", async () => {
+  const tsLoaded = await loadTypescript(process.cwd());
+  assert.equal(tsLoaded.ok, true);
+  if (!tsLoaded.ok) return;
+
+  const source = `
+const dep = require("./dep");
+export async function loadDep() {
+  return import("./lazy");
+}
+`;
+  const result = extractTsFileGraph(
+    "src/example.ts",
+    source,
+    new Set(["src/dep.js", "src/lazy.ts"]),
+    tsLoaded.ts,
+  );
+
+  const inferredImports = result.edges.filter((edge) => edge.kind === "imports");
+  assert.deepEqual(
+    inferredImports.map((edge) => `${edge.to}:${edge.confidence}`).sort(),
+    [
+      "file:src/dep.js:inferred",
+      "file:src/dep.js:inferred",
+      "file:src/lazy.ts:inferred",
+    ],
+  );
+  assert.ok(result.nodes.some((node) => node.id.startsWith("imp:src/example.ts#dep@")));
+});

--- a/tests/unit/parsers-ts-loader.test.ts
+++ b/tests/unit/parsers-ts-loader.test.ts
@@ -1,0 +1,28 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadTypescript } from "../../src/parsers/ts/loader.js";
+
+test("parsers ts loader: resolves installed typescript", async () => {
+  const result = await loadTypescript(process.cwd());
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(typeof result.ts.createSourceFile, "function");
+});
+
+test("parsers ts loader: missing typescript branch returns structured error", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "tokenomy-ts-missing-"));
+  try {
+    const result = await loadTypescript(dir, { allowProcessResolver: false });
+    assert.deepEqual(result, {
+      ok: false,
+      reason: "typescript-not-installed",
+      hint:
+        "Install `typescript` in the target repo or alongside Tokenomy, then re-run `tokenomy graph build`.",
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/pre-dispatch.test.ts
+++ b/tests/unit/pre-dispatch.test.ts
@@ -1,0 +1,57 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { mkdtempSync } from "node:fs";
+import { DEFAULT_CONFIG } from "../../src/core/config.js";
+import { graphMetaPath } from "../../src/core/paths.js";
+import { preDispatch } from "../../src/hook/pre-dispatch.js";
+import { resolveRepoId } from "../../src/graph/repo-id.js";
+
+test("preDispatch: appends graph-aware hint when a local graph snapshot exists", () => {
+  const home = mkdtempSync(join(tmpdir(), "tokenomy-pre-home-"));
+  const repo = mkdtempSync(join(tmpdir(), "tokenomy-pre-repo-"));
+  const prev = process.env["HOME"];
+  process.env["HOME"] = home;
+  try {
+    const largeFile = join(repo, "large.ts");
+    writeFileSync(largeFile, "x".repeat(60_000));
+
+    const { repoId } = resolveRepoId(repo);
+    const metaPath = graphMetaPath(repoId);
+    mkdirSync(dirname(metaPath), { recursive: true });
+    writeFileSync(metaPath, "{}\n");
+
+    const output = preDispatch(
+      {
+        session_id: "s",
+        transcript_path: "/tmp/t",
+        cwd: repo,
+        permission_mode: "default",
+        hook_event_name: "PreToolUse",
+        tool_name: "Read",
+        tool_input: { file_path: largeFile },
+      },
+      {
+        ...DEFAULT_CONFIG,
+        log_path: join(home, ".tokenomy", "savings.jsonl"),
+      },
+    );
+
+    assert.ok(output);
+    assert.match(
+      output!.hookSpecificOutput.additionalContext ?? "",
+      /tokenomy-graph/,
+    );
+    assert.match(
+      output!.hookSpecificOutput.additionalContext ?? "",
+      /clamped Read/,
+    );
+  } finally {
+    if (prev === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = prev;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/settings-patch.test.ts
+++ b/tests/unit/settings-patch.test.ts
@@ -3,8 +3,11 @@ import assert from "node:assert/strict";
 import {
   addHook,
   countHooksForPath,
+  getMcpServer,
   hasOverlappingMcpHook,
+  removeMcpServerByName,
   removeHookByCommandPath,
+  upsertMcpServer,
 } from "../../src/util/settings-patch.js";
 
 const HOOK = "/Users/me/.tokenomy/bin/tokenomy-hook";
@@ -83,4 +86,19 @@ test("idempotent: init-then-init keeps exactly one entry per event", () => {
   s = addHook(s, "PreToolUse", HOOK, "Read", 10);
   assert.equal(countHooksForPath(s, HOOK, "PostToolUse"), 1);
   assert.equal(countHooksForPath(s, HOOK, "PreToolUse"), 1);
+});
+
+test("mcp server helpers: upsert and remove tokenomy-graph entry", () => {
+  const withServer = upsertMcpServer({}, "tokenomy-graph", {
+    command: "tokenomy",
+    args: ["graph", "serve", "--path", "/repo"],
+  });
+  assert.deepEqual(getMcpServer(withServer, "tokenomy-graph"), {
+    command: "tokenomy",
+    args: ["graph", "serve", "--path", "/repo"],
+  });
+
+  const removed = removeMcpServerByName(withServer, "tokenomy-graph");
+  assert.equal(getMcpServer(removed, "tokenomy-graph"), undefined);
+  assert.equal(removed.mcpServers, undefined);
 });


### PR DESCRIPTION
## Summary

Phase 3 of the roadmap: a **local code-graph MCP server** that lets the agent query a pre-built graph of the TS/JS codebase instead of brute-forcing `Read` calls. Tokenomy grows from a pair of transparent hooks into an opt-in context-retrieval toolkit. Covers all 5 slices of the design plan; also corrects three bugs surfaced while dogfooding on Tokenomy's own source.

## Surface

- [x] `PreToolUse` hook (Read clamp) — `src/hook/pre-dispatch.ts` (graph-aware hint)
- [x] CLI — `src/cli/graph*.ts`, `src/cli/entry.ts`
- [x] Config / types — `src/core/config.ts`, `src/core/types.ts`, `src/core/paths.ts`
- [x] Install / settings-patch — `src/util/settings-patch.ts`, `src/cli/init.ts`, `src/cli/uninstall.ts`, `src/cli/doctor.ts`
- [x] Tests (unit + integration + fixture repo)
- [x] Docs — `CHANGELOG.md`
- [x] Other — `src/graph/*` (schema, store, queries), `src/parsers/ts/*` (TS AST extractor), `src/mcp/*` (stdio MCP server)

## Why

Long Claude Code sessions still burn tokens on broad `Read` sweeps across a codebase — the MCP trim and Read clamp reduce, but don't *redirect*. The graph server is the first Tokenomy surface that redirects: the agent asks for "what's connected to this file/symbol?" and gets ≤ 4 KB of focused context with a hint pointing at narrower follow-ups, instead of pulling several thousand lines of source.

It's also the only Tokenomy surface that's genuinely portable — the same stdio MCP server registers into both Claude Code and Codex.

## How it works

### Graph build

```bash
tokenomy graph build --path "$PWD"
# { "ok": true, "node_count": 884, "edge_count": 2412,
#   "parse_error_count": 0, "duration_ms": 360, ... }
```

- `sha256(git-root)` → cache at `~/.tokenomy/graphs/<id>/{snapshot.json, meta.json, build.jsonl}`
- TS compiler API AST-only (no type checker)
- `git ls-files` enumeration + hardcoded ignore list + 5 000-file inline trip-wire
- mtime fast-path for stale detection; only re-hashes changed files
- Build lock via `openSync(path, "wx")` prevents concurrent corruption
- Every edge carries `confidence: "definite" | "inferred"` from day 1

### 4 MCP tools over stdio

| Tool | Output | Budget |
|---|---|---|
| `build_or_update_graph` | `{built, node_count, edge_count, duration_ms, …}` | 4 KB |
| `get_minimal_context` | `{focal, neighbors[], hint}` | 4 KB |
| `get_impact_radius` | `{reverse_deps[], suggested_tests[], summary}` | 6 KB |
| `get_review_context` | `{changed_files, exports_touched, fanout_summary[], hotspots[]}` | 1 KB |

All responses use the `{ok, stale, stale_files, data, truncated?}` envelope. `budget-clip.ts` is the belt-and-suspenders: if a query exceeds the byte budget, it drops tail elements of the largest array and sets `truncated.dropped_count`.

### Graph-aware Read clamp

`pre-dispatch.ts` now appends an `additionalContext` nudge pointing the agent at `get_minimal_context` / `get_impact_radius` / `get_review_context` when a graph snapshot exists. Cheap `existsSync(~/.tokenomy/graphs/)` pre-check means installs without a graph pay zero overhead — no git subprocess, no file stats.

### Install surface

- `tokenomy init --graph-path <dir>` → adds `mcpServers["tokenomy-graph"]` to `~/.claude/settings.json` alongside the existing hooks
- `tokenomy uninstall` strips it
- `tokenomy doctor` adds a "Graph MCP registration" check

### Dependency footprint

- `typescript` → `peerDependencies` + `peerDependenciesMeta.optional` (core install stays zero-runtime-deps)
- `@modelcontextprotocol/sdk` → first runtime dep, dynamically imported only on the graph code path

## Test plan

- [x] `npm test` — **67 pass / 0 fail** (was 42 before this branch; 25 new tests)
- [x] `npm run build` clean
- [x] `npm run typecheck` clean
- [x] End-to-end smoke on Tokenomy's own source (81 files, 6 K LOC):
  ```bash
  tokenomy graph build --path "$PWD"
  # 884 nodes, 2412 edges, 0 parse errors, 360 ms
  tokenomy graph status --path "$PWD"
  tokenomy graph query minimal --path "$PWD" --file src/graph/build.ts
  tokenomy graph query review  --path "$PWD" --files src/cli/entry.ts,src/hook/pre-dispatch.ts
  ```
  All four returned well-formed, budget-clipped responses.
- [x] MCP stdio server round-tripped `initialize` + `tools/list` + `tools/call` via raw JSON-RPC against the fixture repo and the real Tokenomy graph.
- [x] `tokenomy doctor` 10/10 ✓ post-install on the extended check set.

## Invariants preserved

- [x] **Fail-open everywhere:** every CLI + MCP path returns `{ok: false, reason}` instead of throwing. Exit 2 never used.
- [x] **Schema integrity:** `content.length` in MCP responses never shrinks; non-text blocks keep original relative position; `is_error` flows through.
- [x] **Read clamp** still preserves `file_path` and any other caller-supplied input keys.
- [x] **Hook hot path stays cheap:** pre-dispatch short-circuits before spawning git when no graph dir exists.
- [x] **Graph cache integrity:** build lock prevents concurrent corruption; snapshot-size cap prevents half-writes.

## Breaking changes

- [x] **No breaking changes for existing users.** All graph functionality is opt-in via `--graph-path` and the `tokenomy-graph` MCP server registration. Existing `tokenomy init` / `doctor` / `uninstall` behavior is preserved.
- New `graph` section added to `~/.tokenomy/config.json` — defaulted, backward-compatible.
- `@modelcontextprotocol/sdk` added as a runtime dependency — package size grows but the core hook path doesn't load it.

## Screenshots / logs

**Build on Tokenomy's own source:**

```json
{
  "ok": true,
  "stale": false,
  "stale_files": [],
  "data": {
    "repo_id": "1390bd1d7f7c23e0a59f49a68df1957ead993d240cc9103ce7631e04702cc92d",
    "built": true,
    "node_count": 884,
    "edge_count": 2412,
    "parse_error_count": 0,
    "duration_ms": 360,
    "skipped_files": []
  }
}
```

**`get_minimal_context` over MCP (trimmed for brevity):**

```json
{
  "ok": true,
  "stale": false,
  "stale_files": [],
  "data": {
    "focal": { "id": "file:src/graph/build.ts", "kind": "file", "name": "src/graph/build.ts", "file": "src/graph/build.ts" },
    "neighbors": [
      { "id": "ext:node:fs", "kind": "external-module", "edge_kind": "imports", "direction": "out", "confidence": "definite", "depth": 1 },
      { "id": "ext:node:path", "kind": "external-module", "edge_kind": "imports", "direction": "out", "confidence": "definite", "depth": 1 },
      ...
    ],
    "hint": "If this is insufficient, try get_impact_radius or Read src/graph/build.ts"
  }
}
```

## Bugs fixed during review

1. **Resolver silently dropped every `.js` import to `.ts` source** (TypeScript NodeNext convention). 146 phantom parse errors → **0** on Tokenomy's own source. Now also maps `.jsx→.tsx`, `.mjs→.mts`, `.cjs→.cts`. Regression tests added (`tests/unit/graph-resolve.test.ts`).
2. **`tokenomy graph query … --file <path>` with space-separated flag** returned `invalid-input`. Outer CLI parser consumed `--file` / `--files` into its own flags map before forwarding to `runGraphQuery`. Fixed by forwarding raw argv for the `query` subcommand.
3. **`git rev-parse` spawned on every `Read` hook invocation** even with no graph built. Added cheap `existsSync(graphs root)` pre-check so installs without a graph pay zero git overhead.

## Checklist

- [x] Title follows `<type>(<scope>): <description>`
- [x] Rebased on `main`, no merge commits
- [x] One logical change per PR (Phase 3 end-to-end; bug fixes are surface-adjacent regressions caught during the same review)
- [x] `CHANGELOG.md` updated with a full `[0.1.0-alpha.5]` section
- [x] `npm test` + `npm run build` + `npm run typecheck` green locally
