### PR TITLE
feat: Phase 2 — tokenomy analyze (Claude Code + Codex transcripts, fancy CLI) (0.1.0-alpha.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.1.0-alpha.7] — 2026-04-18
+
+Phase 2 lands: `tokenomy analyze` — walks Claude Code and Codex CLI transcripts, replays the full Tokenomy rule pipeline with a real tokenizer, and surfaces waste patterns in a fancy CLI dashboard. Also repositions the project as a toolkit for both Claude Code and Codex CLI rather than Claude-Code-only.
+
+### Added
+
+- **`tokenomy analyze` CLI** (`src/cli/analyze.ts` + `src/analyze/*`) — recursive JSONL scanner over `~/.claude/projects/**` and `~/.codex/sessions/**`, with filters for `--since`, `--project`, `--session`, plus `--top`, `--tokenizer`, `--json`, `--no-color`, `--verbose`.
+- **Streaming scanner** (`src/analyze/scan.ts`) — `readline`-based line-by-line ingest so gigabyte transcript dirs don't OOM. Emits per-file progress to stderr so stdout stays clean for `--json` piping.
+- **Transcript parser** (`src/analyze/parse.ts`) — normalizes Claude Code's `assistant → tool_use` / `user → tool_result` pairing AND Codex CLI's `payload.tool_call` rollout shape into a single `ToolCall` record. Handles both array-shape and string-shape `content` payloads.
+- **Tokenizer abstraction** (`src/analyze/tokens.ts`) — default heuristic tokenizer (zero-dep, word/punct/digit-segmentation tuned for code+JSON, ~±10% of cl100k on typical tool output). Optional `--tokenizer=tiktoken` dynamically imports `js-tiktoken` for real `cl100k_base` counts (added as `peerDependenciesMeta.optional`).
+- **Rule simulator** (`src/analyze/simulate.ts`) — replays dedup, redact, stacktrace-collapse, profile trim, MCP byte trim, and Read clamp over historical calls; emits per-event hypothetical savings and a canonicalized `call_key` for hotspot aggregation.
+- **Aggregator** (`src/analyze/report.ts`) — folds per-event sim results into totals, by-tool top-N, by-rule breakdown, by-day series, duplicate hotspots, and outliers. USD estimate using `cfg.report.price_per_million`.
+- **Fancy CLI renderer** (`src/analyze/render.ts`) — rounded-box header, progress line, per-rule bar charts, top-N waste leaderboard with inline bars, duplicate hotspots, outliers list, by-day sparkline. Pure stdlib ANSI; auto-disables color when stdout is not a TTY or `--no-color` is passed.
+
+### Changed
+
+- **Positioning**: Tokenomy is now framed as a toolkit for **both Claude Code and Codex CLI**. Live hooks remain Claude-Code-only for now (Codex CLI has no hook contract yet); the graph MCP server and `tokenomy analyze` work with either agent.
+- **README** restructured with an agent-support matrix, separate quickstart paths for Claude Code and Codex CLI, and a new `tokenomy analyze` section documenting the fancy CLI output and tokenizer choices.
+- **CONTRIBUTING** updated to reflect the new module layout (`src/analyze/`) and the agent-agnostic principle for new work.
+
+### Added (deps)
+
+- `js-tiktoken` declared as an **optional peer dependency**. Users who want accurate `cl100k_base` token counts in `tokenomy analyze` install it separately (`npm i -g js-tiktoken`); the core install stays lean. All other analyze features work with the built-in heuristic tokenizer.
+
 ## [0.1.0-alpha.6] — 2026-04-18
 
 Extends the PostToolUse pipeline, graph MCP server, and CLI with 10 new features. Test suite grows from 67 → 128 passing. No new runtime dependencies.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Tokenomy
 
-Thanks for wanting to make Claude Code lighter on tokens. Tokenomy is small by design (≈800 LOC, zero runtime deps) — which means almost any contribution lands in shippable scope within a day.
+Thanks for wanting to make coding agents (Claude Code, Codex CLI) lighter on tokens. Tokenomy is small by design (zero runtime deps in the hot path) — which means almost any contribution lands in shippable scope within a day.
 
 This document goes deeper than the README's "Contribute" section: setup, conventions, testing philosophy, and the PR process.
 
@@ -10,7 +10,7 @@ This document goes deeper than the README's "Contribute" section: setup, convent
 
 Before you open a PR, make sure:
 
-- [ ] `npm test` is green (existing 41+ tests pass)
+- [ ] `npm test` is green (existing 161+ tests pass)
 - [ ] New rule? Add at least one passthrough and one trim test case
 - [ ] Touched `init`/`uninstall`? Extend the round-trip integration test
 - [ ] New config field? Document it in `README.md` and `DEFAULT_CONFIG`
@@ -37,11 +37,11 @@ Pick a row from the **Good first issues** table in the README. The 🟡 medium /
 ### Proposing a new phase / surface
 
 Open a GitHub Discussion (not a PR) with:
-- What behavior changes Claude sees
-- Which Claude Code hook event or mechanism is used
+- What behavior changes the agent sees (Claude Code, Codex, or both)
+- Which hook event or agent mechanism is used
 - What can *go wrong* and how the fail-open guarantee is preserved
 
-Architecture changes get reviewed the same way v1 of the plan did — cross-checked against primary Anthropic docs before any code lands.
+Architecture changes get reviewed the same way v1 of the plan did — cross-checked against primary docs before any code lands.
 
 ---
 
@@ -62,10 +62,11 @@ Node 20+ required (we use `node:test`, `cpSync`, fsync on directories).
 
 ```bash
 # write code
-npm test                         # ~1 s unit + integration
+npm test                         # ~2 s unit + integration
 npm run build                    # re-emit dist/
-tokenomy doctor                  # 9/9 ✓ if things are wired
+tokenomy doctor                  # 12/12 ✓ if things are wired
 tail -f ~/.tokenomy/debug.jsonl  # see every hook invocation in your live session
+tokenomy analyze --since 1d      # sanity-check changes against real transcripts
 ```
 
 ### End-to-end smoke
@@ -101,27 +102,32 @@ Tokenomy is TypeScript + Node ESM + `node:test`. No build magic.
 
 ```
 src/
-  core/     — types, config, paths, gate, log, recovery hint
-  rules/    — pure transforms: (toolName, toolInput, toolResponse, cfg) → RuleResult
-  hook/     — entry.ts + dispatch.ts + pre-dispatch.ts (stdin → rule → stdout)
-  cli/      — init, doctor, uninstall, config-cmd, entry
+  core/     — types, config, paths, gate, log, dedup, recovery hint
+  rules/    — pure transforms: mcp-content, read-bound, text-trim, profiles, stacktrace, redact
+  hook/     — entry.ts + dispatch.ts + pre-dispatch.ts (stdin → rule → stdout, Claude Code)
+  analyze/  — transcript scanner (Claude Code + Codex), parse, tokens, simulate, report, render
+  graph/    — code-graph schema, build, query (minimal, impact, review, usages)
+  mcp/      — stdio server, tool handlers, schemas, query LRU cache, budget-clip
+  parsers/  — TS/JS AST extraction
+  cli/      — init, doctor (+ --fix), uninstall, config-cmd, report, analyze, graph, entry
   util/     — settings-patch, manifest, atomic-write, backup, json helpers
 
 tests/
   unit/         — one file per module
-  integration/  — spawn the compiled binary; tmp HOME round-trips
-  fixtures/     — JSON inputs/expected outputs
+  integration/  — spawn compiled binary; tmp HOME round-trips
+  fixtures/     — JSON inputs/expected outputs, synthetic graph repo
 ```
 
 Rules are pure functions. Adding a new rule is a single-file drop-in + a test file. No framework to learn.
 
 ### Guiding principles (non-negotiable)
 
-1. **Fail-open always.** A broken hook is worse than no hook. Never exit 2, never throw past the top-level `try`, never leave stdout with garbage that breaks Claude's `JSON.parse`. When in doubt, exit 0 with empty stdout.
+1. **Fail-open always.** A broken hook is worse than no hook. Never exit 2, never throw past the top-level `try`, never leave stdout with garbage that breaks the agent's `JSON.parse`. When in doubt, exit 0 with empty stdout.
 2. **Schema invariants over trust.** Test that rule outputs never fabricate keys, flip types, shrink arrays, or lose `is_error`. Every rule PR must add at least one invariant assertion.
-3. **Path-match over markers.** Uninstall identifies our hook entries by absolute command path under `~/.tokenomy/bin/`, not by injected `_tokenomy: true` keys. Claude Code's settings schema may tighten tomorrow.
-4. **Measure before bragging.** No "X% savings" claims in code or docs until Phase 2 benchmarks them against a real transcript corpus.
+3. **Path-match over markers.** Uninstall identifies our hook entries by absolute command path under `~/.tokenomy/bin/`, not by injected `_tokenomy: true` keys. The upstream settings schema may tighten tomorrow.
+4. **Measure before bragging.** Use `tokenomy analyze` to back up performance claims with real transcript data instead of pulling numbers out of thin air.
 5. **Small and legible.** If a dependency shaves a dozen lines for a 200 KB install cost, say no.
+6. **Agent-agnostic where possible.** Live hooks are Claude-Code-specific today, but graph + analyze must work across agents. Don't bake Claude-Code-only assumptions into the shared modules.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Stop burning tokens on tool chatter.
 
-A surgical Claude Code hook that transparently trims bloated MCP responses and clamps oversized file reads — so your agent spends tokens on *thinking*, not on parsing 40 KB of Jira JSON for the third time.
+A surgical hook + analysis toolkit for **Claude Code and Codex CLI** that transparently trims bloated MCP responses, clamps oversized file reads, dedupes repeat calls, and benchmarks historical waste — so your agent spends tokens on *thinking*, not on parsing 40 KB of Jira JSON for the third time.
 
 [![CI](https://github.com/RahulDhiman93/Tokenomy/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/RahulDhiman93/Tokenomy/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/RahulDhiman93/Tokenomy/main/.github/badges/coverage.json&cacheSeconds=300)](#contribute)
@@ -19,7 +19,7 @@ A surgical Claude Code hook that transparently trims bloated MCP responses and c
 
 ## 🩻 The pain
 
-Your last long Claude Code session looked something like this:
+Your last long coding-agent session — Claude Code or Codex — looked something like this:
 
 ```
 Assistant → get_jira_issue        ← 40 KB
@@ -30,31 +30,48 @@ Assistant → read src/config.ts    ← 14 KB
 ...
 ```
 
-200 K tokens gone before Claude did any real work. **Compaction kicks in too late, and it's lossy.**
+200 K tokens gone before the agent did any real work. **Compaction kicks in too late, and it's lossy.**
 
-Tokenomy plugs the holes the Claude Code hook contract lets you close — with zero proxy, no monkey-patching:
+Tokenomy plugs the holes the agent hook contracts let you close — with zero proxy, no monkey-patching:
 
-| Surface | Mechanism | What it kills |
-|---|---|---|
-| `PostToolUse` on `mcp__.*` | `updatedMCPToolOutput` (multi-stage: redact → stacktrace collapse → schema-aware profile → byte trim) | 10–50 KB MCP responses from Atlassian, Notion, Gmail, Asana, HubSpot, Intercom… |
-| `PostToolUse` on `mcp__.*` | duplicate-response dedup (per session) | Repeated identical tool calls — second hit returns a pointer stub, not a 30 KB refetch |
-| `PreToolUse` on `Read` | `updatedInput` | Unbounded reads on huge source files |
-| `tokenomy-graph` MCP server | 5 tools over stdio | Brute-force `Read` sweeps of the codebase — agent gets focused context from a pre-built graph |
+| Surface | Works with | Mechanism | What it kills |
+|---|---|---|---|
+| `PostToolUse` on `mcp__.*` | Claude Code | `updatedMCPToolOutput` (multi-stage: redact → stacktrace collapse → schema-aware profile → byte trim) | 10–50 KB MCP responses from Atlassian, Notion, Gmail, Asana, HubSpot, Intercom… |
+| `PostToolUse` on `mcp__.*` | Claude Code | duplicate-response dedup (per session) | Repeated identical tool calls — second hit returns a pointer stub, not a 30 KB refetch |
+| `PreToolUse` on `Read` | Claude Code | `updatedInput` | Unbounded reads on huge source files |
+| `tokenomy-graph` MCP server | Claude Code · Codex CLI | 5 tools over stdio | Brute-force `Read` sweeps of the codebase — agent gets focused context from a pre-built graph |
+| `tokenomy analyze` | Claude Code · Codex CLI transcripts | Walks `~/.claude/projects/**/*.jsonl` + `~/.codex/sessions/**/*.jsonl`, replays Tokenomy rules with a real tokenizer | Tells you *exactly* how much you've been wasting, by tool, by day, by rule |
 
-Each trim appends a row to `~/.tokenomy/savings.jsonl` with measured bytes-in / bytes-out, so you can prove the savings. Run `tokenomy report` for a TUI + HTML digest.
+Each live trim appends a row to `~/.tokenomy/savings.jsonl` with measured bytes-in / bytes-out, so you can prove the savings. Run `tokenomy report` for a TUI + HTML digest, or `tokenomy analyze` to benchmark real historical waste from session transcripts.
 
 ---
 
 ## ⚡ Quickstart
 
+### Claude Code (full integration: live hooks + graph + analyze)
+
 ```bash
 npm install -g tokenomy
 tokenomy init          # patches ~/.claude/settings.json (backed up first)
-tokenomy doctor        # 9/9 ✓
+tokenomy doctor        # 12/12 ✓
 # restart Claude Code
 ```
 
 That's it. Use Claude Code normally. Tokenomy does the rest.
+
+### Codex CLI (graph MCP server + transcript analysis)
+
+Codex doesn't expose PostToolUse/PreToolUse hooks yet, so the live trim features are Claude-Code-only. But the two **agent-agnostic** features work great with Codex:
+
+```bash
+npm install -g tokenomy
+codex mcp add tokenomy-graph -- tokenomy graph serve --path "$PWD"
+tokenomy graph build --path "$PWD"
+# Codex can now call build_or_update_graph / get_minimal_context / get_impact_radius
+# / get_review_context / find_usages, exactly as Claude Code does.
+
+tokenomy analyze       # benchmarks both ~/.claude and ~/.codex transcripts
+```
 
 > **Still pre-`1.0`.** Every release carries an `-alpha.N` suffix and breaking changes may land on minor bumps — the [CHANGELOG](./CHANGELOG.md) calls them out. Users who want stability should pin a specific version: `npm install -g tokenomy@0.1.0-alpha.6`.
 
@@ -87,7 +104,7 @@ grep -oE '"tokens_saved_est":[0-9]+' ~/.tokenomy/savings.jsonl \
 ## 🧠 How it actually works
 
 ```
-   ┌─────────────────────── Claude Code ───────────────────────┐
+   ┌────────────────── Claude Code (full integration) ──────────┐
    │                                                            │
    │   user prompt → LLM → tool call                            │
    │                          │                                 │
@@ -106,6 +123,12 @@ grep -oE '"tokens_saved_est":[0-9]+' ~/.tokenomy/savings.jsonl \
    │                          │                                 │
    │              savings.jsonl  ◄──  best-effort append        │
    └────────────────────────────────────────────────────────────┘
+
+   ┌────────────── Claude Code · Codex CLI (shared) ────────────┐
+   │                                                            │
+   │   tokenomy-graph MCP   → focused neighborhood queries      │
+   │   tokenomy analyze     → replays rules over transcripts    │
+   └────────────────────────────────────────────────────────────┘
 ```
 
 ### Under the hood
@@ -120,9 +143,9 @@ grep -oE '"tokens_saved_est":[0-9]+' ~/.tokenomy/savings.jsonl \
 
 `content.length` never shrinks, `is_error` flows through, non-text blocks (images, resources) pass through untouched, and unknown top-level keys are preserved. Each trim's `reason` reports which stages fired (e.g. `redact:3+profile:atlassian-jira-issue`).
 
-**Read clamp (`PreToolUse`).** If Claude's `Read` call has an explicit `limit` or `offset`, passthrough — respect user intent. Otherwise, stat the file. Under threshold → passthrough. Over threshold → inject `limit: N` plus an `additionalContext` note so Claude knows it can offset-Read more regions.
+**Read clamp (`PreToolUse`).** If the agent's `Read` call has an explicit `limit` or `offset`, passthrough — respect user intent. Otherwise, stat the file. Under threshold → passthrough. Over threshold → inject `limit: N` plus an `additionalContext` note so the agent knows it can offset-Read more regions.
 
-**Fail-open is a non-negotiable.** Malformed stdin, parse errors, unknown shapes → exit 0 with empty stdout (true passthrough). 10 MB stdin cap. 2.5 s internal timeout. Exit code 2 (blocking) is never used. Breaking Claude is worse than wasting tokens.
+**Fail-open is a non-negotiable.** Malformed stdin, parse errors, unknown shapes → exit 0 with empty stdout (true passthrough). 10 MB stdin cap. 2.5 s internal timeout. Exit code 2 (blocking) is never used. Breaking the agent is worse than wasting tokens.
 
 ---
 
@@ -251,18 +274,79 @@ The HTML variant renders a daily bar chart you can screenshot for PR description
 
 ---
 
-## 🕸️ Code-graph MCP server (opt-in, Phase 3)
+## 🔬 `tokenomy analyze`
 
-Once the two hooks stop bleeding tokens on tool chatter, the next waste is Claude reading half a codebase to find one function. The optional **`tokenomy-graph` MCP server** gives the agent four surgical tools over stdio — the graph is built once, queries return focused neighborhoods, budgets are hard-capped.
+`report` shows what the live hooks already saved. `analyze` goes further: it walks the **raw session transcripts** of Claude Code (`~/.claude/projects/**/*.jsonl`) *and* Codex CLI (`~/.codex/sessions/**/*.jsonl`), replays the full Tokenomy rule pipeline over every historical tool call with a real tokenizer, and tells you exactly how much you *would have* saved if Tokenomy had been installed from day one — plus where the waste actually concentrates today.
 
-### Install + register
+```bash
+tokenomy analyze                              # default: scan last 30 days, top 10 tools
+tokenomy analyze --since 7d                   # last week
+tokenomy analyze --since 2026-04-01           # from a specific date
+tokenomy analyze --project Tokenomy           # filter by project dir substring
+tokenomy analyze --session 6689da94           # one session
+tokenomy analyze --tokenizer tiktoken         # accurate cl100k counts (see below)
+tokenomy analyze --json                       # machine-readable
+tokenomy analyze --verbose                    # include per-day breakdown
+```
+
+The default output is a fancy CLI dashboard: rounded-box header, per-rule savings bars, top-N waste leaderboard, duplicate hotspots, largest individual tool results, and an inline sparkline by day. Pipe to a file or use `--no-color` to disable ANSI.
+
+### Tokenizer choice
+
+- **`heuristic`** (default) — zero-dep word/punctuation splitter calibrated for code + JSON. Accurate to ~±10% on typical tool responses.
+- **`tiktoken`** — real `cl100k_base` counts via `js-tiktoken`. A solid Claude-token approximation (Anthropic doesn't publish Claude 4's BPE). Install with `npm i -g js-tiktoken` and pass `--tokenizer=tiktoken`.
+- **`auto`** — use tiktoken if present, else heuristic.
+
+### Sample output
+
+```
+╭────────────────────────── tokenomy analyze ──────────────────────────╮
+│ Window: 2026-04-17T10:00:00Z  →  2026-04-18T19:59:18Z                │
+│ Tokenizer: heuristic (approximate)                                   │
+╰──────────────────────────────────────────────────────────────────────╯
+
+Summary
+  Files scanned              4     Sessions       2
+  Tool calls parsed        299     Duplicate calls 1
+  Tokens observed       89,562     ~USD observed  $0.2687
+  Tokens Tokenomy would save  1,926  (2.2% of observed)
+  ~USD Tokenomy would save   $0.0058
+
+Savings by rule
+  Duplicate-response dedup       ████████████████████████   1,926 tok
+  Read clamp                     ████░░░░░░░░░░░░░░░░░░░░     324 tok
+
+Duplicate hotspots  (same args, repeated within a session)
+  Read                     2×      2,263 tok wasted
+  Read                     2×      1,965 tok wasted
+  ...
+```
+
+`analyze` never modifies anything; it just reads. The transcript parser handles both Claude Code's `assistant.message.content[].tool_use` → `user.message.content[].tool_result` pairing and Codex CLI's `payload.tool_call` rollout shape.
+
+---
+
+## 🕸️ Code-graph MCP server (agent-agnostic, Phase 3)
+
+Once the live hooks stop bleeding tokens on tool chatter, the next waste is the agent reading half a codebase to find one function. The optional **`tokenomy-graph` MCP server** gives the agent five surgical tools over stdio — the graph is built once, queries return focused neighborhoods, budgets are hard-capped. Works with both Claude Code and Codex CLI.
+
+### Install + register (Claude Code)
 
 ```bash
 npm install -g typescript              # peer-optional; required for the graph
 tokenomy init --graph-path "$PWD"      # adds tokenomy-graph to ~/.claude/settings.json
 tokenomy graph build --path "$PWD"     # parses TS/JS into ~/.tokenomy/graphs/<id>/
-tokenomy doctor                        # 10/10 ✓
+tokenomy doctor                        # 12/12 ✓
 # restart Claude Code
+```
+
+### Install + register (Codex CLI)
+
+```bash
+npm install -g typescript
+codex mcp add tokenomy-graph -- tokenomy graph serve --path "$PWD"
+tokenomy graph build --path "$PWD"
+codex mcp list                         # verify tokenomy-graph is registered
 ```
 
 ### The five tools
@@ -295,15 +379,6 @@ tokenomy graph query usages  --path "$PWD" --file src/foo.ts
 tokenomy graph purge [--all]
 ```
 
-### Codex
-
-The MCP server ports cleanly:
-
-```bash
-codex mcp add tokenomy-graph -- tokenomy graph serve --path "$PWD"
-codex mcp list
-```
-
 ### Scope + limits (v1)
 
 - **TypeScript + JavaScript only** (`.ts`/`.tsx`/`.js`/`.jsx`/`.mjs`/`.cjs`, with `.mts`/`.cts` probed). Python / 23-lang support explicitly out of scope.
@@ -326,29 +401,29 @@ Removes both hook entries from `~/.claude/settings.json` (matched by absolute co
 
 ## 🧭 Roadmap
 
-- [x] **Phase 1.** `PostToolUse` MCP trim + `PreToolUse` Read clamp + CLI + 12-check doctor + savings log
-- [ ] **Phase 2.** `tokenomy analyze` — walk `~/.claude/projects/**/*.jsonl`, surface waste patterns, benchmark real savings with a real tokenizer
-- [x] **Phase 3.** Local code-graph MCP server: `tokenomy-graph` stdio server + `graph build|status|serve|query|purge` CLI + `init --graph-path` + doctor check. TypeScript AST, 5 tools, hard budget caps, fail-open everywhere.
+- [x] **Phase 1.** `PostToolUse` MCP trim + `PreToolUse` Read clamp + CLI + 12-check doctor + savings log (Claude Code).
+- [x] **Phase 2.** `tokenomy analyze` — walks Claude Code + Codex CLI transcripts, replays rules with a real tokenizer, surfaces waste patterns in a fancy CLI dashboard.
+- [x] **Phase 3.** Local code-graph MCP server: `tokenomy-graph` stdio server + `graph build|status|serve|query|purge` CLI + doctor check. Works with both Claude Code and Codex CLI. TypeScript AST, 5 tools, hard budget caps, fail-open everywhere.
 - [x] **Phase 3.5.** Multi-stage PostToolUse pipeline: duplicate-response dedup, secret redaction, stacktrace collapse, schema-aware trim profiles (Atlassian/Linear/Slack/Gmail/GitHub), per-tool config overrides, `find_usages` graph tool, MCP query LRU cache, `tokenomy report` (TUI + HTML), hook perf telemetry, `doctor --fix`.
-- [ ] **Phase 4.** `PreToolUse` Bash input-bounder (auto-append `| head -N` on verbose commands) + hinting layer nudging Claude toward Tokenomy MCP alternatives
-- [ ] **Phase 5.** Polish — statusline with live savings counter, `UserPromptSubmit` prompt-classifier for effort-level nudges, npm publish
+- [ ] **Phase 4.** `PreToolUse` Bash input-bounder (auto-append `| head -N` on verbose commands) + hinting layer nudging the agent toward Tokenomy MCP alternatives. Codex live-hook support when the CLI exposes a hook contract.
+- [ ] **Phase 5.** Polish — statusline with live savings counter, `UserPromptSubmit` prompt-classifier for effort-level nudges, Python parser plugin for the graph, npm publish at 1.0.
 
 ---
 
 ## 🤝 Contribute
 
-Contributions are very welcome. The repo is still small, dependency-light (zero runtime deps in the hot hook path; `@modelcontextprotocol/sdk` loaded dynamically for the graph server only), and test-first (128/128 currently green).
+Contributions are very welcome. The repo is still small, dependency-light (zero runtime deps in the hot hook path; `@modelcontextprotocol/sdk` loaded dynamically for the graph server only; `js-tiktoken` is an optional peer dep for accurate `analyze` token counts), and test-first (161/161 currently green).
 
 ### Good first issues
 
 | Difficulty | What | Where |
 |---|---|---|
 | 🟢 easy | Add a synthetic fixture for a real-world MCP tool you use (Asana, HubSpot, etc.) and a rule-level test | `tests/fixtures/` + `tests/unit/mcp-content.test.ts` |
-| 🟢 easy | Make `tokenomy analyze` (Phase 2) — read `~/.claude/projects/**/*.jsonl`, aggregate `tokens_saved_est` by tool | new `src/cli/analyze.ts` |
-| 🟡 medium | Add a "structured JSON" trim rule — when an MCP text block is valid JSON, trim the parsed structure instead of the raw text | new `src/rules/json-aware.ts` |
+| 🟢 easy | Add more `analyze` transcript parser support (other Codex rollout shapes, OpenCode, Aider) | `src/analyze/parse.ts` |
+| 🟡 medium | Add a built-in trim profile for another MCP server you use | `src/rules/profiles.ts` |
 | 🟡 medium | Statusline script (`bin/tokenomy-statusline`) that consumes Claude Code's statusline stdin and renders live savings | new `src/statusline/` |
-| 🔴 hard | Phase 3 MCP companion server (stdio transport). Main scaffolding done in spec; needs implementation | new `src/mcp/` |
 | 🔴 hard | Phase 4 Bash input-bounder — shell-aware parsing to detect commands lacking any existing bound | new `src/rules/bash-bound.ts` |
+| 🔴 hard | Python parser plugin for the graph MCP server — spawn `python -c "import ast"` and extract imports/defs | new `src/parsers/py/` |
 
 ### Architecture tour
 
@@ -357,16 +432,17 @@ src/
   core/     — types, config (+ per-tool overrides), paths, gate, log, dedup, recovery hint
   rules/    — pure transforms: mcp-content, read-bound, text-trim, profiles, stacktrace, redact
   hook/     — entry.ts + dispatch.ts + pre-dispatch.ts (stdin → rule → stdout)
+  analyze/  — transcript scanner (Claude Code + Codex), parse, tokens, simulate, report, render
   graph/    — schema, build, stale detection, repo-id, query/{minimal,impact,review,usages,budget,common}
   mcp/      — stdio server, tool handlers, schema definitions, query-cache (LRU), budget-clip
   parsers/  — TS/JS AST extraction
-  cli/      — init, doctor (+ --fix), uninstall, config-cmd, report, graph, entry
+  cli/      — init, doctor (+ --fix), uninstall, config-cmd, report, analyze, graph, entry
   util/     — settings-patch, manifest, atomic-write, backup, json helpers
 
 tests/
   unit/         — one file per module, ≥1 trim + ≥1 passthrough per rule
-  integration/  — spawn compiled dist/hook/entry.js as subprocess
-  fixtures/     — synthetic repos for graph tests; will host real captured MCP responses (Phase 2)
+  integration/  — spawn compiled dist/hook/entry.js or dist/cli/entry.js as subprocess
+  fixtures/     — synthetic graph repos + synthesized transcripts for analyze
 ```
 
 Rules are pure functions: `(toolName, toolInput, toolResponse, config) → { kind: "passthrough" | "trim", ... }`. Adding a new rule is a one-file drop-in.
@@ -380,11 +456,12 @@ git clone https://github.com/RahulDhiman93/Tokenomy.git
 cd Tokenomy
 npm install
 npm run build        # tsc + chmod +x
-npm test             # node:test runner, 128 tests, ~2 s
+npm test             # node:test runner, 161 tests, ~2 s
 npm run coverage     # c8 → coverage/lcov.info + HTML report
 npm run typecheck    # tsc --noEmit
 npm link             # overrides any installed `tokenomy` with your local build
 tokenomy doctor      # 12/12 ✓
+tokenomy analyze     # benchmarks your real transcripts
 ```
 
 Revert to the published version later with `npm unlink -g tokenomy && npm install -g tokenomy`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tokenomy",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tokenomy",
-      "version": "0.1.0-alpha.6",
+      "version": "0.1.0-alpha.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.15.0"
@@ -25,9 +25,13 @@
         "node": ">=20"
       },
       "peerDependencies": {
+        "js-tiktoken": "^1.0.0",
         "typescript": "^5.6.0"
       },
       "peerDependenciesMeta": {
+        "js-tiktoken": {
+          "optional": true
+        },
         "typescript": {
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenomy",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "description": "Surgical Claude Code hook that transparently trims bloated MCP tool responses and clamps oversized file reads — stop burning tokens on tool chatter.",
   "type": "module",
   "engines": {
@@ -55,10 +55,14 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "typescript": "^5.6.0"
+    "typescript": "^5.6.0",
+    "js-tiktoken": "^1.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {
+      "optional": true
+    },
+    "js-tiktoken": {
       "optional": true
     }
   },

--- a/src/analyze/parse.ts
+++ b/src/analyze/parse.ts
@@ -48,16 +48,18 @@ const utf8Bytes = (s: string): number => Buffer.byteLength(s, "utf8");
 //   "Chunk ID: abc\nWall time: 0.4s\nProcess exited with code 0\n" +
 //   "Original token count: 123\nOutput:\n<actual payload>"
 // For MCP connector calls, <actual payload> is structured JSON (same shape
-// mcpContentRule expects). For exec_command / write_stdin it's plain text.
-// We strip the header so downstream rules can see the true payload and,
-// when the payload is structured JSON, parse it back into an object.
+// mcpContentRule expects). For exec_command / write_stdin it's plain text
+// and must NOT be JSON-parsed, even if the output happens to be valid JSON
+// (e.g. `cat package.json`) — that'd mask the text as a structured object
+// and downstream tooling would miscount / mis-trim it.
 const CODEX_OUTPUT_PREFIX = /^(?:Chunk ID:.*\n)?(?:Wall time:.*\n)?(?:Process exited with code.*\n)?(?:Original token count:.*\n)?Output:\n/;
-export const unwrapCodexOutput = (raw: unknown): unknown => {
+export const unwrapCodexOutput = (raw: unknown, toolName: string): unknown => {
   if (typeof raw !== "string") return raw;
   const match = raw.match(CODEX_OUTPUT_PREFIX);
   const stripped = match ? raw.slice(match[0].length) : raw;
-  // Opportunistic JSON parse: if the payload looks like a JSON object or
-  // array, decode it so mcp-content-rule can traverse the structure.
+  // Only MCP connector outputs get JSON-decoded. exec_command and similar
+  // shell tools stay as strings so the simulator/rules see the real text.
+  if (!toolName.startsWith("mcp__")) return stripped;
   const trimmed = stripped.trim();
   if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
     try {
@@ -234,8 +236,15 @@ const extractCodex = (
     if (!use) return true; // orphan output — drop
     state.pending.delete(id);
     const rawOutput = payload["output"];
-    const output = unwrapCodexOutput(rawOutput);
-    const bytes = utf8Bytes(JSON.stringify(output ?? null));
+    const output = unwrapCodexOutput(rawOutput, use.tool_name);
+    // Count observed bytes from the un-decorated raw string when the tool
+    // output is plain text (shell), so we don't inflate the size by
+    // re-escaping. For JSON-parsed connector outputs, stringify to get a
+    // stable structured-size measurement.
+    const bytes =
+      typeof output === "string"
+        ? utf8Bytes(output)
+        : utf8Bytes(JSON.stringify(output ?? null));
     emit({
       agent: "codex",
       session_id: state.session_id,

--- a/src/analyze/parse.ts
+++ b/src/analyze/parse.ts
@@ -47,6 +47,13 @@ const utf8Bytes = (s: string): number => Buffer.byteLength(s, "utf8");
 // Per-session bookkeeping carried across lines in a single file.
 // Claude Code and Codex both emit call + output as separate lines keyed by
 // a correlation id — we buffer the call until its matching output arrives.
+//
+// session_id and project_hint start as path-derived fallbacks but get
+// replaced by values read from event metadata (Claude Code: `.sessionId` +
+// `.cwd`; Codex: `session_meta.payload.{id,cwd}`). This ensures sidechain
+// transcripts and flat Codex rollouts still aggregate under the correct
+// logical session/project rather than under a path-derived surrogate like
+// the day number in `~/.codex/sessions/YYYY/MM/DD/`.
 export interface ParserState {
   session_id: string;
   project_hint: string;
@@ -59,6 +66,25 @@ export const makeState = (session_id: string, project_hint: string): ParserState
   project_hint,
   pending: new Map(),
 });
+
+// Update session/project identity from in-event metadata. Called on every
+// line before extraction; once we've seen a trustworthy value we keep it.
+const upgradeIdentity = (line: Record<string, unknown>, state: ParserState): void => {
+  // Claude Code: assistant/user/attachment events carry `.sessionId` + `.cwd`.
+  const claudeSession = typeof line["sessionId"] === "string" ? (line["sessionId"] as string) : "";
+  const claudeCwd = typeof line["cwd"] === "string" ? (line["cwd"] as string) : "";
+  if (claudeSession) state.session_id = claudeSession;
+  if (claudeCwd) state.project_hint = claudeCwd;
+
+  // Codex: first line is `session_meta` with `payload.{id,cwd}`.
+  if (line["type"] === "session_meta") {
+    const payload = asObject(line["payload"]);
+    const codexId = typeof payload["id"] === "string" ? (payload["id"] as string) : "";
+    const codexCwd = typeof payload["cwd"] === "string" ? (payload["cwd"] as string) : "";
+    if (codexId) state.session_id = codexId;
+    if (codexCwd) state.project_hint = codexCwd;
+  }
+};
 
 const extractClaudeToolUses = (line: Record<string, unknown>, state: ParserState): void => {
   if (line["type"] !== "assistant") return;
@@ -206,6 +232,7 @@ export const feedLine = (
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return;
   const obj = parsed as Record<string, unknown>;
+  upgradeIdentity(obj, state);
   if (extractCodex(obj, state, emit)) return;
   extractClaudeToolUses(obj, state);
   extractClaudeToolResults(obj, state, emit);

--- a/src/analyze/parse.ts
+++ b/src/analyze/parse.ts
@@ -44,6 +44,31 @@ const asObject = (v: unknown): Record<string, unknown> =>
 
 const utf8Bytes = (s: string): number => Buffer.byteLength(s, "utf8");
 
+// Codex CLI wraps every function_call_output in a decorated header like:
+//   "Chunk ID: abc\nWall time: 0.4s\nProcess exited with code 0\n" +
+//   "Original token count: 123\nOutput:\n<actual payload>"
+// For MCP connector calls, <actual payload> is structured JSON (same shape
+// mcpContentRule expects). For exec_command / write_stdin it's plain text.
+// We strip the header so downstream rules can see the true payload and,
+// when the payload is structured JSON, parse it back into an object.
+const CODEX_OUTPUT_PREFIX = /^(?:Chunk ID:.*\n)?(?:Wall time:.*\n)?(?:Process exited with code.*\n)?(?:Original token count:.*\n)?Output:\n/;
+export const unwrapCodexOutput = (raw: unknown): unknown => {
+  if (typeof raw !== "string") return raw;
+  const match = raw.match(CODEX_OUTPUT_PREFIX);
+  const stripped = match ? raw.slice(match[0].length) : raw;
+  // Opportunistic JSON parse: if the payload looks like a JSON object or
+  // array, decode it so mcp-content-rule can traverse the structure.
+  const trimmed = stripped.trim();
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      // Fall through to string.
+    }
+  }
+  return stripped;
+};
+
 // Per-session bookkeeping carried across lines in a single file.
 // Claude Code and Codex both emit call + output as separate lines keyed by
 // a correlation id — we buffer the call until its matching output arrives.
@@ -165,7 +190,13 @@ const extractCodex = (
 
   if (pType === "function_call" || pType === "custom_tool_call") {
     const id = typeof payload["call_id"] === "string" ? (payload["call_id"] as string) : "";
-    const name = typeof payload["name"] === "string" ? (payload["name"] as string) : "";
+    const rawName = typeof payload["name"] === "string" ? (payload["name"] as string) : "";
+    // Codex connector tools split their identity across `namespace` +
+    // `name` (e.g. namespace="mcp__codex_apps__github", name="_search_prs").
+    // Concatenate so the simulator's `startsWith("mcp__")` check and the
+    // per-tool config glob matching see the full qualified identifier.
+    const ns = typeof payload["namespace"] === "string" ? (payload["namespace"] as string) : "";
+    const name = ns ? `${ns}${rawName}` : rawName;
     if (!id || !name) return true; // consumed but unusable
     // Codex serializes arguments as a JSON string; parse it opportunistically.
     let input: Record<string, unknown> = {};
@@ -197,7 +228,8 @@ const extractCodex = (
     const use = state.pending.get(id);
     if (!use) return true; // orphan output — drop
     state.pending.delete(id);
-    const output = payload["output"];
+    const rawOutput = payload["output"];
+    const output = unwrapCodexOutput(rawOutput);
     const bytes = utf8Bytes(JSON.stringify(output ?? null));
     emit({
       agent: "codex",

--- a/src/analyze/parse.ts
+++ b/src/analyze/parse.ts
@@ -193,10 +193,15 @@ const extractCodex = (
     const rawName = typeof payload["name"] === "string" ? (payload["name"] as string) : "";
     // Codex connector tools split their identity across `namespace` +
     // `name` (e.g. namespace="mcp__codex_apps__github", name="_search_prs").
-    // Concatenate so the simulator's `startsWith("mcp__")` check and the
-    // per-tool config glob matching see the full qualified identifier.
+    // Normalize to the Claude-style `mcp__<vendor>__<method>` separator so
+    // built-in profile globs (like `mcp__*Atlassian*__getJiraIssue`) match
+    // both agents' tool names without per-agent special-casing.
     const ns = typeof payload["namespace"] === "string" ? (payload["namespace"] as string) : "";
-    const name = ns ? `${ns}${rawName}` : rawName;
+    const name = ns
+      ? rawName.startsWith("_")
+        ? `${ns}_${rawName}` // name already starts with "_" → yields `__`
+        : `${ns}__${rawName}` // otherwise add the full `__` separator
+      : rawName;
     if (!id || !name) return true; // consumed but unusable
     // Codex serializes arguments as a JSON string; parse it opportunistically.
     let input: Record<string, unknown> = {};

--- a/src/analyze/parse.ts
+++ b/src/analyze/parse.ts
@@ -45,10 +45,13 @@ const asObject = (v: unknown): Record<string, unknown> =>
 const utf8Bytes = (s: string): number => Buffer.byteLength(s, "utf8");
 
 // Per-session bookkeeping carried across lines in a single file.
+// Claude Code and Codex both emit call + output as separate lines keyed by
+// a correlation id — we buffer the call until its matching output arrives.
 export interface ParserState {
   session_id: string;
   project_hint: string;
-  pending: Map<string, RawToolUse>; // tool_use_id → tool use
+  // Claude Code: tool_use_id → use; Codex: call_id → use.
+  pending: Map<string, RawToolUse>;
 }
 
 export const makeState = (session_id: string, project_hint: string): ParserState => ({
@@ -117,38 +120,74 @@ const extractClaudeToolResults = (
   }
 };
 
-// Codex rollout shape: events look like
-//   { "type":"event_msg", "payload": { "type":"tool_call", "tool":{...}, "result":{...} } }
-// or separate function_call / function_call_output items. We accept any shape
-// that exposes {tool_name, tool_input, tool_output} at a top-level key.
+// Codex rollout shape (as of codex-cli 0.12x):
+//   { "type":"response_item", "timestamp":"...", "payload":{
+//       "type":"function_call", "name":"...", "arguments":"<json-string>",
+//       "call_id":"call_..." } }
+//   { "type":"response_item", "timestamp":"...", "payload":{
+//       "type":"function_call_output", "call_id":"call_...", "output":"..." } }
+// The call and output arrive on separate lines, keyed by call_id.
 const extractCodex = (
   line: Record<string, unknown>,
   state: ParserState,
   emit: (call: ToolCall) => void,
 ): boolean => {
-  // Heuristic: Codex rollout lines often carry "payload" or "item_type".
+  if (line["type"] !== "response_item") return false;
   const payload = asObject(line["payload"]);
-  const item = asObject(line["item"]);
-  const tc = asObject(payload["tool_call"] ?? item["tool_call"]);
-  if (!tc || Object.keys(tc).length === 0) return false;
-  const name = typeof tc["name"] === "string" ? (tc["name"] as string) : "";
-  const input = asObject(tc["arguments"] ?? tc["input"]);
-  const output = tc["output"] ?? tc["result"];
-  if (!name) return false;
+  const pType = payload["type"];
   const ts = typeof line["timestamp"] === "string" ? (line["timestamp"] as string) : "";
-  const bytes = utf8Bytes(JSON.stringify(output ?? null));
-  emit({
-    agent: "codex",
-    session_id: state.session_id,
-    project_hint: state.project_hint,
-    ts,
-    tool_name: name,
-    tool_input: input,
-    tool_response: output,
-    is_error: tc["is_error"] === true,
-    response_bytes: bytes,
-  });
-  return true;
+
+  if (pType === "function_call" || pType === "custom_tool_call") {
+    const id = typeof payload["call_id"] === "string" ? (payload["call_id"] as string) : "";
+    const name = typeof payload["name"] === "string" ? (payload["name"] as string) : "";
+    if (!id || !name) return true; // consumed but unusable
+    // Codex serializes arguments as a JSON string; parse it opportunistically.
+    let input: Record<string, unknown> = {};
+    const rawArgs = payload["arguments"];
+    if (typeof rawArgs === "string") {
+      try {
+        const parsed = JSON.parse(rawArgs);
+        input = asObject(parsed);
+      } catch {
+        input = { _raw: rawArgs };
+      }
+    } else {
+      input = asObject(rawArgs);
+    }
+    state.pending.set(id, {
+      session_id: state.session_id,
+      project_hint: state.project_hint,
+      ts,
+      tool_use_id: id,
+      tool_name: name,
+      tool_input: input,
+    });
+    return true;
+  }
+
+  if (pType === "function_call_output" || pType === "custom_tool_call_output") {
+    const id = typeof payload["call_id"] === "string" ? (payload["call_id"] as string) : "";
+    if (!id) return true;
+    const use = state.pending.get(id);
+    if (!use) return true; // orphan output — drop
+    state.pending.delete(id);
+    const output = payload["output"];
+    const bytes = utf8Bytes(JSON.stringify(output ?? null));
+    emit({
+      agent: "codex",
+      session_id: state.session_id,
+      project_hint: state.project_hint,
+      ts: ts || use.ts,
+      tool_name: use.tool_name,
+      tool_input: use.tool_input,
+      tool_response: output,
+      is_error: false,
+      response_bytes: bytes,
+    });
+    return true;
+  }
+
+  return false;
 };
 
 // Fold a single JSONL line into the parser state, emitting zero or more

--- a/src/analyze/parse.ts
+++ b/src/analyze/parse.ts
@@ -37,6 +37,11 @@ export interface ToolCall {
   tool_response: unknown; // same shape as HookInput.tool_response
   is_error: boolean;
   response_bytes: number;
+  // Codex's function_call_output wrapper advertises an exact token count
+  // for the inner payload (e.g. `Original token count: 423`). When present,
+  // the simulator uses it directly instead of re-tokenizing — crucial for
+  // correct observed-token / USD numbers on exec-heavy sessions.
+  observed_tokens_override?: number;
 }
 
 const asObject = (v: unknown): Record<string, unknown> =>
@@ -53,6 +58,19 @@ const utf8Bytes = (s: string): number => Buffer.byteLength(s, "utf8");
 // (e.g. `cat package.json`) — that'd mask the text as a structured object
 // and downstream tooling would miscount / mis-trim it.
 const CODEX_OUTPUT_PREFIX = /^(?:Chunk ID:.*\n)?(?:Wall time:.*\n)?(?:Process exited with code.*\n)?(?:Original token count:.*\n)?Output:\n/;
+
+// Extract Codex's own "Original token count: N" from the wrapper header
+// when present. Used as an authoritative override on observed_tokens so
+// our heuristic (or cl100k) approximation doesn't skew the headline
+// numbers on exec-heavy Codex sessions where the real count is known.
+const CODEX_TOKEN_COUNT_RE = /^(?:.*\n)*?Original token count:\s*(\d+)\s*\n/;
+export const extractCodexTokenCount = (raw: unknown): number | undefined => {
+  if (typeof raw !== "string") return undefined;
+  const m = raw.match(CODEX_TOKEN_COUNT_RE);
+  if (!m) return undefined;
+  const n = parseInt(m[1]!, 10);
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
+};
 export const unwrapCodexOutput = (raw: unknown, toolName: string): unknown => {
   if (typeof raw !== "string") return raw;
   const match = raw.match(CODEX_OUTPUT_PREFIX);
@@ -273,6 +291,7 @@ const extractCodex = (
       typeof output === "string"
         ? utf8Bytes(output)
         : utf8Bytes(JSON.stringify(output ?? null));
+    const observed_tokens_override = extractCodexTokenCount(rawOutput);
     emit({
       agent: "codex",
       session_id: state.session_id,
@@ -283,6 +302,7 @@ const extractCodex = (
       tool_response: output,
       is_error: false,
       response_bytes: bytes,
+      ...(observed_tokens_override !== undefined ? { observed_tokens_override } : {}),
     });
     return true;
   }

--- a/src/analyze/parse.ts
+++ b/src/analyze/parse.ts
@@ -63,7 +63,35 @@ export const unwrapCodexOutput = (raw: unknown, toolName: string): unknown => {
   const trimmed = stripped.trim();
   if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
     try {
-      return JSON.parse(trimmed);
+      const parsed = JSON.parse(trimmed);
+      // Normalize to the Claude Code MCP shape (`{content: [...]}`) so
+      // mcpContentRule can traverse the text blocks. Codex connectors
+      // frequently return bare JSON like `{"issues": [...]}`; without the
+      // wrapper the profile/trim pipeline would short-circuit on
+      // passthrough and never count the savings.
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        const obj = parsed as Record<string, unknown>;
+        if (Array.isArray(obj["content"])) return parsed;
+        // Wrap bare JSON objects in a single-text-block MCP response.
+        return {
+          content: [{ type: "text", text: JSON.stringify(parsed) }],
+        };
+      }
+      // Arrays of MCP blocks pass through; anything else gets wrapped too.
+      if (Array.isArray(parsed)) {
+        // If the array already looks like MCP content blocks, keep it as-is
+        // so the raw-array shape path in mcp-content-rule stays intact.
+        if (
+          parsed.length > 0 &&
+          parsed.every(
+            (b) => b && typeof b === "object" && typeof (b as { type?: unknown }).type === "string",
+          )
+        ) {
+          return parsed;
+        }
+        return { content: [{ type: "text", text: JSON.stringify(parsed) }] };
+      }
+      return parsed;
     } catch {
       // Fall through to string.
     }

--- a/src/analyze/parse.ts
+++ b/src/analyze/parse.ts
@@ -1,0 +1,173 @@
+// Transcript parser: turns raw Claude Code / Codex JSONL events into a
+// normalized stream of ToolCall records that the simulator + report builder
+// can consume without caring about agent-specific shape quirks.
+//
+// Claude Code shape:
+//   { type: "assistant", message: { content: [ { type: "tool_use", id, name, input }, ... ] }, sessionId, timestamp, cwd }
+//   { type: "user",      message: { content: [ { type: "tool_result", tool_use_id, content, is_error }, ... ] } }
+//
+// Codex CLI shape (rollout jsonl): similar but wrapped under a "payload"
+// envelope with "msg"/"item_type". We probe both and emit the same
+// normalized record shape either way.
+
+export interface RawToolUse {
+  session_id: string;
+  project_hint: string;
+  ts: string;
+  tool_use_id: string;
+  tool_name: string;
+  tool_input: Record<string, unknown>;
+}
+
+export interface RawToolResult {
+  session_id: string;
+  ts: string;
+  tool_use_id: string;
+  content: unknown; // string | array[{type,text,...}]
+  is_error?: boolean;
+}
+
+export interface ToolCall {
+  agent: "claude-code" | "codex" | "unknown";
+  session_id: string;
+  project_hint: string;
+  ts: string;
+  tool_name: string;
+  tool_input: Record<string, unknown>;
+  tool_response: unknown; // same shape as HookInput.tool_response
+  is_error: boolean;
+  response_bytes: number;
+}
+
+const asObject = (v: unknown): Record<string, unknown> =>
+  v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+
+const utf8Bytes = (s: string): number => Buffer.byteLength(s, "utf8");
+
+// Per-session bookkeeping carried across lines in a single file.
+export interface ParserState {
+  session_id: string;
+  project_hint: string;
+  pending: Map<string, RawToolUse>; // tool_use_id → tool use
+}
+
+export const makeState = (session_id: string, project_hint: string): ParserState => ({
+  session_id,
+  project_hint,
+  pending: new Map(),
+});
+
+const extractClaudeToolUses = (line: Record<string, unknown>, state: ParserState): void => {
+  if (line["type"] !== "assistant") return;
+  const message = asObject(line["message"]);
+  const content = message["content"];
+  if (!Array.isArray(content)) return;
+  const ts = typeof line["timestamp"] === "string" ? (line["timestamp"] as string) : "";
+  for (const block of content) {
+    const b = asObject(block);
+    if (b["type"] !== "tool_use") continue;
+    const id = typeof b["id"] === "string" ? (b["id"] as string) : "";
+    const name = typeof b["name"] === "string" ? (b["name"] as string) : "";
+    if (!id || !name) continue;
+    const input = asObject(b["input"]);
+    state.pending.set(id, {
+      session_id: state.session_id,
+      project_hint: state.project_hint,
+      ts,
+      tool_use_id: id,
+      tool_name: name,
+      tool_input: input,
+    });
+  }
+};
+
+const extractClaudeToolResults = (
+  line: Record<string, unknown>,
+  state: ParserState,
+  emit: (call: ToolCall) => void,
+): void => {
+  if (line["type"] !== "user") return;
+  const message = asObject(line["message"]);
+  const content = message["content"];
+  if (!Array.isArray(content)) return;
+  const ts = typeof line["timestamp"] === "string" ? (line["timestamp"] as string) : "";
+  for (const block of content) {
+    const b = asObject(block);
+    if (b["type"] !== "tool_result") continue;
+    const id = typeof b["tool_use_id"] === "string" ? (b["tool_use_id"] as string) : "";
+    if (!id) continue;
+    const use = state.pending.get(id);
+    if (!use) continue; // orphan tool_result — drop
+    state.pending.delete(id);
+
+    const response = b["content"];
+    const is_error = b["is_error"] === true;
+    const bytes = utf8Bytes(JSON.stringify(response ?? null));
+    emit({
+      agent: "claude-code",
+      session_id: state.session_id,
+      project_hint: state.project_hint,
+      ts: ts || use.ts,
+      tool_name: use.tool_name,
+      tool_input: use.tool_input,
+      tool_response: response,
+      is_error,
+      response_bytes: bytes,
+    });
+  }
+};
+
+// Codex rollout shape: events look like
+//   { "type":"event_msg", "payload": { "type":"tool_call", "tool":{...}, "result":{...} } }
+// or separate function_call / function_call_output items. We accept any shape
+// that exposes {tool_name, tool_input, tool_output} at a top-level key.
+const extractCodex = (
+  line: Record<string, unknown>,
+  state: ParserState,
+  emit: (call: ToolCall) => void,
+): boolean => {
+  // Heuristic: Codex rollout lines often carry "payload" or "item_type".
+  const payload = asObject(line["payload"]);
+  const item = asObject(line["item"]);
+  const tc = asObject(payload["tool_call"] ?? item["tool_call"]);
+  if (!tc || Object.keys(tc).length === 0) return false;
+  const name = typeof tc["name"] === "string" ? (tc["name"] as string) : "";
+  const input = asObject(tc["arguments"] ?? tc["input"]);
+  const output = tc["output"] ?? tc["result"];
+  if (!name) return false;
+  const ts = typeof line["timestamp"] === "string" ? (line["timestamp"] as string) : "";
+  const bytes = utf8Bytes(JSON.stringify(output ?? null));
+  emit({
+    agent: "codex",
+    session_id: state.session_id,
+    project_hint: state.project_hint,
+    ts,
+    tool_name: name,
+    tool_input: input,
+    tool_response: output,
+    is_error: tc["is_error"] === true,
+    response_bytes: bytes,
+  });
+  return true;
+};
+
+// Fold a single JSONL line into the parser state, emitting zero or more
+// ToolCall records via the callback. Malformed lines are silently skipped.
+export const feedLine = (
+  line: string,
+  state: ParserState,
+  emit: (call: ToolCall) => void,
+): void => {
+  if (!line) return;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return;
+  const obj = parsed as Record<string, unknown>;
+  if (extractCodex(obj, state, emit)) return;
+  extractClaudeToolUses(obj, state);
+  extractClaudeToolResults(obj, state, emit);
+};

--- a/src/analyze/render.ts
+++ b/src/analyze/render.ts
@@ -1,0 +1,245 @@
+import type { AggregateReport } from "./report.js";
+
+// Pure stdlib ANSI. No chalk, no boxen, no ora.
+// Colours are disabled automatically when stdout isn't a TTY or when the
+// caller passes {color: false}.
+
+export interface RenderOptions {
+  color: boolean;
+  width: number; // terminal width (columns), capped to a sane max.
+  verbose: boolean;
+}
+
+const ansi = (on: boolean) => ({
+  reset: on ? "\x1b[0m" : "",
+  bold: on ? "\x1b[1m" : "",
+  dim: on ? "\x1b[2m" : "",
+  red: on ? "\x1b[31m" : "",
+  green: on ? "\x1b[32m" : "",
+  yellow: on ? "\x1b[33m" : "",
+  blue: on ? "\x1b[34m" : "",
+  magenta: on ? "\x1b[35m" : "",
+  cyan: on ? "\x1b[36m" : "",
+  gray: on ? "\x1b[90m" : "",
+  bgGreen: on ? "\x1b[42m" : "",
+});
+
+const n = (v: number): string => v.toLocaleString("en-US");
+
+const pad = (s: string, width: number, align: "l" | "r" = "l"): string => {
+  // ANSI-aware length: strip control codes before measuring.
+  const visible = s.replace(/\x1b\[[0-9;]*m/g, "");
+  if (visible.length >= width) return s;
+  const filler = " ".repeat(width - visible.length);
+  return align === "l" ? s + filler : filler + s;
+};
+
+const SPARK = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
+
+const sparkline = (values: number[]): string => {
+  if (values.length === 0) return "";
+  const max = Math.max(...values, 1);
+  return values
+    .map((v) => SPARK[Math.min(SPARK.length - 1, Math.floor((v / max) * (SPARK.length - 1)))])
+    .join("");
+};
+
+const bar = (fraction: number, width: number): string => {
+  const filled = Math.round(Math.max(0, Math.min(1, fraction)) * width);
+  return "█".repeat(filled) + "░".repeat(Math.max(0, width - filled));
+};
+
+const boxTop = (width: number, title: string, c: ReturnType<typeof ansi>): string => {
+  const plain = ` ${title} `;
+  const fill = Math.max(0, width - plain.length - 2);
+  return `${c.cyan}╭${"─".repeat(Math.floor(fill / 2))}${c.bold}${plain}${c.reset}${c.cyan}${"─".repeat(Math.ceil(fill / 2))}╮${c.reset}`;
+};
+const boxBottom = (width: number, c: ReturnType<typeof ansi>): string =>
+  `${c.cyan}╰${"─".repeat(Math.max(0, width - 2))}╯${c.reset}`;
+const boxLine = (width: number, inner: string, c: ReturnType<typeof ansi>): string => {
+  const visible = inner.replace(/\x1b\[[0-9;]*m/g, "");
+  const padCount = Math.max(0, width - 2 - visible.length);
+  return `${c.cyan}│${c.reset}${inner}${" ".repeat(padCount)}${c.cyan}│${c.reset}`;
+};
+
+const RULE_LABEL: Record<string, string> = {
+  dedup: "Duplicate-response dedup",
+  stacktrace: "Stacktrace collapse",
+  profile: "Schema-aware profile trim",
+  mcp_trim: "Byte head+tail trim",
+  read_clamp: "Read clamp",
+};
+
+// Render a progress line that overwrites itself via \r. Caller should emit
+// a trailing \n when the scan completes.
+export const renderProgress = (
+  file_index: number,
+  file_total: number,
+  bytes_read: number,
+  elapsed_ms: number,
+  color: boolean,
+  width: number,
+): string => {
+  const c = ansi(color);
+  const pct = file_total > 0 ? file_index / file_total : 1;
+  const barWidth = Math.max(8, Math.min(30, width - 60));
+  const mbs = bytes_read / Math.max(1, elapsed_ms) / 1000;
+  const eta = pct > 0 && pct < 1 ? ` ETA ${Math.round((elapsed_ms / pct - elapsed_ms) / 1000)}s` : "";
+  const line =
+    `${c.dim}Scanning${c.reset} ` +
+    `${c.bold}${String(file_index).padStart(String(file_total).length)}${c.reset}/` +
+    `${file_total}  ` +
+    `${c.green}${bar(pct, barWidth)}${c.reset}  ` +
+    `${(pct * 100).toFixed(1)}%  ${mbs.toFixed(1)} MB/s${eta}`;
+  return `\r${line.slice(0, width + 40)}`; // allow extra for ansi codes
+};
+
+export const render = (report: AggregateReport, opts: RenderOptions): string => {
+  const c = ansi(opts.color);
+  const width = Math.min(120, Math.max(60, opts.width));
+  const out: string[] = [];
+
+  // Header box.
+  out.push(boxTop(width, "tokenomy analyze", c));
+  const window =
+    report.window.first_ts && report.window.last_ts
+      ? `${report.window.first_ts.slice(0, 19)}Z  →  ${report.window.last_ts.slice(0, 19)}Z`
+      : "(no events)";
+  out.push(boxLine(width, ` ${c.dim}Window:${c.reset} ${window}`, c));
+  out.push(
+    boxLine(
+      width,
+      ` ${c.dim}Tokenizer:${c.reset} ${c.bold}${report.tokenizer.name}${c.reset} ${report.tokenizer.approximate ? c.dim + "(approximate)" + c.reset : c.green + "(accurate)" + c.reset}`,
+      c,
+    ),
+  );
+  out.push(boxBottom(width, c));
+  out.push("");
+
+  // Totals card.
+  const t = report.totals;
+  const wastePct = t.observed_tokens > 0 ? (t.savings_tokens / t.observed_tokens) * 100 : 0;
+  out.push(`${c.bold}Summary${c.reset}`);
+  out.push(
+    `  ${pad("Files scanned", 26)} ${c.bold}${n(t.files)}${c.reset}` +
+      `     ${pad("Sessions", 14)} ${c.bold}${n(t.sessions)}${c.reset}`,
+  );
+  out.push(
+    `  ${pad("Tool calls parsed", 26)} ${c.bold}${n(t.tool_calls)}${c.reset}` +
+      `     ${pad("Duplicate calls", 14)} ${c.bold}${n(t.duplicate_calls)}${c.reset}`,
+  );
+  out.push(
+    `  ${pad("Tokens observed", 26)} ${c.bold}${n(t.observed_tokens)}${c.reset}` +
+      `     ${pad("~USD observed", 14)} ${c.bold}$${t.estimated_usd_observed.toFixed(4)}${c.reset}`,
+  );
+  out.push(
+    `  ${pad("Tokens Tokenomy would save", 26)} ` +
+      `${c.green}${c.bold}${n(t.savings_tokens)}${c.reset} ` +
+      `${c.dim}(${wastePct.toFixed(1)}% of observed)${c.reset}`,
+  );
+  out.push(
+    `  ${pad("~USD Tokenomy would save", 26)} ${c.green}${c.bold}$${t.estimated_usd_saved.toFixed(4)}${c.reset}`,
+  );
+  if (t.redact_matches > 0) {
+    out.push(
+      `  ${c.yellow}⚠${c.reset}  ${pad("Secret-pattern matches", 26)} ${c.yellow}${c.bold}${n(t.redact_matches)}${c.reset} ${c.dim}(redaction would fire)${c.reset}`,
+    );
+  }
+  out.push("");
+
+  // Per-rule breakdown.
+  out.push(`${c.bold}Savings by rule${c.reset}`);
+  if (report.by_rule.length === 0) {
+    out.push(`  ${c.dim}(no rule fires — either no events or nothing to trim)${c.reset}`);
+  } else {
+    const maxR = Math.max(...report.by_rule.map((r) => r.savings_tokens), 1);
+    for (const r of report.by_rule) {
+      const label = RULE_LABEL[r.rule] ?? r.rule;
+      const frac = r.savings_tokens / maxR;
+      out.push(
+        `  ${pad(label, 30)} ${c.green}${bar(frac, 24)}${c.reset} ` +
+          `${c.bold}${pad(n(r.savings_tokens), 10, "r")}${c.reset} tok ` +
+          `${c.dim}(${n(r.events)} events)${c.reset}`,
+      );
+    }
+  }
+  out.push("");
+
+  // Top tools.
+  out.push(`${c.bold}Top tools by observed token waste${c.reset}`);
+  if (report.by_tool.length === 0) {
+    out.push(`  ${c.dim}(no tool activity)${c.reset}`);
+  } else {
+    const maxT = Math.max(...report.by_tool.map((t2) => t2.observed_tokens), 1);
+    const header =
+      `  ${pad("Tool", 40)}  ${pad("Calls", 7, "r")}  ${pad("Observed", 12, "r")}  ` +
+      `${pad("Saveable", 12, "r")}  ${pad("%", 5, "r")}  ${pad("Bar", 20)}`;
+    out.push(c.dim + header + c.reset);
+    for (const row of report.by_tool) {
+      const frac = row.observed_tokens / maxT;
+      const waste = row.waste_pct * 100;
+      const colourLabel =
+        waste >= 50
+          ? c.red + row.tool + c.reset
+          : waste >= 20
+          ? c.yellow + row.tool + c.reset
+          : row.tool;
+      out.push(
+        `  ${pad(colourLabel, 40)}  ` +
+          `${pad(n(row.calls), 7, "r")}  ` +
+          `${pad(n(row.observed_tokens), 12, "r")}  ` +
+          `${c.green}${pad(n(row.savings_tokens), 12, "r")}${c.reset}  ` +
+          `${pad(waste.toFixed(0) + "%", 5, "r")}  ` +
+          `${c.cyan}${bar(frac, 20)}${c.reset}`,
+      );
+    }
+  }
+  out.push("");
+
+  // Duplicate hotspots.
+  if (report.hotspots.length > 0) {
+    out.push(`${c.bold}Duplicate hotspots${c.reset}  ${c.dim}(same args, repeated within a session)${c.reset}`);
+    for (const h of report.hotspots) {
+      out.push(
+        `  ${pad(h.tool, 40)}  ${pad(n(h.calls) + "×", 7, "r")}  ` +
+          `${c.red}${pad(n(h.wasted_tokens), 12, "r")}${c.reset} tok wasted`,
+      );
+    }
+    out.push("");
+  }
+
+  // Outliers.
+  if (report.outliers.length > 0) {
+    out.push(`${c.bold}Largest individual tool results${c.reset}`);
+    for (const o of report.outliers) {
+      out.push(
+        `  ${pad(o.tool, 40)}  ${pad(n(o.tokens), 10, "r")} tok  ` +
+          `${c.dim}${o.ts.slice(0, 19)}  ${o.session_id.slice(0, 8)}${c.reset}`,
+      );
+    }
+    out.push("");
+  }
+
+  // By-day sparkline.
+  if (report.by_day.length > 1) {
+    out.push(`${c.bold}By day${c.reset}  ${c.dim}(observed tokens)${c.reset}`);
+    const values = report.by_day.map((d) => d.observed_tokens);
+    out.push(
+      `  ${c.cyan}${sparkline(values)}${c.reset}  ` +
+        `${c.dim}${report.by_day[0]!.day} → ${report.by_day[report.by_day.length - 1]!.day}${c.reset}`,
+    );
+    if (opts.verbose) {
+      for (const d of report.by_day) {
+        const frac = d.observed_tokens / Math.max(1, ...values);
+        out.push(
+          `  ${d.day}  ${c.cyan}${bar(frac, 20)}${c.reset}  ` +
+            `${pad(n(d.observed_tokens), 10, "r")} observed  ` +
+            `${c.green}${pad(n(d.savings_tokens), 10, "r")}${c.reset} saveable`,
+        );
+      }
+    }
+    out.push("");
+  }
+
+  return out.join("\n") + "\n";
+};

--- a/src/analyze/report.ts
+++ b/src/analyze/report.ts
@@ -140,7 +140,10 @@ export class Aggregator {
 
     // Hotspots are session-scoped because real dedup is session-scoped.
     // Two separate sessions each calling the same tool once isn't a hotspot
-    // dedup can fix, so we must not count them together.
+    // dedup can fix, so we must not count them together. We also only count
+    // repeats that the SIMULATOR actually flagged as duplicates — otherwise
+    // we'd rank calls the live hook would miss (outside window_seconds,
+    // below min_bytes, or with dedup disabled) as savable waste.
     const hotspotKey = `${e.session_id}\u0000${e.call_key}`;
     const kb = this.byKey.get(hotspotKey) ?? {
       tool: e.tool_name,
@@ -149,8 +152,7 @@ export class Aggregator {
       wasted_tokens: 0,
     };
     kb.calls++;
-    if (kb.calls > 1) {
-      // Every repeat is waste — the first call is a necessary lookup.
+    if (e.duplicate_of_index !== undefined) {
       kb.wasted_tokens += e.observed_tokens;
     }
     this.byKey.set(hotspotKey, kb);
@@ -210,7 +212,11 @@ export class Aggregator {
       .sort((a, b) => a.day.localeCompare(b.day));
 
     const hotspots = [...this.byKey.values()]
-      .filter((k) => k.calls > 1)
+      // Only surface keys the simulator actually credited as duplicates
+      // (wasted_tokens > 0). A call_key that appeared twice but fell out
+      // of the dedup window or was below min_bytes is not something the
+      // live hook would save, so it doesn't belong on this list.
+      .filter((k) => k.calls > 1 && k.wasted_tokens > 0)
       .map((k) => ({ tool: k.tool, calls: k.calls, wasted_tokens: k.wasted_tokens }))
       .sort((a, b) => b.wasted_tokens - a.wasted_tokens)
       .slice(0, top);

--- a/src/analyze/report.ts
+++ b/src/analyze/report.ts
@@ -162,7 +162,10 @@ export class Aggregator {
   }
 
   private maybeRecordOutlier(e: SimEvent): void {
+    // Treat non-positive top_n as "disable outlier tracking" rather than
+    // letting a zero-size heap underflow on access.
     const n = this.opts.top_n;
+    if (!Number.isFinite(n) || n <= 0) return;
     if (this.outliers.length < n) {
       this.outliers.push({
         tool: e.tool_name,

--- a/src/analyze/report.ts
+++ b/src/analyze/report.ts
@@ -138,8 +138,11 @@ export class Aggregator {
       this.byDay.set(day, d);
     }
 
-    // Hotspots by canonical (tool, args) key.
-    const kb = this.byKey.get(e.call_key) ?? {
+    // Hotspots are session-scoped because real dedup is session-scoped.
+    // Two separate sessions each calling the same tool once isn't a hotspot
+    // dedup can fix, so we must not count them together.
+    const hotspotKey = `${e.session_id}\u0000${e.call_key}`;
+    const kb = this.byKey.get(hotspotKey) ?? {
       tool: e.tool_name,
       calls: 0,
       first_observed_tokens: e.observed_tokens,
@@ -150,7 +153,7 @@ export class Aggregator {
       // Every repeat is waste — the first call is a necessary lookup.
       kb.wasted_tokens += e.observed_tokens;
     }
-    this.byKey.set(e.call_key, kb);
+    this.byKey.set(hotspotKey, kb);
 
     // Maintain a top-N outliers list (by observed tokens).
     this.maybeRecordOutlier(e);

--- a/src/analyze/report.ts
+++ b/src/analyze/report.ts
@@ -1,0 +1,246 @@
+import type { SimEvent } from "./simulate.js";
+
+export interface AggregateReport {
+  window: { first_ts: string | null; last_ts: string | null };
+  totals: {
+    files: number;
+    sessions: number;
+    tool_calls: number;
+    observed_bytes: number;
+    observed_tokens: number;
+    savings_bytes: number;
+    savings_tokens: number;
+    redact_matches: number;
+    duplicate_calls: number;
+    estimated_usd_saved: number;
+    estimated_usd_observed: number;
+  };
+  by_tool: Array<{
+    tool: string;
+    calls: number;
+    observed_tokens: number;
+    savings_tokens: number;
+    waste_pct: number; // savings / observed
+  }>;
+  by_rule: Array<{ rule: string; savings_tokens: number; events: number }>;
+  by_day: Array<{ day: string; observed_tokens: number; savings_tokens: number }>;
+  hotspots: Array<{
+    tool: string;
+    calls: number;
+    wasted_tokens: number; // observed tokens of repeats beyond the first
+  }>;
+  outliers: Array<{
+    tool: string;
+    tokens: number;
+    bytes: number;
+    ts: string;
+    session_id: string;
+  }>;
+  tokenizer: { name: string; approximate: boolean };
+}
+
+export interface AggregatorOptions {
+  top_n: number;
+  price_per_million: number;
+  tokenizer_name: string;
+  tokenizer_approximate: boolean;
+}
+
+interface ToolBucket {
+  calls: number;
+  observed_tokens: number;
+  savings_tokens: number;
+}
+
+interface KeyBucket {
+  tool: string;
+  calls: number;
+  first_observed_tokens: number;
+  wasted_tokens: number;
+}
+
+interface DayBucket {
+  observed_tokens: number;
+  savings_tokens: number;
+}
+
+export class Aggregator {
+  private readonly opts: AggregatorOptions;
+  private files = 0;
+  private sessions = new Set<string>();
+  private tool_calls = 0;
+  private observed_bytes = 0;
+  private observed_tokens = 0;
+  private savings_bytes = 0;
+  private savings_tokens = 0;
+  private redact_matches = 0;
+  private duplicate_calls = 0;
+  private first_ts: string | null = null;
+  private last_ts: string | null = null;
+
+  private byTool = new Map<string, ToolBucket>();
+  private byRule = new Map<string, { savings_tokens: number; events: number }>();
+  private byDay = new Map<string, DayBucket>();
+  private byKey = new Map<string, KeyBucket>();
+  private outliers: AggregateReport["outliers"] = [];
+
+  constructor(opts: AggregatorOptions) {
+    this.opts = opts;
+  }
+
+  noteFile(): void {
+    this.files++;
+  }
+
+  feed(e: SimEvent): void {
+    this.tool_calls++;
+    this.sessions.add(e.session_id);
+    this.observed_bytes += e.observed_bytes;
+    this.observed_tokens += e.observed_tokens;
+    this.savings_bytes += e.savings_bytes;
+    this.savings_tokens += e.savings_tokens;
+    this.redact_matches += e.per_rule.redact_matches;
+    if (e.duplicate_of_index !== undefined) this.duplicate_calls++;
+    if (e.ts) {
+      if (!this.first_ts || e.ts < this.first_ts) this.first_ts = e.ts;
+      if (!this.last_ts || e.ts > this.last_ts) this.last_ts = e.ts;
+    }
+
+    // By tool.
+    const bt = this.byTool.get(e.tool_name) ?? { calls: 0, observed_tokens: 0, savings_tokens: 0 };
+    bt.calls++;
+    bt.observed_tokens += e.observed_tokens;
+    bt.savings_tokens += e.savings_tokens;
+    this.byTool.set(e.tool_name, bt);
+
+    // By rule.
+    const rules: Array<[string, number]> = [
+      ["dedup", e.per_rule.dedup],
+      ["stacktrace", e.per_rule.stacktrace],
+      ["profile", e.per_rule.profile],
+      ["mcp_trim", e.per_rule.mcp_trim],
+      ["read_clamp", e.per_rule.read_clamp],
+    ];
+    for (const [name, saved] of rules) {
+      if (saved <= 0) continue;
+      const r = this.byRule.get(name) ?? { savings_tokens: 0, events: 0 };
+      r.savings_tokens += saved;
+      r.events++;
+      this.byRule.set(name, r);
+    }
+
+    // By day (UTC date).
+    if (e.ts.length >= 10) {
+      const day = e.ts.slice(0, 10);
+      const d = this.byDay.get(day) ?? { observed_tokens: 0, savings_tokens: 0 };
+      d.observed_tokens += e.observed_tokens;
+      d.savings_tokens += e.savings_tokens;
+      this.byDay.set(day, d);
+    }
+
+    // Hotspots by canonical (tool, args) key.
+    const kb = this.byKey.get(e.call_key) ?? {
+      tool: e.tool_name,
+      calls: 0,
+      first_observed_tokens: e.observed_tokens,
+      wasted_tokens: 0,
+    };
+    kb.calls++;
+    if (kb.calls > 1) {
+      // Every repeat is waste — the first call is a necessary lookup.
+      kb.wasted_tokens += e.observed_tokens;
+    }
+    this.byKey.set(e.call_key, kb);
+
+    // Maintain a top-N outliers list (by observed tokens).
+    this.maybeRecordOutlier(e);
+  }
+
+  private maybeRecordOutlier(e: SimEvent): void {
+    const n = this.opts.top_n;
+    if (this.outliers.length < n) {
+      this.outliers.push({
+        tool: e.tool_name,
+        tokens: e.observed_tokens,
+        bytes: e.observed_bytes,
+        ts: e.ts,
+        session_id: e.session_id,
+      });
+      this.outliers.sort((a, b) => a.tokens - b.tokens);
+      return;
+    }
+    const min = this.outliers[0]!;
+    if (e.observed_tokens <= min.tokens) return;
+    this.outliers[0] = {
+      tool: e.tool_name,
+      tokens: e.observed_tokens,
+      bytes: e.observed_bytes,
+      ts: e.ts,
+      session_id: e.session_id,
+    };
+    this.outliers.sort((a, b) => a.tokens - b.tokens);
+  }
+
+  build(): AggregateReport {
+    const top = this.opts.top_n;
+    const byTool = [...this.byTool.entries()]
+      .map(([tool, v]) => ({
+        tool,
+        calls: v.calls,
+        observed_tokens: v.observed_tokens,
+        savings_tokens: v.savings_tokens,
+        waste_pct: v.observed_tokens > 0 ? v.savings_tokens / v.observed_tokens : 0,
+      }))
+      .sort((a, b) => b.savings_tokens - a.savings_tokens || b.observed_tokens - a.observed_tokens)
+      .slice(0, top);
+
+    const byRule = [...this.byRule.entries()]
+      .map(([rule, v]) => ({ rule, savings_tokens: v.savings_tokens, events: v.events }))
+      .sort((a, b) => b.savings_tokens - a.savings_tokens);
+
+    const byDay = [...this.byDay.entries()]
+      .map(([day, v]) => ({
+        day,
+        observed_tokens: v.observed_tokens,
+        savings_tokens: v.savings_tokens,
+      }))
+      .sort((a, b) => a.day.localeCompare(b.day));
+
+    const hotspots = [...this.byKey.values()]
+      .filter((k) => k.calls > 1)
+      .map((k) => ({ tool: k.tool, calls: k.calls, wasted_tokens: k.wasted_tokens }))
+      .sort((a, b) => b.wasted_tokens - a.wasted_tokens)
+      .slice(0, top);
+
+    const outliers = [...this.outliers].sort((a, b) => b.tokens - a.tokens);
+
+    const usd_saved = (this.savings_tokens / 1_000_000) * this.opts.price_per_million;
+    const usd_observed = (this.observed_tokens / 1_000_000) * this.opts.price_per_million;
+
+    return {
+      window: { first_ts: this.first_ts, last_ts: this.last_ts },
+      totals: {
+        files: this.files,
+        sessions: this.sessions.size,
+        tool_calls: this.tool_calls,
+        observed_bytes: this.observed_bytes,
+        observed_tokens: this.observed_tokens,
+        savings_bytes: this.savings_bytes,
+        savings_tokens: this.savings_tokens,
+        redact_matches: this.redact_matches,
+        duplicate_calls: this.duplicate_calls,
+        estimated_usd_saved: usd_saved,
+        estimated_usd_observed: usd_observed,
+      },
+      by_tool: byTool,
+      by_rule: byRule,
+      by_day: byDay,
+      hotspots,
+      outliers,
+      tokenizer: {
+        name: this.opts.tokenizer_name,
+        approximate: this.opts.tokenizer_approximate,
+      },
+    };
+  }
+}

--- a/src/analyze/scan.ts
+++ b/src/analyze/scan.ts
@@ -55,9 +55,13 @@ export interface ScanOptions {
   progressEveryFiles?: number;
 }
 
-const sessionFromPath = (filePath: string): { session: string; project: string } => {
-  // ~/.claude/projects/<projectDir>/<sessionId>.jsonl
-  // ~/.codex/sessions/<...>/rollout-*.jsonl
+// Path-derived fallback identity. The parser upgrades these as soon as it
+// reads a `sessionId`/`cwd` field (Claude Code) or `session_meta` event
+// (Codex), but the fallback still helps when a transcript is too short to
+// carry metadata. Claude Code layout: `~/.claude/projects/<project>/<session>.jsonl`.
+// Codex layout: `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` — here both
+// `project` and `session` are just placeholders until metadata upgrades them.
+const fallbackIdentity = (filePath: string): { session: string; project: string } => {
   const sep = filePath.lastIndexOf("/");
   const basename = sep >= 0 ? filePath.slice(sep + 1) : filePath;
   const sessionId = basename.replace(/\.jsonl$/, "");
@@ -67,24 +71,16 @@ const sessionFromPath = (filePath: string): { session: string; project: string }
   return { session: sessionId, project };
 };
 
-const matchesFilters = (
-  filePath: string,
-  session: string,
-  project: string,
-  opts: ScanOptions,
-): boolean => {
-  if (opts.sessionFilter && !session.includes(opts.sessionFilter)) return false;
-  if (opts.projectFilter && !project.includes(opts.projectFilter)) return false;
-  // mtime-based since filter: skip files that haven't been touched.
-  if (opts.since) {
-    try {
-      const mtime = statSync(filePath).mtime;
-      if (mtime < opts.since) return false;
-    } catch {
-      return false;
-    }
+// File-level prefilter: only `--since` uses mtime since the other filters
+// depend on metadata inside the file. Session/project filters are applied
+// at emit-time on the ToolCall's authoritative identifiers.
+const passesMtimeFilter = (filePath: string, since: Date | undefined): boolean => {
+  if (!since) return true;
+  try {
+    return statSync(filePath).mtime >= since;
+  } catch {
+    return false;
   }
-  return true;
 };
 
 // Stream every matched transcript, feeding lines to the parser and forwarding
@@ -102,18 +98,22 @@ export const scan = async (
 
   for (let i = 0; i < files.length; i++) {
     const file = files[i]!;
-    const { session, project } = sessionFromPath(file);
-    if (!matchesFilters(file, session, project, opts)) continue;
+    if (!passesMtimeFilter(file, opts.since)) continue;
 
+    const { session, project } = fallbackIdentity(file);
     const state: ParserState = makeState(session, project);
     await readFileLines(file, (line, bytes) => {
       lineCount++;
       byteCount += bytes;
       feedLine(line, state, (call) => {
+        // Post-emit filtering uses the authoritative identity carried on
+        // the ToolCall (set by upgradeIdentity inside the parser).
         if (opts.since && call.ts) {
           const t = Date.parse(call.ts);
           if (Number.isFinite(t) && t < opts.since.getTime()) return;
         }
+        if (opts.sessionFilter && !call.session_id.includes(opts.sessionFilter)) return;
+        if (opts.projectFilter && !call.project_hint.includes(opts.projectFilter)) return;
         emit(call);
       });
     });

--- a/src/analyze/scan.ts
+++ b/src/analyze/scan.ts
@@ -1,0 +1,153 @@
+import { createReadStream, existsSync, readdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import type { ParserState } from "./parse.js";
+import { feedLine, makeState } from "./parse.js";
+import type { ToolCall } from "./parse.js";
+
+// Default Claude Code + Codex transcript locations.
+export const DEFAULT_CLAUDE_PROJECTS = (): string =>
+  join(homedir(), ".claude", "projects");
+export const DEFAULT_CODEX_SESSIONS = (): string => join(homedir(), ".codex", "sessions");
+
+// Recursively enumerate .jsonl files under one or more root directories. We
+// deliberately stay inside the two canonical locations plus user overrides;
+// there is no glob walker because we already know the layout.
+export const enumerateTranscripts = (roots: string[]): string[] => {
+  const out: string[] = [];
+  for (const root of roots) {
+    if (!root || !existsSync(root)) continue;
+    collectJsonl(root, out);
+  }
+  return out.sort();
+};
+
+const collectJsonl = (dir: string, acc: string[]): void => {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      collectJsonl(full, acc);
+    } else if (st.isFile() && entry.endsWith(".jsonl")) {
+      acc.push(full);
+    }
+  }
+};
+
+export interface ScanOptions {
+  roots: string[];
+  since?: Date;
+  projectFilter?: string; // substring match against project_hint
+  sessionFilter?: string;
+  onProgress?: (status: { file_index: number; file_total: number; bytes_read: number; elapsed_ms: number }) => void;
+  progressEveryFiles?: number;
+}
+
+const sessionFromPath = (filePath: string): { session: string; project: string } => {
+  // ~/.claude/projects/<projectDir>/<sessionId>.jsonl
+  // ~/.codex/sessions/<...>/rollout-*.jsonl
+  const sep = filePath.lastIndexOf("/");
+  const basename = sep >= 0 ? filePath.slice(sep + 1) : filePath;
+  const sessionId = basename.replace(/\.jsonl$/, "");
+  const dir = sep >= 0 ? filePath.slice(0, sep) : "";
+  const dirSep = dir.lastIndexOf("/");
+  const project = dirSep >= 0 ? dir.slice(dirSep + 1) : dir;
+  return { session: sessionId, project };
+};
+
+const matchesFilters = (
+  filePath: string,
+  session: string,
+  project: string,
+  opts: ScanOptions,
+): boolean => {
+  if (opts.sessionFilter && !session.includes(opts.sessionFilter)) return false;
+  if (opts.projectFilter && !project.includes(opts.projectFilter)) return false;
+  // mtime-based since filter: skip files that haven't been touched.
+  if (opts.since) {
+    try {
+      const mtime = statSync(filePath).mtime;
+      if (mtime < opts.since) return false;
+    } catch {
+      return false;
+    }
+  }
+  return true;
+};
+
+// Stream every matched transcript, feeding lines to the parser and forwarding
+// normalized ToolCall records to the caller. Progress is reported at a
+// per-file granularity to avoid drowning stderr on every line.
+export const scan = async (
+  opts: ScanOptions,
+  emit: (call: ToolCall) => void,
+): Promise<{ files: number; lines: number; bytes: number; elapsed_ms: number }> => {
+  const files = enumerateTranscripts(opts.roots);
+  const start = Date.now();
+  let lineCount = 0;
+  let byteCount = 0;
+  let processed = 0;
+
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i]!;
+    const { session, project } = sessionFromPath(file);
+    if (!matchesFilters(file, session, project, opts)) continue;
+
+    const state: ParserState = makeState(session, project);
+    await readFileLines(file, (line, bytes) => {
+      lineCount++;
+      byteCount += bytes;
+      feedLine(line, state, (call) => {
+        if (opts.since && call.ts) {
+          const t = Date.parse(call.ts);
+          if (Number.isFinite(t) && t < opts.since.getTime()) return;
+        }
+        emit(call);
+      });
+    });
+    processed++;
+
+    if (opts.onProgress) {
+      const every = opts.progressEveryFiles ?? 1;
+      if (processed % every === 0 || i === files.length - 1) {
+        opts.onProgress({
+          file_index: i + 1,
+          file_total: files.length,
+          bytes_read: byteCount,
+          elapsed_ms: Date.now() - start,
+        });
+      }
+    }
+  }
+
+  return {
+    files: processed,
+    lines: lineCount,
+    bytes: byteCount,
+    elapsed_ms: Date.now() - start,
+  };
+};
+
+const readFileLines = (
+  file: string,
+  onLine: (line: string, bytes: number) => void,
+): Promise<void> =>
+  new Promise((resolve) => {
+    const stream = createReadStream(file, { encoding: "utf8" });
+    stream.on("error", () => resolve());
+    const rl = createInterface({ input: stream, crlfDelay: Infinity });
+    rl.on("line", (line) => onLine(line, Buffer.byteLength(line, "utf8") + 1));
+    rl.on("close", () => resolve());
+  });

--- a/src/analyze/simulate.ts
+++ b/src/analyze/simulate.ts
@@ -116,6 +116,11 @@ interface DedupEntry {
   bytes: number;
 }
 
+// Max prior entries retained per (session, call_key). Bounds memory even if a
+// session replays the same tool hundreds of times. Eight is large enough to
+// survive normal sidechain interleaving.
+const MAX_LEDGER_ENTRIES_PER_KEY = 8;
+
 const withinWindow = (priorTs: string, currentTs: string, windowSeconds: number): boolean => {
   const p = Date.parse(priorTs);
   const c = Date.parse(currentTs);
@@ -137,9 +142,11 @@ export class Simulator {
   private readonly scoped: boolean;
   // Nested per-session dedup ledgers so events can stream in any order
   // (including sidechain files that revisit a parent session) without
-  // resetting state. Memory is bounded by unique (session, call_key)
-  // pairs — not raw response bodies — so this scales to large corpora.
-  private readonly ledgers = new Map<string, Map<string, DedupEntry>>();
+  // resetting state. Each key stores a bounded list of prior entries
+  // rather than a single one — so when the scanner encounters events
+  // out of chronological order, intermediate duplicates are still
+  // catchable against whichever prior entry falls inside the window.
+  private readonly ledgers = new Map<string, Map<string, DedupEntry[]>>();
   private readonly sessionCounters = new Map<string, number>();
   // Per-project config cache: avoid re-loading + re-scaling on every event.
   // Key is the absolute project path (ToolCall.project_hint) when it
@@ -152,20 +159,12 @@ export class Simulator {
     this.scoped = opts.session_scoped_dedup !== false;
   }
 
-  private ledgerFor(sessionId: string): Map<string, DedupEntry> {
-    if (!this.scoped) {
-      // All events share one ledger.
-      let ledger = this.ledgers.get("_global");
-      if (!ledger) {
-        ledger = new Map();
-        this.ledgers.set("_global", ledger);
-      }
-      return ledger;
-    }
-    let ledger = this.ledgers.get(sessionId);
+  private ledgerFor(sessionId: string): Map<string, DedupEntry[]> {
+    const key = this.scoped ? sessionId : "_global";
+    let ledger = this.ledgers.get(key);
     if (!ledger) {
       ledger = new Map();
-      this.ledgers.set(sessionId, ledger);
+      this.ledgers.set(key, ledger);
     }
     return ledger;
   }
@@ -252,33 +251,45 @@ export class Simulator {
       if (dedupEnabled) {
         const minBytes = toolCfg.dedup?.min_bytes ?? 2_000;
         const windowSeconds = toolCfg.dedup?.window_seconds ?? 1_800;
-        const prev = ledger.get(key);
-        if (
-          prev &&
-          observed_bytes >= minBytes &&
-          withinWindow(prev.ts, call.ts, windowSeconds)
-        ) {
+        // Of all stored prior entries, pick the most-recent one that still
+        // falls inside the directional window relative to the current call.
+        // Because files may be scanned out of chronological order, we can't
+        // just look at the "last inserted" entry — we have to search.
+        const priors = ledger.get(key) ?? [];
+        let bestPrior: DedupEntry | null = null;
+        for (const p of priors) {
+          if (!withinWindow(p.ts, call.ts, windowSeconds)) continue;
+          if (!bestPrior || Date.parse(p.ts) > Date.parse(bestPrior.ts)) bestPrior = p;
+        }
+        if (bestPrior && observed_bytes >= minBytes) {
           const stubTokens = this.tokenizer.count(
-            `[tokenomy: duplicate of call #${prev.index} at ${call.ts} — body elided, no refetch required.]`,
+            `[tokenomy: duplicate of call #${bestPrior.index} at ${call.ts} — body elided, no refetch required.]`,
           );
           const saved = Math.max(0, observed_tokens - stubTokens);
           perRule.dedup = saved;
           savings_tokens += saved;
           savings_bytes += Math.max(0, observed_bytes - 200);
-          duplicate_of_index = prev.index;
+          duplicate_of_index = bestPrior.index;
         }
-        // Always record every call in the ledger (mirrors the live
-        // checkAndRecordDuplicate which appends unconditionally); `min_bytes`
+        // Always append to the bounded per-key list. Mirrors the live
+        // checkAndRecordDuplicate which appends unconditionally; `min_bytes`
         // gates only whether the *current* call qualifies for the stub
-        // replacement. This ensures a small first call followed by a large
-        // same-args call still counts as a duplicate the live hook would
-        // catch.
-        ledger.set(key, {
+        // replacement. The bound keeps memory flat on hot call keys.
+        const entry: DedupEntry = {
           index: counter,
           ts: call.ts,
           tokens: observed_tokens,
           bytes: observed_bytes,
-        });
+        };
+        const updated = [...priors, entry];
+        if (updated.length > MAX_LEDGER_ENTRIES_PER_KEY) {
+          // Evict the oldest by ts, not by insertion order, so we don't
+          // drop an earlier-timestamped entry that future out-of-order
+          // scans might still match against within the window.
+          updated.sort((a, b) => Date.parse(a.ts) - Date.parse(b.ts));
+          updated.shift();
+        }
+        ledger.set(key, updated);
       }
 
       // If deduped, the live hook short-circuits — no other rules fire.

--- a/src/analyze/simulate.ts
+++ b/src/analyze/simulate.ts
@@ -4,7 +4,7 @@ import type { Config } from "../core/types.js";
 import { mcpContentRule } from "../rules/mcp-content.js";
 import { readBoundRule } from "../rules/read-bound.js";
 import { shouldApply } from "../core/gate.js";
-import { configForTool, loadConfig } from "../core/config.js";
+import { configForTool, loadConfig, resolveToolOverride } from "../core/config.js";
 import type { ToolCall } from "./parse.js";
 import type { Tokenizer } from "./tokens.js";
 
@@ -129,9 +129,12 @@ export class Simulator {
   private readonly cfg: Config;
   private readonly tokenizer: Tokenizer;
   private readonly scoped: boolean;
-  private currentSession: string | null = null;
-  private dedupLedger = new Map<string, DedupEntry>();
-  private sessionCounter = 0;
+  // Nested per-session dedup ledgers so events can stream in any order
+  // (including sidechain files that revisit a parent session) without
+  // resetting state. Memory is bounded by unique (session, call_key)
+  // pairs — not raw response bodies — so this scales to large corpora.
+  private readonly ledgers = new Map<string, Map<string, DedupEntry>>();
+  private readonly sessionCounters = new Map<string, number>();
   // Per-project config cache: avoid re-loading + re-scaling on every event.
   // Key is the absolute project path (ToolCall.project_hint) when it
   // resolves to an existing directory; otherwise the fallback cfg is used.
@@ -141,6 +144,31 @@ export class Simulator {
     this.cfg = opts.cfg;
     this.tokenizer = opts.tokenizer;
     this.scoped = opts.session_scoped_dedup !== false;
+  }
+
+  private ledgerFor(sessionId: string): Map<string, DedupEntry> {
+    if (!this.scoped) {
+      // All events share one ledger.
+      let ledger = this.ledgers.get("_global");
+      if (!ledger) {
+        ledger = new Map();
+        this.ledgers.set("_global", ledger);
+      }
+      return ledger;
+    }
+    let ledger = this.ledgers.get(sessionId);
+    if (!ledger) {
+      ledger = new Map();
+      this.ledgers.set(sessionId, ledger);
+    }
+    return ledger;
+  }
+
+  private nextCounter(sessionId: string): number {
+    const key = this.scoped ? sessionId : "_global";
+    const n = (this.sessionCounters.get(key) ?? 0) + 1;
+    this.sessionCounters.set(key, n);
+    return n;
   }
 
   private configForEvent(call: ToolCall): Config {
@@ -159,12 +187,8 @@ export class Simulator {
   }
 
   feed(call: ToolCall): SimEvent {
-    if (this.scoped && call.session_id !== this.currentSession) {
-      this.currentSession = call.session_id;
-      this.dedupLedger.clear();
-      this.sessionCounter = 0;
-    }
-    this.sessionCounter++;
+    const ledger = this.ledgerFor(call.session_id);
+    const counter = this.nextCounter(call.session_id);
 
     const text = asText(call.tool_response);
     const observed_tokens = this.tokenizer.count(text || JSON.stringify(call.tool_response ?? ""));
@@ -214,11 +238,15 @@ export class Simulator {
     // PostToolUse rules only fire for mcp__* tools in the real dispatch.
     // Non-MCP tools get only the Read-clamp path (handled separately below).
     if (isMcp) {
-      // Rule 1: dedup with session scope + window_seconds gate.
-      if (toolCfg.dedup?.enabled !== false) {
+      // Rule 1: dedup with session scope + window_seconds gate + per-tool
+      // `disable_dedup` override (matches the live dispatch path).
+      const toolOverride = resolveToolOverride(projectCfg, call.tool_name);
+      const dedupEnabled =
+        toolCfg.dedup?.enabled !== false && toolOverride?.disable_dedup !== true;
+      if (dedupEnabled) {
         const minBytes = toolCfg.dedup?.min_bytes ?? 2_000;
         const windowSeconds = toolCfg.dedup?.window_seconds ?? 1_800;
-        const prev = this.dedupLedger.get(key);
+        const prev = ledger.get(key);
         if (
           prev &&
           observed_bytes >= minBytes &&
@@ -234,8 +262,8 @@ export class Simulator {
           duplicate_of_index = prev.index;
         } else if (observed_bytes >= minBytes) {
           // Record (or refresh) for future-duplicate detection.
-          this.dedupLedger.set(key, {
-            index: this.sessionCounter,
+          ledger.set(key, {
+            index: counter,
             ts: call.ts,
             tokens: observed_tokens,
             bytes: observed_bytes,
@@ -275,19 +303,30 @@ export class Simulator {
       }
     } else if (isRead && toolCfg.read.enabled) {
       // Rule 6: Read clamp. Mirrors preDispatch logic: no clamp if the user
-      // passed explicit limit/offset, and only fires above clamp_above_bytes.
+      // passed explicit limit/offset, only fires above clamp_above_bytes,
+      // AND — unlike the earlier naive "injected_limit * 50 B" estimate —
+      // uses the actual newline count from the observed transcript text so
+      // we don't falsely credit savings on minified or single-line files.
       const input = call.tool_input;
       const hasExplicit =
         typeof input["limit"] === "number" || typeof input["offset"] === "number";
       if (!hasExplicit && observed_bytes >= toolCfg.read.clamp_above_bytes) {
-        // Estimated post-clamp size: injected_limit lines at ~50 B/line.
-        const keptBytes = toolCfg.read.injected_limit * 50;
-        const keptText = "x".repeat(keptBytes);
-        const keptTokens = this.tokenizer.count(keptText);
-        const saved = Math.max(0, observed_tokens - keptTokens);
-        perRule.read_clamp = saved;
-        savings_tokens += saved;
-        savings_bytes += Math.max(0, observed_bytes - keptBytes);
+        const body = text;
+        // Count lines; if there aren't more than injected_limit there's
+        // nothing to clamp — a single-line 80KB minified bundle stays
+        // 80KB after `limit:500`.
+        let newlines = 0;
+        for (let i = 0; i < body.length; i++) if (body.charCodeAt(i) === 10) newlines++;
+        const totalLines = newlines + 1;
+        const kept = Math.min(totalLines, toolCfg.read.injected_limit);
+        if (kept < totalLines) {
+          const kept_ratio = kept / totalLines;
+          const keptTokens = Math.ceil(observed_tokens * kept_ratio);
+          const saved = Math.max(0, observed_tokens - keptTokens);
+          perRule.read_clamp = saved;
+          savings_tokens += saved;
+          savings_bytes += Math.max(0, observed_bytes - Math.ceil(observed_bytes * kept_ratio));
+        }
       }
     }
 

--- a/src/analyze/simulate.ts
+++ b/src/analyze/simulate.ts
@@ -1,9 +1,10 @@
+import { existsSync } from "node:fs";
 import { createHash } from "node:crypto";
 import type { Config } from "../core/types.js";
 import { mcpContentRule } from "../rules/mcp-content.js";
 import { readBoundRule } from "../rules/read-bound.js";
 import { shouldApply } from "../core/gate.js";
-import { configForTool } from "../core/config.js";
+import { configForTool, loadConfig } from "../core/config.js";
 import type { ToolCall } from "./parse.js";
 import type { Tokenizer } from "./tokens.js";
 
@@ -99,6 +100,8 @@ const parseReason = (reason: string): ReasonFlags => {
 };
 
 export interface SimulatorOptions {
+  // Default (fallback) config, used when a ToolCall has no resolvable
+  // project_hint or the per-project override file doesn't exist.
   cfg: Config;
   tokenizer: Tokenizer;
   // If true, the per-session dedup state is cleared when session_id changes.
@@ -129,11 +132,30 @@ export class Simulator {
   private currentSession: string | null = null;
   private dedupLedger = new Map<string, DedupEntry>();
   private sessionCounter = 0;
+  // Per-project config cache: avoid re-loading + re-scaling on every event.
+  // Key is the absolute project path (ToolCall.project_hint) when it
+  // resolves to an existing directory; otherwise the fallback cfg is used.
+  private readonly projectCfgCache = new Map<string, Config>();
 
   constructor(opts: SimulatorOptions) {
     this.cfg = opts.cfg;
     this.tokenizer = opts.tokenizer;
     this.scoped = opts.session_scoped_dedup !== false;
+  }
+
+  private configForEvent(call: ToolCall): Config {
+    const hint = call.project_hint;
+    if (!hint || !hint.startsWith("/") || !existsSync(hint)) return this.cfg;
+    const cached = this.projectCfgCache.get(hint);
+    if (cached) return cached;
+    try {
+      const loaded = loadConfig(hint);
+      this.projectCfgCache.set(hint, loaded);
+      return loaded;
+    } catch {
+      this.projectCfgCache.set(hint, this.cfg);
+      return this.cfg;
+    }
   }
 
   feed(call: ToolCall): SimEvent {
@@ -165,10 +187,14 @@ export class Simulator {
     const isMcp = call.tool_name.startsWith("mcp__");
     const isRead = call.tool_name === "Read";
 
+    // Use per-project config when the ToolCall carries a resolvable cwd.
+    // This matches how the real hook's `loadConfig(input.cwd)` picks up
+    // `<project>/.tokenomy.json` overrides in addition to the global cfg.
+    const projectCfg = this.configForEvent(call);
     // Honor disabled_tools and per-tool overrides exactly like the real
     // dispatch does. A tool explicitly disabled gets no simulated savings;
     // per-tool aggression overrides flow into the downstream rule configs.
-    if (this.cfg.disabled_tools?.includes(call.tool_name)) {
+    if (projectCfg.disabled_tools?.includes(call.tool_name)) {
       return {
         agent: call.agent,
         session_id: call.session_id,
@@ -183,7 +209,7 @@ export class Simulator {
         call_key: key,
       };
     }
-    const toolCfg = configForTool(this.cfg, call.tool_name);
+    const toolCfg = configForTool(projectCfg, call.tool_name);
 
     // PostToolUse rules only fire for mcp__* tools in the real dispatch.
     // Non-MCP tools get only the Read-clamp path (handled separately below).

--- a/src/analyze/simulate.ts
+++ b/src/analyze/simulate.ts
@@ -3,6 +3,7 @@ import type { Config } from "../core/types.js";
 import { mcpContentRule } from "../rules/mcp-content.js";
 import { readBoundRule } from "../rules/read-bound.js";
 import { shouldApply } from "../core/gate.js";
+import { configForTool } from "../core/config.js";
 import type { ToolCall } from "./parse.js";
 import type { Tokenizer } from "./tokens.js";
 
@@ -164,13 +165,33 @@ export class Simulator {
     const isMcp = call.tool_name.startsWith("mcp__");
     const isRead = call.tool_name === "Read";
 
+    // Honor disabled_tools and per-tool overrides exactly like the real
+    // dispatch does. A tool explicitly disabled gets no simulated savings;
+    // per-tool aggression overrides flow into the downstream rule configs.
+    if (this.cfg.disabled_tools?.includes(call.tool_name)) {
+      return {
+        agent: call.agent,
+        session_id: call.session_id,
+        project_hint: call.project_hint,
+        ts: call.ts,
+        tool_name: call.tool_name,
+        observed_bytes,
+        observed_tokens,
+        savings_bytes: 0,
+        savings_tokens: 0,
+        per_rule: perRule,
+        call_key: key,
+      };
+    }
+    const toolCfg = configForTool(this.cfg, call.tool_name);
+
     // PostToolUse rules only fire for mcp__* tools in the real dispatch.
     // Non-MCP tools get only the Read-clamp path (handled separately below).
     if (isMcp) {
       // Rule 1: dedup with session scope + window_seconds gate.
-      if (this.cfg.dedup?.enabled !== false) {
-        const minBytes = this.cfg.dedup?.min_bytes ?? 2_000;
-        const windowSeconds = this.cfg.dedup?.window_seconds ?? 1_800;
+      if (toolCfg.dedup?.enabled !== false) {
+        const minBytes = toolCfg.dedup?.min_bytes ?? 2_000;
+        const windowSeconds = toolCfg.dedup?.window_seconds ?? 1_800;
         const prev = this.dedupLedger.get(key);
         if (
           prev &&
@@ -206,13 +227,13 @@ export class Simulator {
           call.tool_name,
           call.tool_input,
           call.tool_response,
-          this.cfg,
+          toolCfg,
         );
         if (r.kind === "trim") {
           const flags = parseReason(r.reason);
           // Match dispatch: redaction force-applies regardless of gate.
           const redactionForced = flags.redact_count > 0;
-          if (redactionForced || shouldApply(r.bytesIn, r.bytesOut, this.cfg)) {
+          if (redactionForced || shouldApply(r.bytesIn, r.bytesOut, toolCfg)) {
             const newText = asText(r.output);
             const newTokens = this.tokenizer.count(newText);
             const saved = Math.max(0, observed_tokens - newTokens);
@@ -226,15 +247,15 @@ export class Simulator {
           }
         }
       }
-    } else if (isRead && this.cfg.read.enabled) {
+    } else if (isRead && toolCfg.read.enabled) {
       // Rule 6: Read clamp. Mirrors preDispatch logic: no clamp if the user
       // passed explicit limit/offset, and only fires above clamp_above_bytes.
       const input = call.tool_input;
       const hasExplicit =
         typeof input["limit"] === "number" || typeof input["offset"] === "number";
-      if (!hasExplicit && observed_bytes >= this.cfg.read.clamp_above_bytes) {
+      if (!hasExplicit && observed_bytes >= toolCfg.read.clamp_above_bytes) {
         // Estimated post-clamp size: injected_limit lines at ~50 B/line.
-        const keptBytes = this.cfg.read.injected_limit * 50;
+        const keptBytes = toolCfg.read.injected_limit * 50;
         const keptText = "x".repeat(keptBytes);
         const keptTokens = this.tokenizer.count(keptText);
         const saved = Math.max(0, observed_tokens - keptTokens);

--- a/src/analyze/simulate.ts
+++ b/src/analyze/simulate.ts
@@ -196,7 +196,11 @@ export class Simulator {
     const counter = this.nextCounter(call.session_id);
 
     const text = asText(call.tool_response);
-    const observed_tokens = this.tokenizer.count(text || JSON.stringify(call.tool_response ?? ""));
+    // Prefer an authoritative count from the transcript wrapper (Codex)
+    // over our tokenizer approximation when one is available.
+    const observed_tokens =
+      call.observed_tokens_override ??
+      this.tokenizer.count(text || JSON.stringify(call.tool_response ?? ""));
     const observed_bytes = call.response_bytes;
 
     const perRule: SimEvent["per_rule"] = {

--- a/src/analyze/simulate.ts
+++ b/src/analyze/simulate.ts
@@ -1,15 +1,20 @@
 import { createHash } from "node:crypto";
 import type { Config } from "../core/types.js";
 import { mcpContentRule } from "../rules/mcp-content.js";
-import { BUILTIN_PATTERNS, redactSecrets } from "../rules/redact.js";
-import { collapseStacktrace } from "../rules/stacktrace.js";
 import { readBoundRule } from "../rules/read-bound.js";
+import { shouldApply } from "../core/gate.js";
 import type { ToolCall } from "./parse.js";
 import type { Tokenizer } from "./tokens.js";
 
 // Per-event sim result: what would Tokenomy have saved if it had been active?
 // `observed_tokens` is the actual token cost of this tool response.
 // `savings_tokens` is the hypothetical save after running the full pipeline.
+//
+// Fidelity invariant: the simulator mirrors the real `dispatch()` /
+// `preDispatch()` logic exactly — a rule is only credited if the live hook
+// would have fired it. In particular: PostToolUse rules (dedup, redact,
+// stacktrace, profile, mcp-trim) only run for `mcp__*` tools; `Read`
+// clamp is the only thing that fires for non-MCP calls.
 export interface SimEvent {
   agent: ToolCall["agent"];
   session_id: string;
@@ -74,12 +79,22 @@ const asText = (response: unknown): string => {
   return "";
 };
 
-const responseBytesFromTokens = (resp: unknown): number => {
-  try {
-    return Buffer.byteLength(JSON.stringify(resp ?? null), "utf8");
-  } catch {
-    return 0;
-  }
+// Parse the "redact:N+profile:foo+stacktrace+mcp-content-trim" reason string
+// that mcp-content-rule emits. Returns which stages fired.
+interface ReasonFlags {
+  redact_count: number;
+  stacktrace: boolean;
+  profile: boolean;
+  mcp_trim: boolean;
+}
+const parseReason = (reason: string): ReasonFlags => {
+  const redactMatch = /redact:(\d+)/.exec(reason);
+  return {
+    redact_count: redactMatch ? parseInt(redactMatch[1]!, 10) : 0,
+    stacktrace: /stacktrace/.test(reason),
+    profile: /profile:/.test(reason),
+    mcp_trim: /mcp-content-trim/.test(reason),
+  };
 };
 
 export interface SimulatorOptions {
@@ -90,13 +105,21 @@ export interface SimulatorOptions {
   session_scoped_dedup?: boolean;
 }
 
-// Session-scoped dedup ledger used during simulation. Entries are the
-// observed tokens of the *first* call with that key in the current session.
 interface DedupEntry {
   index: number;
+  ts: string; // ISO timestamp of the first occurrence, for window_seconds check.
   tokens: number;
   bytes: number;
 }
+
+const withinWindow = (priorTs: string, currentTs: string, windowSeconds: number): boolean => {
+  const p = Date.parse(priorTs);
+  const c = Date.parse(currentTs);
+  // If either timestamp is unparseable, assume same window (fail-open —
+  // matches the real dedup path which uses Date.now).
+  if (!Number.isFinite(p) || !Number.isFinite(c)) return true;
+  return Math.abs(c - p) <= windowSeconds * 1_000;
+};
 
 export class Simulator {
   private readonly cfg: Config;
@@ -138,83 +161,86 @@ export class Simulator {
     let duplicate_of_index: number | undefined;
 
     const key = callKey(call.tool_name, call.tool_input);
+    const isMcp = call.tool_name.startsWith("mcp__");
+    const isRead = call.tool_name === "Read";
 
-    // Rule 1: dedup. If the same call appeared earlier in this session, a
-    // stub body would replace the full response — savings = observed tokens
-    // minus a short pointer.
-    if (this.cfg.dedup?.enabled !== false) {
-      const prev = this.dedupLedger.get(key);
-      const minBytes = this.cfg.dedup?.min_bytes ?? 2_000;
-      if (prev && observed_bytes >= minBytes) {
-        // Stub roughly: 1 text block with a 120-byte pointer line.
-        const stubTokens = this.tokenizer.count(
-          `[tokenomy: duplicate of call #${prev.index} at ${call.ts} — body elided, no refetch required.]`,
+    // PostToolUse rules only fire for mcp__* tools in the real dispatch.
+    // Non-MCP tools get only the Read-clamp path (handled separately below).
+    if (isMcp) {
+      // Rule 1: dedup with session scope + window_seconds gate.
+      if (this.cfg.dedup?.enabled !== false) {
+        const minBytes = this.cfg.dedup?.min_bytes ?? 2_000;
+        const windowSeconds = this.cfg.dedup?.window_seconds ?? 1_800;
+        const prev = this.dedupLedger.get(key);
+        if (
+          prev &&
+          observed_bytes >= minBytes &&
+          withinWindow(prev.ts, call.ts, windowSeconds)
+        ) {
+          const stubTokens = this.tokenizer.count(
+            `[tokenomy: duplicate of call #${prev.index} at ${call.ts} — body elided, no refetch required.]`,
+          );
+          const saved = Math.max(0, observed_tokens - stubTokens);
+          perRule.dedup = saved;
+          savings_tokens += saved;
+          savings_bytes += Math.max(0, observed_bytes - 200);
+          duplicate_of_index = prev.index;
+        } else if (observed_bytes >= minBytes) {
+          // Record (or refresh) for future-duplicate detection.
+          this.dedupLedger.set(key, {
+            index: this.sessionCounter,
+            ts: call.ts,
+            tokens: observed_tokens,
+            bytes: observed_bytes,
+          });
+        }
+      }
+
+      // If deduped, the live hook short-circuits — no other rules fire.
+      if (duplicate_of_index === undefined && call.tool_response) {
+        // Single-shot pipeline: mcp-content-rule internally runs
+        // redact → stacktrace → profile → mcp-trim. Parsing the returned
+        // `reason` lets us split the credit across those stages without
+        // running them separately (which was double-counting).
+        const r = mcpContentRule(
+          call.tool_name,
+          call.tool_input,
+          call.tool_response,
+          this.cfg,
         );
-        const saved = Math.max(0, observed_tokens - stubTokens);
-        perRule.dedup = saved;
-        savings_tokens += saved;
-        savings_bytes += Math.max(0, observed_bytes - 200);
-        duplicate_of_index = prev.index;
-      } else if (observed_bytes >= minBytes) {
-        this.dedupLedger.set(key, {
-          index: this.sessionCounter,
-          tokens: observed_tokens,
-          bytes: observed_bytes,
-        });
-      }
-    }
-
-    // If deduped, short-circuit other rules (stub would replace the body).
-    if (duplicate_of_index === undefined) {
-      // Rule 2: redaction match count (informational).
-      if (text && this.cfg.redact?.enabled !== false) {
-        const r = redactSecrets(text, BUILTIN_PATTERNS);
-        perRule.redact_matches = r.total;
-      }
-
-      // Rule 3: stacktrace collapse.
-      if (text) {
-        const s = collapseStacktrace(text);
-        if (s.ok && s.trimmed) {
-          const newTokens = this.tokenizer.count(s.trimmed);
-          const saved = Math.max(0, observed_tokens - newTokens);
-          perRule.stacktrace = saved;
-          savings_tokens += saved;
-          savings_bytes += Math.max(0, s.bytesIn - s.bytesOut);
-        }
-      }
-
-      // Rule 4 + 5: full MCP pipeline (profile trim + byte trim).
-      if (call.tool_name.startsWith("mcp__") && call.tool_response) {
-        const r = mcpContentRule(call.tool_name, call.tool_input, call.tool_response, this.cfg);
         if (r.kind === "trim") {
-          const newText = asText(r.output);
-          const newTokens = this.tokenizer.count(newText);
-          const saved = Math.max(0, observed_tokens - newTokens);
-          // Split between profile vs trim reason, best-effort.
-          if (r.reason.includes("profile")) perRule.profile = saved;
-          else perRule.mcp_trim = saved;
-          savings_tokens += saved;
-          savings_bytes += Math.max(0, r.bytesIn - r.bytesOut);
+          const flags = parseReason(r.reason);
+          // Match dispatch: redaction force-applies regardless of gate.
+          const redactionForced = flags.redact_count > 0;
+          if (redactionForced || shouldApply(r.bytesIn, r.bytesOut, this.cfg)) {
+            const newText = asText(r.output);
+            const newTokens = this.tokenizer.count(newText);
+            const saved = Math.max(0, observed_tokens - newTokens);
+            // Split savings attribution by which stage fired.
+            if (flags.profile) perRule.profile = saved;
+            else if (flags.mcp_trim) perRule.mcp_trim = saved;
+            else if (flags.stacktrace) perRule.stacktrace = saved;
+            savings_tokens += saved;
+            savings_bytes += Math.max(0, r.bytesIn - r.bytesOut);
+            perRule.redact_matches = flags.redact_count;
+          }
         }
       }
-
-      // Rule 6: Read clamp. Applies when tool is Read, response is big, and
-      // there was no explicit limit/offset in the input.
-      if (call.tool_name === "Read" && this.cfg.read.enabled) {
-        const fileBytes = observed_bytes;
-        const input = call.tool_input;
-        const hasExplicit =
-          typeof input["limit"] === "number" || typeof input["offset"] === "number";
-        if (!hasExplicit && fileBytes >= this.cfg.read.clamp_above_bytes) {
-          // Estimated savings: keeps injected_limit lines at ~50 B/line.
-          const keptBytes = this.cfg.read.injected_limit * 50;
-          const keptTokens = this.tokenizer.count("x".repeat(keptBytes)); // rough
-          const saved = Math.max(0, observed_tokens - keptTokens);
-          perRule.read_clamp = saved;
-          savings_tokens += saved;
-          savings_bytes += Math.max(0, fileBytes - keptBytes);
-        }
+    } else if (isRead && this.cfg.read.enabled) {
+      // Rule 6: Read clamp. Mirrors preDispatch logic: no clamp if the user
+      // passed explicit limit/offset, and only fires above clamp_above_bytes.
+      const input = call.tool_input;
+      const hasExplicit =
+        typeof input["limit"] === "number" || typeof input["offset"] === "number";
+      if (!hasExplicit && observed_bytes >= this.cfg.read.clamp_above_bytes) {
+        // Estimated post-clamp size: injected_limit lines at ~50 B/line.
+        const keptBytes = this.cfg.read.injected_limit * 50;
+        const keptText = "x".repeat(keptBytes);
+        const keptTokens = this.tokenizer.count(keptText);
+        const saved = Math.max(0, observed_tokens - keptTokens);
+        perRule.read_clamp = saved;
+        savings_tokens += saved;
+        savings_bytes += Math.max(0, observed_bytes - keptBytes);
       }
     }
 
@@ -235,7 +261,6 @@ export class Simulator {
   }
 }
 
-// Unused import suppressor: keeps readBoundRule callable via re-export to
-// preserve the symmetry with the real hook pipeline. Downstream consumers
-// can use this to simulate PreToolUse behaviour for ad-hoc fixtures.
+// Re-exported for symmetry with the real hook pipeline; downstream consumers
+// can simulate PreToolUse behaviour directly against ad-hoc fixtures.
 export const simulateReadClamp = readBoundRule;

--- a/src/analyze/simulate.ts
+++ b/src/analyze/simulate.ts
@@ -1,0 +1,241 @@
+import { createHash } from "node:crypto";
+import type { Config } from "../core/types.js";
+import { mcpContentRule } from "../rules/mcp-content.js";
+import { BUILTIN_PATTERNS, redactSecrets } from "../rules/redact.js";
+import { collapseStacktrace } from "../rules/stacktrace.js";
+import { readBoundRule } from "../rules/read-bound.js";
+import type { ToolCall } from "./parse.js";
+import type { Tokenizer } from "./tokens.js";
+
+// Per-event sim result: what would Tokenomy have saved if it had been active?
+// `observed_tokens` is the actual token cost of this tool response.
+// `savings_tokens` is the hypothetical save after running the full pipeline.
+export interface SimEvent {
+  agent: ToolCall["agent"];
+  session_id: string;
+  project_hint: string;
+  ts: string;
+  tool_name: string;
+  observed_bytes: number;
+  observed_tokens: number;
+  savings_bytes: number;
+  savings_tokens: number;
+  // Per-rule breakdowns (tokens each rule would have saved on its own).
+  per_rule: {
+    dedup: number;
+    redact_matches: number; // count, not bytes — redact is security-first
+    stacktrace: number;
+    profile: number;
+    mcp_trim: number;
+    read_clamp: number;
+  };
+  // dedup pointer: if this event was a duplicate of an earlier one, index.
+  duplicate_of_index?: number;
+  // canonicalized key for cross-session hotspot aggregation.
+  call_key: string;
+}
+
+const canonicalize = (value: unknown): unknown => {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(canonicalize);
+  const out: Record<string, unknown> = {};
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  for (const k of keys) out[k] = canonicalize((value as Record<string, unknown>)[k]);
+  return out;
+};
+
+const callKey = (toolName: string, toolInput: Record<string, unknown>): string =>
+  createHash("sha256")
+    .update(toolName)
+    .update("\u0000")
+    .update(JSON.stringify(canonicalize(toolInput ?? {})))
+    .digest("hex");
+
+// Extract the raw textual payload from a tool response (used for token count
+// and for running text-based rules like redact + stacktrace).
+const asText = (response: unknown): string => {
+  if (response === null || response === undefined) return "";
+  if (typeof response === "string") return response;
+  if (Array.isArray(response)) {
+    return response
+      .map((b) => {
+        if (b && typeof b === "object" && (b as { type?: unknown }).type === "text") {
+          const t = (b as { text?: unknown }).text;
+          return typeof t === "string" ? t : "";
+        }
+        return "";
+      })
+      .join("\n");
+  }
+  if (typeof response === "object") {
+    const content = (response as { content?: unknown }).content;
+    if (Array.isArray(content)) return asText(content);
+  }
+  return "";
+};
+
+const responseBytesFromTokens = (resp: unknown): number => {
+  try {
+    return Buffer.byteLength(JSON.stringify(resp ?? null), "utf8");
+  } catch {
+    return 0;
+  }
+};
+
+export interface SimulatorOptions {
+  cfg: Config;
+  tokenizer: Tokenizer;
+  // If true, the per-session dedup state is cleared when session_id changes.
+  // Default true — matches how Tokenomy's real dedup works.
+  session_scoped_dedup?: boolean;
+}
+
+// Session-scoped dedup ledger used during simulation. Entries are the
+// observed tokens of the *first* call with that key in the current session.
+interface DedupEntry {
+  index: number;
+  tokens: number;
+  bytes: number;
+}
+
+export class Simulator {
+  private readonly cfg: Config;
+  private readonly tokenizer: Tokenizer;
+  private readonly scoped: boolean;
+  private currentSession: string | null = null;
+  private dedupLedger = new Map<string, DedupEntry>();
+  private sessionCounter = 0;
+
+  constructor(opts: SimulatorOptions) {
+    this.cfg = opts.cfg;
+    this.tokenizer = opts.tokenizer;
+    this.scoped = opts.session_scoped_dedup !== false;
+  }
+
+  feed(call: ToolCall): SimEvent {
+    if (this.scoped && call.session_id !== this.currentSession) {
+      this.currentSession = call.session_id;
+      this.dedupLedger.clear();
+      this.sessionCounter = 0;
+    }
+    this.sessionCounter++;
+
+    const text = asText(call.tool_response);
+    const observed_tokens = this.tokenizer.count(text || JSON.stringify(call.tool_response ?? ""));
+    const observed_bytes = call.response_bytes;
+
+    const perRule: SimEvent["per_rule"] = {
+      dedup: 0,
+      redact_matches: 0,
+      stacktrace: 0,
+      profile: 0,
+      mcp_trim: 0,
+      read_clamp: 0,
+    };
+
+    let savings_tokens = 0;
+    let savings_bytes = 0;
+    let duplicate_of_index: number | undefined;
+
+    const key = callKey(call.tool_name, call.tool_input);
+
+    // Rule 1: dedup. If the same call appeared earlier in this session, a
+    // stub body would replace the full response — savings = observed tokens
+    // minus a short pointer.
+    if (this.cfg.dedup?.enabled !== false) {
+      const prev = this.dedupLedger.get(key);
+      const minBytes = this.cfg.dedup?.min_bytes ?? 2_000;
+      if (prev && observed_bytes >= minBytes) {
+        // Stub roughly: 1 text block with a 120-byte pointer line.
+        const stubTokens = this.tokenizer.count(
+          `[tokenomy: duplicate of call #${prev.index} at ${call.ts} — body elided, no refetch required.]`,
+        );
+        const saved = Math.max(0, observed_tokens - stubTokens);
+        perRule.dedup = saved;
+        savings_tokens += saved;
+        savings_bytes += Math.max(0, observed_bytes - 200);
+        duplicate_of_index = prev.index;
+      } else if (observed_bytes >= minBytes) {
+        this.dedupLedger.set(key, {
+          index: this.sessionCounter,
+          tokens: observed_tokens,
+          bytes: observed_bytes,
+        });
+      }
+    }
+
+    // If deduped, short-circuit other rules (stub would replace the body).
+    if (duplicate_of_index === undefined) {
+      // Rule 2: redaction match count (informational).
+      if (text && this.cfg.redact?.enabled !== false) {
+        const r = redactSecrets(text, BUILTIN_PATTERNS);
+        perRule.redact_matches = r.total;
+      }
+
+      // Rule 3: stacktrace collapse.
+      if (text) {
+        const s = collapseStacktrace(text);
+        if (s.ok && s.trimmed) {
+          const newTokens = this.tokenizer.count(s.trimmed);
+          const saved = Math.max(0, observed_tokens - newTokens);
+          perRule.stacktrace = saved;
+          savings_tokens += saved;
+          savings_bytes += Math.max(0, s.bytesIn - s.bytesOut);
+        }
+      }
+
+      // Rule 4 + 5: full MCP pipeline (profile trim + byte trim).
+      if (call.tool_name.startsWith("mcp__") && call.tool_response) {
+        const r = mcpContentRule(call.tool_name, call.tool_input, call.tool_response, this.cfg);
+        if (r.kind === "trim") {
+          const newText = asText(r.output);
+          const newTokens = this.tokenizer.count(newText);
+          const saved = Math.max(0, observed_tokens - newTokens);
+          // Split between profile vs trim reason, best-effort.
+          if (r.reason.includes("profile")) perRule.profile = saved;
+          else perRule.mcp_trim = saved;
+          savings_tokens += saved;
+          savings_bytes += Math.max(0, r.bytesIn - r.bytesOut);
+        }
+      }
+
+      // Rule 6: Read clamp. Applies when tool is Read, response is big, and
+      // there was no explicit limit/offset in the input.
+      if (call.tool_name === "Read" && this.cfg.read.enabled) {
+        const fileBytes = observed_bytes;
+        const input = call.tool_input;
+        const hasExplicit =
+          typeof input["limit"] === "number" || typeof input["offset"] === "number";
+        if (!hasExplicit && fileBytes >= this.cfg.read.clamp_above_bytes) {
+          // Estimated savings: keeps injected_limit lines at ~50 B/line.
+          const keptBytes = this.cfg.read.injected_limit * 50;
+          const keptTokens = this.tokenizer.count("x".repeat(keptBytes)); // rough
+          const saved = Math.max(0, observed_tokens - keptTokens);
+          perRule.read_clamp = saved;
+          savings_tokens += saved;
+          savings_bytes += Math.max(0, fileBytes - keptBytes);
+        }
+      }
+    }
+
+    return {
+      agent: call.agent,
+      session_id: call.session_id,
+      project_hint: call.project_hint,
+      ts: call.ts,
+      tool_name: call.tool_name,
+      observed_bytes,
+      observed_tokens,
+      savings_bytes,
+      savings_tokens,
+      per_rule: perRule,
+      ...(duplicate_of_index !== undefined ? { duplicate_of_index } : {}),
+      call_key: key,
+    };
+  }
+}
+
+// Unused import suppressor: keeps readBoundRule callable via re-export to
+// preserve the symmetry with the real hook pipeline. Downstream consumers
+// can use this to simulate PreToolUse behaviour for ad-hoc fixtures.
+export const simulateReadClamp = readBoundRule;

--- a/src/analyze/simulate.ts
+++ b/src/analyze/simulate.ts
@@ -122,7 +122,13 @@ const withinWindow = (priorTs: string, currentTs: string, windowSeconds: number)
   // If either timestamp is unparseable, assume same window (fail-open —
   // matches the real dedup path which uses Date.now).
   if (!Number.isFinite(p) || !Number.isFinite(c)) return true;
-  return Math.abs(c - p) <= windowSeconds * 1_000;
+  // Directional: only count a current call as a duplicate if it happened
+  // at-or-after the prior one and within the window. This prevents false
+  // hits when the scanner reads Claude sidechain files in pathname order
+  // and visits a later-timestamped main-file event before its earlier
+  // sidechain-file counterpart.
+  const delta = c - p;
+  return delta >= 0 && delta <= windowSeconds * 1_000;
 };
 
 export class Simulator {
@@ -260,15 +266,19 @@ export class Simulator {
           savings_tokens += saved;
           savings_bytes += Math.max(0, observed_bytes - 200);
           duplicate_of_index = prev.index;
-        } else if (observed_bytes >= minBytes) {
-          // Record (or refresh) for future-duplicate detection.
-          ledger.set(key, {
-            index: counter,
-            ts: call.ts,
-            tokens: observed_tokens,
-            bytes: observed_bytes,
-          });
         }
+        // Always record every call in the ledger (mirrors the live
+        // checkAndRecordDuplicate which appends unconditionally); `min_bytes`
+        // gates only whether the *current* call qualifies for the stub
+        // replacement. This ensures a small first call followed by a large
+        // same-args call still counts as a duplicate the live hook would
+        // catch.
+        ledger.set(key, {
+          index: counter,
+          ts: call.ts,
+          tokens: observed_tokens,
+          bytes: observed_bytes,
+        });
       }
 
       // If deduped, the live hook short-circuits — no other rules fire.
@@ -307,10 +317,16 @@ export class Simulator {
       // AND — unlike the earlier naive "injected_limit * 50 B" estimate —
       // uses the actual newline count from the observed transcript text so
       // we don't falsely credit savings on minified or single-line files.
+      //
+      // Compare against the raw text byte count, not observed_bytes (which
+      // is JSON.stringify(response).byteLength and inflates plain-text
+      // results via escaped newlines/quotes). The live readBoundRule uses
+      // `statSync(file_path).size`, which is closest to the raw text.
       const input = call.tool_input;
       const hasExplicit =
         typeof input["limit"] === "number" || typeof input["offset"] === "number";
-      if (!hasExplicit && observed_bytes >= toolCfg.read.clamp_above_bytes) {
+      const rawTextBytes = text ? Buffer.byteLength(text, "utf8") : observed_bytes;
+      if (!hasExplicit && rawTextBytes >= toolCfg.read.clamp_above_bytes) {
         const body = text;
         // Count lines; if there aren't more than injected_limit there's
         // nothing to clamp — a single-line 80KB minified bundle stays
@@ -325,7 +341,7 @@ export class Simulator {
           const saved = Math.max(0, observed_tokens - keptTokens);
           perRule.read_clamp = saved;
           savings_tokens += saved;
-          savings_bytes += Math.max(0, observed_bytes - Math.ceil(observed_bytes * kept_ratio));
+          savings_bytes += Math.max(0, rawTextBytes - Math.ceil(rawTextBytes * kept_ratio));
         }
       }
     }

--- a/src/analyze/tokens.ts
+++ b/src/analyze/tokens.ts
@@ -1,0 +1,110 @@
+// Tokenizer abstraction for `tokenomy analyze`.
+//
+// Two strategies:
+//   - "heuristic"  — zero-dep. Word/punctuation/number splitter calibrated
+//                    against cl100k_base for English code+JSON. ±10% on
+//                    typical tool responses.
+//   - "tiktoken"   — dynamic import of js-tiktoken if the user has it
+//                    installed (peer-optional). Gives real cl100k counts,
+//                    a solid Claude-token approximation (Anthropic does
+//                    not publish Claude 4's BPE).
+//
+// The default is "auto": try tiktoken, fall back to heuristic on failure.
+
+export interface Tokenizer {
+  name: "heuristic" | "tiktoken-cl100k";
+  approximate: boolean;
+  count(text: string): number;
+}
+
+const SPLIT_RE = /[A-Za-z]+|\d+|[\p{P}\p{S}]|\s+/gu;
+
+// Heuristic: split into word/number/punct/ws runs, then weight each run by a
+// factor reflecting how cl100k typically chunks it. This catches the two
+// dominant effects that make bytes/4 wrong:
+//   (1) long runs of ASCII text → sub-word pieces, ~4 chars / token.
+//   (2) JSON / code → lots of punctuation, 1 char / token each.
+export const heuristicCount = (text: string): number => {
+  if (!text) return 0;
+  let tokens = 0;
+  const matches = text.match(SPLIT_RE);
+  if (!matches) return Math.max(1, Math.ceil(text.length / 4));
+  for (const run of matches) {
+    const len = run.length;
+    const first = run.charCodeAt(0);
+    // Punctuation / symbols: cl100k typically merges them with adjacent
+    // word pieces; count 1 token per char but cap at ~half of length.
+    if (/[\p{P}\p{S}]/u.test(run)) {
+      tokens += Math.max(1, Math.ceil(len / 2));
+      continue;
+    }
+    // Whitespace: inter-word spaces merge into adjacent word pieces (0
+    // tokens); newlines break tokens (1 extra token per newline).
+    if (/\s/u.test(run)) {
+      const nl = (run.match(/\n/g) ?? []).length;
+      tokens += nl;
+      continue;
+    }
+    // Digits: ~3 chars per BPE piece.
+    // Letters: ~4 chars per BPE piece on average.
+    if (first >= 48 && first <= 57) {
+      tokens += Math.max(1, Math.ceil(len / 3));
+    } else {
+      tokens += Math.max(1, Math.ceil(len / 4));
+    }
+  }
+  return tokens;
+};
+
+export const heuristicTokenizer: Tokenizer = {
+  name: "heuristic",
+  approximate: true,
+  count: heuristicCount,
+};
+
+interface TiktokenModule {
+  getEncoding: (name: string) => { encode: (s: string) => Uint32Array | number[] };
+}
+
+const tryLoadTiktoken = async (): Promise<Tokenizer | null> => {
+  try {
+    // js-tiktoken is a peer-optional dep; TypeScript can't resolve it unless
+    // the user has installed it. Silence the static-resolution error here
+    // because the failure path is the normal case.
+    // @ts-expect-error optional runtime dependency
+    const mod = (await import("js-tiktoken")) as unknown as TiktokenModule;
+    if (typeof mod.getEncoding !== "function") return null;
+    const enc = mod.getEncoding("cl100k_base");
+    return {
+      name: "tiktoken-cl100k",
+      approximate: true, // still approximate for Claude tokens
+      count(text: string): number {
+        if (!text) return 0;
+        try {
+          return enc.encode(text).length;
+        } catch {
+          return heuristicCount(text);
+        }
+      },
+    };
+  } catch {
+    return null;
+  }
+};
+
+export type TokenizerChoice = "heuristic" | "tiktoken" | "auto";
+
+export const loadTokenizer = async (choice: TokenizerChoice): Promise<Tokenizer> => {
+  if (choice === "heuristic") return heuristicTokenizer;
+  if (choice === "tiktoken") {
+    const t = await tryLoadTiktoken();
+    if (!t) {
+      throw new Error(
+        "js-tiktoken not available. Run `npm i -g js-tiktoken` or use --tokenizer=heuristic.",
+      );
+    }
+    return t;
+  }
+  // auto
+  return (await tryLoadTiktoken()) ?? heuristicTokenizer;
+};

--- a/src/cli/analyze.ts
+++ b/src/cli/analyze.ts
@@ -1,0 +1,148 @@
+import { readFileSync, existsSync } from "node:fs";
+import { loadConfig, DEFAULT_CONFIG } from "../core/config.js";
+import { globalConfigPath } from "../core/paths.js";
+import { safeParse } from "../util/json.js";
+import { Aggregator } from "../analyze/report.js";
+import { render, renderProgress } from "../analyze/render.js";
+import {
+  DEFAULT_CLAUDE_PROJECTS,
+  DEFAULT_CODEX_SESSIONS,
+  scan,
+} from "../analyze/scan.js";
+import { Simulator } from "../analyze/simulate.js";
+import { loadTokenizer, type TokenizerChoice } from "../analyze/tokens.js";
+import type { Config } from "../core/types.js";
+
+export interface AnalyzeOptions {
+  path?: string | string[];
+  since?: string;
+  projectFilter?: string;
+  sessionFilter?: string;
+  top?: number;
+  tokenizer?: TokenizerChoice;
+  json?: boolean;
+  color?: boolean;
+  verbose?: boolean;
+}
+
+const parseSince = (input: string | undefined): Date | undefined => {
+  if (!input) return undefined;
+  // Relative: 1d, 7d, 30d, 1w, 2w, 3mo
+  const rel = /^(\d+)(h|d|w|mo|m)$/.exec(input);
+  if (rel) {
+    const value = parseInt(rel[1]!, 10);
+    const unit = rel[2]!;
+    const ms =
+      unit === "h"
+        ? value * 3_600_000
+        : unit === "d"
+        ? value * 86_400_000
+        : unit === "w"
+        ? value * 7 * 86_400_000
+        : unit === "m"
+        ? value * 60_000
+        : value * 30 * 86_400_000; // mo
+    return new Date(Date.now() - ms);
+  }
+  const parsed = new Date(input);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+};
+
+const readPricePerMillion = (): number => {
+  if (!existsSync(globalConfigPath())) return 3.0;
+  const cfg = safeParse<Partial<Config> & { report?: { price_per_million?: number } }>(
+    readFileSync(globalConfigPath(), "utf8"),
+  );
+  const v = cfg?.report?.price_per_million;
+  return typeof v === "number" && v > 0 ? v : 3.0;
+};
+
+export const runAnalyze = async (opts: AnalyzeOptions): Promise<number> => {
+  const cfg = loadConfig(process.cwd());
+  const since = parseSince(opts.since);
+  const tokenizerChoice = opts.tokenizer ?? "auto";
+  const colorEnabled = opts.color !== false && process.stdout.isTTY === true;
+  const width = typeof process.stdout.columns === "number" ? process.stdout.columns : 100;
+  const verbose = opts.verbose === true;
+
+  // Default roots: Claude Code + Codex session dirs. Override via --path.
+  const roots: string[] = Array.isArray(opts.path)
+    ? opts.path
+    : opts.path
+    ? [opts.path]
+    : [DEFAULT_CLAUDE_PROJECTS(), DEFAULT_CODEX_SESSIONS()];
+
+  // Load tokenizer. If the user asked for tiktoken explicitly and it's
+  // missing, this throws — surface that to the user and exit non-zero.
+  let tokenizer;
+  try {
+    tokenizer = await loadTokenizer(tokenizerChoice);
+  } catch (e) {
+    process.stderr.write(`tokenomy analyze: ${(e as Error).message}\n`);
+    return 1;
+  }
+
+  const simulator = new Simulator({ cfg, tokenizer });
+  const agg = new Aggregator({
+    top_n: opts.top ?? 10,
+    price_per_million: readPricePerMillion(),
+    tokenizer_name: tokenizer.name,
+    tokenizer_approximate: tokenizer.approximate,
+  });
+
+  // Live progress: write \r-updated status line to stderr so stdout stays
+  // clean when the user pipes to `| less` or `--json` is set.
+  const canShowProgress = process.stderr.isTTY === true && !opts.json;
+  if (canShowProgress) process.stderr.write("\x1b[?25l"); // hide cursor
+  let lastProgressWrite = 0;
+
+  try {
+    const scanStats = await scan(
+      {
+        roots,
+        since,
+        projectFilter: opts.projectFilter,
+        sessionFilter: opts.sessionFilter,
+        onProgress: canShowProgress
+          ? (p) => {
+              // Throttle to every ~100ms to avoid spamming the terminal.
+              const now = Date.now();
+              if (now - lastProgressWrite < 100) return;
+              lastProgressWrite = now;
+              process.stderr.write(
+                renderProgress(p.file_index, p.file_total, p.bytes_read, p.elapsed_ms, colorEnabled, width),
+              );
+            }
+          : undefined,
+      },
+      (call) => {
+        agg.feed(simulator.feed(call));
+      },
+    );
+
+    // Note files AFTER scan so we record the true count (including skipped).
+    for (let i = 0; i < scanStats.files; i++) agg.noteFile();
+
+    if (canShowProgress) {
+      process.stderr.write("\r" + " ".repeat(Math.min(200, width)) + "\r");
+      process.stderr.write("\x1b[?25h"); // show cursor
+    }
+
+    const report = agg.build();
+
+    if (opts.json) {
+      process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+      return 0;
+    }
+
+    process.stdout.write(render(report, { color: colorEnabled, width, verbose }));
+    return 0;
+  } catch (e) {
+    if (canShowProgress) process.stderr.write("\x1b[?25h");
+    process.stderr.write(`tokenomy analyze: ${(e as Error).message}\n`);
+    return 1;
+  }
+};
+
+// Unused-import guard: DEFAULT_CONFIG kept reachable for future config keys.
+void DEFAULT_CONFIG;

--- a/src/cli/analyze.ts
+++ b/src/cli/analyze.ts
@@ -65,11 +65,22 @@ export const runAnalyze = async (opts: AnalyzeOptions): Promise<number> => {
   const cfg = loadConfig(process.cwd());
   // Honor an explicit `--since 0d` / `--since all` as "no window".
   const explicitAll = opts.since === "0d" || opts.since === "0" || opts.since === "all";
-  const since = explicitAll
-    ? undefined
-    : opts.since
-    ? parseSince(opts.since)
-    : new Date(Date.now() - DEFAULT_SINCE_DAYS * 86_400_000);
+  let since: Date | undefined;
+  if (explicitAll) {
+    since = undefined;
+  } else if (opts.since) {
+    since = parseSince(opts.since);
+    if (!since) {
+      process.stderr.write(
+        `tokenomy analyze: invalid --since value "${opts.since}". ` +
+          `Use ISO (e.g. 2026-04-01), a relative span (1h / 7d / 2w / 3mo), ` +
+          `or "all" / "0d" for the full history.\n`,
+      );
+      return 1;
+    }
+  } else {
+    since = new Date(Date.now() - DEFAULT_SINCE_DAYS * 86_400_000);
+  }
   const tokenizerChoice = opts.tokenizer ?? "auto";
   const colorEnabled = opts.color !== false && process.stdout.isTTY === true;
   const width = typeof process.stdout.columns === "number" ? process.stdout.columns : 100;

--- a/src/cli/analyze.ts
+++ b/src/cli/analyze.ts
@@ -107,14 +107,11 @@ export const runAnalyze = async (opts: AnalyzeOptions): Promise<number> => {
   let lastProgressWrite = 0;
 
   try {
-    // Claude sidechains live in separate files under subagents/ but share
-    // the parent session_id. Feeding events to the simulator in file-walk
-    // order causes dedup to see the wrong "first" occurrence. We instead
-    // buffer every ToolCall, group by session_id, sort each group by
-    // timestamp, then replay per session — which mirrors the real agent's
-    // live execution order.
-    const rawCalls: Parameters<typeof simulator.feed>[0][] = [];
-
+    // Stream tool calls straight through the simulator. The simulator's
+    // per-session dedup ledger tolerates interleaved/resumed sessions
+    // (sidechain files may reopen a parent session_id after the main file)
+    // without resetting state, so we don't have to buffer the corpus in
+    // memory. This keeps `analyze` safe on large transcript histories.
     const scanStats = await scan(
       {
         roots,
@@ -134,26 +131,9 @@ export const runAnalyze = async (opts: AnalyzeOptions): Promise<number> => {
           : undefined,
       },
       (call) => {
-        rawCalls.push(call);
+        agg.feed(simulator.feed(call));
       },
     );
-
-    // Group by session, sort each group by timestamp, then feed in order.
-    const bySession = new Map<string, typeof rawCalls>();
-    for (const c of rawCalls) {
-      const bucket = bySession.get(c.session_id) ?? [];
-      bucket.push(c);
-      bySession.set(c.session_id, bucket);
-    }
-    for (const bucket of bySession.values()) {
-      bucket.sort((a, b) => {
-        const ta = Date.parse(a.ts);
-        const tb = Date.parse(b.ts);
-        if (Number.isFinite(ta) && Number.isFinite(tb)) return ta - tb;
-        return 0;
-      });
-      for (const call of bucket) agg.feed(simulator.feed(call));
-    }
 
     // Note files AFTER scan so we record the true count (including skipped).
     for (let i = 0; i < scanStats.files; i++) agg.noteFile();

--- a/src/cli/analyze.ts
+++ b/src/cli/analyze.ts
@@ -1,7 +1,4 @@
-import { readFileSync, existsSync } from "node:fs";
 import { loadConfig, DEFAULT_CONFIG } from "../core/config.js";
-import { globalConfigPath } from "../core/paths.js";
-import { safeParse } from "../util/json.js";
 import { Aggregator } from "../analyze/report.js";
 import { render, renderProgress } from "../analyze/render.js";
 import {
@@ -23,6 +20,9 @@ export interface AnalyzeOptions {
   json?: boolean;
   color?: boolean;
   verbose?: boolean;
+  // Per-million token price in USD for the $ estimate; falls back to
+  // cfg.report.price_per_million or $3 default.
+  pricePerMillion?: number;
 }
 
 const parseSince = (input: string | undefined): Date | undefined => {
@@ -48,12 +48,11 @@ const parseSince = (input: string | undefined): Date | undefined => {
   return Number.isNaN(parsed.getTime()) ? undefined : parsed;
 };
 
-const readPricePerMillion = (): number => {
-  if (!existsSync(globalConfigPath())) return 3.0;
-  const cfg = safeParse<Partial<Config> & { report?: { price_per_million?: number } }>(
-    readFileSync(globalConfigPath(), "utf8"),
-  );
-  const v = cfg?.report?.price_per_million;
+// Pricing is sourced from the already-merged Config (global + per-project
+// .tokenomy.json overrides applied). Reading from the global file alone
+// would silently drop repo-level overrides of report.price_per_million.
+const priceFromConfig = (cfg: Config & { report?: { price_per_million?: number } }): number => {
+  const v = cfg.report?.price_per_million;
   return typeof v === "number" && v > 0 ? v : 3.0;
 };
 
@@ -106,7 +105,8 @@ export const runAnalyze = async (opts: AnalyzeOptions): Promise<number> => {
   const simulator = new Simulator({ cfg, tokenizer });
   const agg = new Aggregator({
     top_n: opts.top ?? 10,
-    price_per_million: readPricePerMillion(),
+    price_per_million:
+      opts.pricePerMillion ?? priceFromConfig(cfg as Config & { report?: { price_per_million?: number } }),
     tokenizer_name: tokenizer.name,
     tokenizer_approximate: tokenizer.approximate,
   });

--- a/src/cli/analyze.ts
+++ b/src/cli/analyze.ts
@@ -107,6 +107,14 @@ export const runAnalyze = async (opts: AnalyzeOptions): Promise<number> => {
   let lastProgressWrite = 0;
 
   try {
+    // Claude sidechains live in separate files under subagents/ but share
+    // the parent session_id. Feeding events to the simulator in file-walk
+    // order causes dedup to see the wrong "first" occurrence. We instead
+    // buffer every ToolCall, group by session_id, sort each group by
+    // timestamp, then replay per session — which mirrors the real agent's
+    // live execution order.
+    const rawCalls: Parameters<typeof simulator.feed>[0][] = [];
+
     const scanStats = await scan(
       {
         roots,
@@ -126,9 +134,26 @@ export const runAnalyze = async (opts: AnalyzeOptions): Promise<number> => {
           : undefined,
       },
       (call) => {
-        agg.feed(simulator.feed(call));
+        rawCalls.push(call);
       },
     );
+
+    // Group by session, sort each group by timestamp, then feed in order.
+    const bySession = new Map<string, typeof rawCalls>();
+    for (const c of rawCalls) {
+      const bucket = bySession.get(c.session_id) ?? [];
+      bucket.push(c);
+      bySession.set(c.session_id, bucket);
+    }
+    for (const bucket of bySession.values()) {
+      bucket.sort((a, b) => {
+        const ta = Date.parse(a.ts);
+        const tb = Date.parse(b.ts);
+        if (Number.isFinite(ta) && Number.isFinite(tb)) return ta - tb;
+        return 0;
+      });
+      for (const call of bucket) agg.feed(simulator.feed(call));
+    }
 
     // Note files AFTER scan so we record the true count (including skipped).
     for (let i = 0; i < scanStats.files; i++) agg.noteFile();

--- a/src/cli/analyze.ts
+++ b/src/cli/analyze.ts
@@ -57,9 +57,19 @@ const readPricePerMillion = (): number => {
   return typeof v === "number" && v > 0 ? v : 3.0;
 };
 
+// Default lookback window. Documented in README as "scans the last 30 days
+// unless --since is passed". Users who want the full history pass --since=0d.
+const DEFAULT_SINCE_DAYS = 30;
+
 export const runAnalyze = async (opts: AnalyzeOptions): Promise<number> => {
   const cfg = loadConfig(process.cwd());
-  const since = parseSince(opts.since);
+  // Honor an explicit `--since 0d` / `--since all` as "no window".
+  const explicitAll = opts.since === "0d" || opts.since === "0" || opts.since === "all";
+  const since = explicitAll
+    ? undefined
+    : opts.since
+    ? parseSince(opts.since)
+    : new Date(Date.now() - DEFAULT_SINCE_DAYS * 86_400_000);
   const tokenizerChoice = opts.tokenizer ?? "auto";
   const colorEnabled = opts.color !== false && process.stdout.isTTY === true;
   const width = typeof process.stdout.columns === "number" ? process.stdout.columns : 100;

--- a/src/cli/entry.ts
+++ b/src/cli/entry.ts
@@ -5,6 +5,8 @@ import { runDoctor, runDoctorFix } from "./doctor.js";
 import { configGet, configSet } from "./config-cmd.js";
 import { runGraph } from "./graph.js";
 import { runReport } from "./report.js";
+import { runAnalyze } from "./analyze.js";
+import type { TokenizerChoice } from "../analyze/tokens.js";
 import type { Config } from "../core/types.js";
 import { TOKENOMY_VERSION } from "../core/version.js";
 
@@ -14,6 +16,8 @@ Usage:
   tokenomy init [--aggression=conservative|balanced|aggressive] [--no-backup] [--graph-path=<dir>]
   tokenomy doctor [--fix]
   tokenomy report [--since=<ISO>] [--top=<N>] [--out=<path>] [--json]
+  tokenomy analyze [--path=<dir>] [--since=<ISO|Nd|Nw>] [--project=<str>] [--session=<id>]
+                   [--top=<N>] [--tokenizer=heuristic|tiktoken|auto] [--json] [--no-color] [--verbose]
   tokenomy graph build [--force] [--path=<dir>]
   tokenomy graph status [--path=<dir>]
   tokenomy graph serve [--path=<dir>]
@@ -135,6 +139,23 @@ const main = async (): Promise<number> => {
     return printDoctor();
   }
   if (cmd === "graph") return runGraph(process.argv.slice(3));
+
+  if (cmd === "analyze") {
+    const tokFlag = typeof args.flags["tokenizer"] === "string" ? (args.flags["tokenizer"] as string) : "auto";
+    const tok: TokenizerChoice =
+      tokFlag === "heuristic" || tokFlag === "tiktoken" || tokFlag === "auto" ? tokFlag : "auto";
+    return runAnalyze({
+      path: typeof args.flags["path"] === "string" ? args.flags["path"] : undefined,
+      since: typeof args.flags["since"] === "string" ? args.flags["since"] : undefined,
+      projectFilter: typeof args.flags["project"] === "string" ? args.flags["project"] : undefined,
+      sessionFilter: typeof args.flags["session"] === "string" ? args.flags["session"] : undefined,
+      top: typeof args.flags["top"] === "string" ? parseInt(args.flags["top"], 10) : undefined,
+      tokenizer: tok,
+      json: args.flags["json"] === true,
+      color: args.flags["no-color"] !== true,
+      verbose: args.flags["verbose"] === true,
+    });
+  }
 
   if (cmd === "report") {
     const since =

--- a/src/cli/entry.ts
+++ b/src/cli/entry.ts
@@ -144,12 +144,26 @@ const main = async (): Promise<number> => {
     const tokFlag = typeof args.flags["tokenizer"] === "string" ? (args.flags["tokenizer"] as string) : "auto";
     const tok: TokenizerChoice =
       tokFlag === "heuristic" || tokFlag === "tiktoken" || tokFlag === "auto" ? tokFlag : "auto";
+    // Clamp --top to a sane positive integer: zero, negative, or non-numeric
+    // input falls back to the default 10. This prevents the aggregator from
+    // ever maintaining a zero-size outlier heap (which would blow up on
+    // first access) and makes the behaviour predictable for typos.
+    let topOpt: number | undefined;
+    if (typeof args.flags["top"] === "string") {
+      const parsed = parseInt(args.flags["top"], 10);
+      if (Number.isFinite(parsed) && parsed > 0) topOpt = parsed;
+      else {
+        process.stderr.write(
+          `tokenomy analyze: --top must be a positive integer (got ${JSON.stringify(args.flags["top"])}); using default 10.\n`,
+        );
+      }
+    }
     return runAnalyze({
       path: typeof args.flags["path"] === "string" ? args.flags["path"] : undefined,
       since: typeof args.flags["since"] === "string" ? args.flags["since"] : undefined,
       projectFilter: typeof args.flags["project"] === "string" ? args.flags["project"] : undefined,
       sessionFilter: typeof args.flags["session"] === "string" ? args.flags["session"] : undefined,
-      top: typeof args.flags["top"] === "string" ? parseInt(args.flags["top"], 10) : undefined,
+      top: topOpt,
       tokenizer: tok,
       json: args.flags["json"] === true,
       color: args.flags["no-color"] !== true,

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -144,9 +144,12 @@ const applyAggression = (cfg: Config): Config => {
   };
 };
 
+// Case-insensitive to match the profile glob behaviour — keeps per-tool
+// overrides portable between Claude Code's CamelCase names and Codex's
+// lowercase snake_case variants of the same MCP tool.
 const globToRegex = (glob: string): RegExp => {
   const escaped = glob.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
-  return new RegExp(`^${escaped}$`);
+  return new RegExp(`^${escaped}$`, "i");
 };
 
 // Find the most specific tool override (longest non-wildcard pattern wins).

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,1 +1,1 @@
-export const TOKENOMY_VERSION = "0.1.0-alpha.6";
+export const TOKENOMY_VERSION = "0.1.0-alpha.7";

--- a/src/rules/profiles.ts
+++ b/src/rules/profiles.ts
@@ -157,9 +157,14 @@ export const BUILTIN_PROFILES: TrimProfile[] = [
   },
 ];
 
+// Glob compile: case-insensitive so profile patterns written in
+// CamelCase (e.g. `mcp__*Atlassian*__getJiraIssue`, the Claude Code style)
+// also match lowercase-normalized Codex tool names like
+// `mcp__codex_apps__atlassian_rovo__getjiraissue`. This keeps a single set
+// of built-in profiles useful across both agents.
 const globToRegex = (glob: string): RegExp => {
   const escaped = glob.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
-  return new RegExp(`^${escaped}$`);
+  return new RegExp(`^${escaped}$`, "i");
 };
 
 export const selectProfile = (

--- a/src/rules/profiles.ts
+++ b/src/rules/profiles.ts
@@ -155,6 +155,33 @@ export const BUILTIN_PROFILES: TrimProfile[] = [
     max_string_bytes: 1_500,
     max_array_items: 20,
   },
+  {
+    // Codex-style GitHub connector method names: fetch_pr, get_pr_info,
+    // search_prs, review_pr, etc. Same keep-set as the pull_request-style
+    // Claude Code names above.
+    name: "github-pr-codex",
+    match: "mcp__*github*__*_pr*",
+    keep: [
+      "number",
+      "title",
+      "state",
+      "user.login",
+      "head.ref",
+      "base.ref",
+      "mergeable",
+      "draft",
+      "body",
+      "html_url",
+      "labels.*.name",
+      "prs.*.number",
+      "prs.*.title",
+      "prs.*.state",
+      "prs.*.user.login",
+      "prs.*.html_url",
+    ],
+    max_string_bytes: 1_500,
+    max_array_items: 20,
+  },
 ];
 
 // Glob compile: case-insensitive so profile patterns written in

--- a/tests/integration/analyze-cli.test.ts
+++ b/tests/integration/analyze-cli.test.ts
@@ -1,0 +1,113 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CLI = join(fileURLToPath(new URL("../..", import.meta.url)), "dist/cli/entry.js");
+
+const synthesize = (projectsDir: string): void => {
+  const session = join(projectsDir, "-fake-project", "session-1.jsonl");
+  mkdirSync(join(projectsDir, "-fake-project"), { recursive: true });
+
+  const lines: string[] = [
+    JSON.stringify({
+      type: "assistant",
+      timestamp: "2026-04-18T10:00:00Z",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "t1",
+            name: "mcp__fake__big",
+            input: { id: 1 },
+          },
+        ],
+      },
+    }),
+    JSON.stringify({
+      type: "user",
+      timestamp: "2026-04-18T10:00:01Z",
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "t1",
+            content: [{ type: "text", text: "x".repeat(50_000) }],
+          },
+        ],
+      },
+    }),
+    // Duplicate call — should fire dedup.
+    JSON.stringify({
+      type: "assistant",
+      timestamp: "2026-04-18T10:01:00Z",
+      message: {
+        content: [{ type: "tool_use", id: "t2", name: "mcp__fake__big", input: { id: 1 } }],
+      },
+    }),
+    JSON.stringify({
+      type: "user",
+      timestamp: "2026-04-18T10:01:01Z",
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "t2",
+            content: [{ type: "text", text: "x".repeat(50_000) }],
+          },
+        ],
+      },
+    }),
+  ];
+  writeFileSync(session, lines.join("\n") + "\n");
+};
+
+test("analyze cli: scans synthetic projects dir and emits JSON report", () => {
+  const home = mkdtempSync(join(tmpdir(), "tokenomy-analyze-"));
+  try {
+    const projects = join(home, ".claude", "projects");
+    mkdirSync(projects, { recursive: true });
+    synthesize(projects);
+
+    const out = execFileSync(
+      process.execPath,
+      [CLI, "analyze", "--path", projects, "--json"],
+      { env: { ...process.env, HOME: home }, encoding: "utf8" },
+    );
+    const report = JSON.parse(out);
+    assert.equal(report.totals.tool_calls, 2);
+    assert.ok(report.totals.observed_tokens > 0);
+    // Duplicate should have fired.
+    assert.equal(report.totals.duplicate_calls, 1);
+    assert.ok(report.by_tool.some((t: { tool: string }) => t.tool === "mcp__fake__big"));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("analyze cli: --tokenizer=tiktoken errors out cleanly when missing", () => {
+  const home = mkdtempSync(join(tmpdir(), "tokenomy-analyze-"));
+  try {
+    mkdirSync(join(home, ".claude", "projects"), { recursive: true });
+    let threw = false;
+    let stderr = "";
+    try {
+      execFileSync(
+        process.execPath,
+        [CLI, "analyze", "--path", join(home, ".claude", "projects"), "--tokenizer=tiktoken"],
+        { env: { ...process.env, HOME: home }, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+      );
+    } catch (e) {
+      threw = true;
+      const err = e as { stderr?: string | Buffer };
+      stderr = typeof err.stderr === "string" ? err.stderr : err.stderr?.toString("utf8") ?? "";
+    }
+    assert.equal(threw, true);
+    assert.match(stderr, /js-tiktoken not available/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/analyze-parse.test.ts
+++ b/tests/unit/analyze-parse.test.ts
@@ -222,6 +222,21 @@ test("parse: Codex MCP output wrapped into {content:[text]} shape when bare JSON
   assert.ok(Array.isArray(resp.content));
 });
 
+test("parse: Codex wrapper's 'Original token count: N' is captured as override", () => {
+  const call = JSON.stringify({
+    type: "response_item",
+    payload: { type: "function_call", name: "exec_command", arguments: "{}", call_id: "call_tok" },
+  });
+  const wrapped = `Chunk ID: abc\nWall time: 0.1\nProcess exited with code 0\nOriginal token count: 423\nOutput:\nhello world`;
+  const output = JSON.stringify({
+    type: "response_item",
+    payload: { type: "function_call_output", call_id: "call_tok", output: wrapped },
+  });
+  const calls = collect([call, output]);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.observed_tokens_override, 423);
+});
+
 test("parse: non-MCP Codex tool with JSON-looking output stays a string", () => {
   const call = JSON.stringify({
     type: "response_item",

--- a/tests/unit/analyze-parse.test.ts
+++ b/tests/unit/analyze-parse.test.ts
@@ -136,8 +136,29 @@ test("parse: Codex namespace + name produce mcp__* tool names", () => {
   });
   const calls = collect([call, output]);
   assert.equal(calls.length, 1);
-  assert.equal(calls[0]!.tool_name, "mcp__codex_apps__github_search_prs");
+  // Leading underscore on the method fuses with the namespace's trailing
+  // character to yield a proper `__` separator.
+  assert.equal(calls[0]!.tool_name, "mcp__codex_apps__github__search_prs");
   assert.ok(calls[0]!.tool_name.startsWith("mcp__"));
+});
+
+test("parse: Codex namespace + underscore-less name uses __ separator", () => {
+  const call = JSON.stringify({
+    type: "response_item",
+    payload: {
+      type: "function_call",
+      namespace: "mcp__codex_apps__github",
+      name: "search",
+      arguments: "{}",
+      call_id: "call_no_us",
+    },
+  });
+  const output = JSON.stringify({
+    type: "response_item",
+    payload: { type: "function_call_output", call_id: "call_no_us", output: "Output:\nx" },
+  });
+  const calls = collect([call, output]);
+  assert.equal(calls[0]!.tool_name, "mcp__codex_apps__github__search");
 });
 
 test("parse: Codex CLI wrapper is stripped from function_call_output", () => {

--- a/tests/unit/analyze-parse.test.ts
+++ b/tests/unit/analyze-parse.test.ts
@@ -182,7 +182,7 @@ test("parse: Codex CLI wrapper is stripped from function_call_output", () => {
   assert.equal(calls[0]!.tool_response, "Hello world");
 });
 
-test("parse: Codex wrapped JSON payload is parsed back into an object", () => {
+test("parse: Codex wrapped JSON payload is parsed back into an object (MCP tool)", () => {
   const call = JSON.stringify({
     type: "response_item",
     payload: { type: "function_call", namespace: "mcp__x__y", name: "z", arguments: "{}", call_id: "call_js" },
@@ -196,6 +196,26 @@ test("parse: Codex wrapped JSON payload is parsed back into an object", () => {
   const calls = collect([call, output]);
   assert.equal(calls.length, 1);
   assert.deepEqual(calls[0]!.tool_response, payload);
+});
+
+test("parse: non-MCP Codex tool with JSON-looking output stays a string", () => {
+  const call = JSON.stringify({
+    type: "response_item",
+    payload: { type: "function_call", name: "exec_command", arguments: "{}", call_id: "call_cat" },
+  });
+  const prettyJson = '{\n  "name": "foo",\n  "version": "1.0.0"\n}';
+  const wrapped = `Wall time: 0.1s\nOutput:\n${prettyJson}`;
+  const output = JSON.stringify({
+    type: "response_item",
+    payload: { type: "function_call_output", call_id: "call_cat", output: wrapped },
+  });
+  const calls = collect([call, output]);
+  assert.equal(calls.length, 1);
+  // Shell outputs stay as strings even when they happen to be JSON —
+  // otherwise `cat package.json` gets mis-parsed into an object and
+  // downstream tooling miscounts it.
+  assert.equal(typeof calls[0]!.tool_response, "string");
+  assert.equal(calls[0]!.tool_response, prettyJson);
 });
 
 test("parse: upgrades identity from Claude Code sessionId + cwd fields", () => {

--- a/tests/unit/analyze-parse.test.ts
+++ b/tests/unit/analyze-parse.test.ts
@@ -117,3 +117,81 @@ test("parse: Codex function_call_output without matching call is dropped", () =>
   const calls = collect([output]);
   assert.equal(calls.length, 0);
 });
+
+test("parse: Codex namespace + name produce mcp__* tool names", () => {
+  const call = JSON.stringify({
+    type: "response_item",
+    timestamp: "2026-04-18T12:00:00Z",
+    payload: {
+      type: "function_call",
+      namespace: "mcp__codex_apps__github",
+      name: "_search_prs",
+      arguments: JSON.stringify({ repo: "x/y" }),
+      call_id: "call_xy",
+    },
+  });
+  const output = JSON.stringify({
+    type: "response_item",
+    payload: { type: "function_call_output", call_id: "call_xy", output: "Output:\n[]" },
+  });
+  const calls = collect([call, output]);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.tool_name, "mcp__codex_apps__github_search_prs");
+  assert.ok(calls[0]!.tool_name.startsWith("mcp__"));
+});
+
+test("parse: Codex CLI wrapper is stripped from function_call_output", () => {
+  const call = JSON.stringify({
+    type: "response_item",
+    payload: {
+      type: "function_call",
+      name: "exec_command",
+      arguments: "{}",
+      call_id: "call_wrap",
+    },
+  });
+  const wrapped =
+    "Chunk ID: abc\nWall time: 0.1 seconds\nProcess exited with code 0\nOriginal token count: 5\nOutput:\nHello world";
+  const output = JSON.stringify({
+    type: "response_item",
+    payload: { type: "function_call_output", call_id: "call_wrap", output: wrapped },
+  });
+  const calls = collect([call, output]);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.tool_response, "Hello world");
+});
+
+test("parse: Codex wrapped JSON payload is parsed back into an object", () => {
+  const call = JSON.stringify({
+    type: "response_item",
+    payload: { type: "function_call", namespace: "mcp__x__y", name: "z", arguments: "{}", call_id: "call_js" },
+  });
+  const payload = { content: [{ type: "text", text: "hi" }] };
+  const wrapped = `Wall time: 0.1s\nOutput:\n${JSON.stringify(payload)}`;
+  const output = JSON.stringify({
+    type: "response_item",
+    payload: { type: "function_call_output", call_id: "call_js", output: wrapped },
+  });
+  const calls = collect([call, output]);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0]!.tool_response, payload);
+});
+
+test("parse: upgrades identity from Claude Code sessionId + cwd fields", () => {
+  const use = JSON.stringify({
+    type: "assistant",
+    timestamp: "2026-04-18T12:00:00Z",
+    sessionId: "real-session",
+    cwd: "/Users/me/actual-project",
+    message: {
+      content: [{ type: "tool_use", id: "tu", name: "Read", input: { file_path: "/x" } }],
+    },
+  });
+  const result = JSON.stringify({
+    type: "user",
+    message: { content: [{ type: "tool_result", tool_use_id: "tu", content: "x" }] },
+  });
+  const calls = collect([use, result], "fallback-session", "fallback-project");
+  assert.equal(calls[0]!.session_id, "real-session");
+  assert.equal(calls[0]!.project_hint, "/Users/me/actual-project");
+});

--- a/tests/unit/analyze-parse.test.ts
+++ b/tests/unit/analyze-parse.test.ts
@@ -1,0 +1,100 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { feedLine, makeState, type ToolCall } from "../../src/analyze/parse.js";
+
+const collect = (lines: string[], session = "s1", project = "p1"): ToolCall[] => {
+  const state = makeState(session, project);
+  const out: ToolCall[] = [];
+  for (const l of lines) feedLine(l, state, (c) => out.push(c));
+  return out;
+};
+
+test("parse: pairs Claude Code tool_use with tool_result", () => {
+  const useLine = JSON.stringify({
+    type: "assistant",
+    timestamp: "2026-04-18T12:00:00Z",
+    message: {
+      content: [
+        { type: "text", text: "calling read" },
+        { type: "tool_use", id: "tu_1", name: "Read", input: { file_path: "/tmp/x" } },
+      ],
+    },
+  });
+  const resultLine = JSON.stringify({
+    type: "user",
+    timestamp: "2026-04-18T12:00:05Z",
+    message: {
+      content: [
+        { type: "tool_result", tool_use_id: "tu_1", content: "file contents", is_error: false },
+      ],
+    },
+  });
+  const calls = collect([useLine, resultLine]);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.tool_name, "Read");
+  assert.equal(calls[0]!.tool_input.file_path, "/tmp/x");
+  assert.equal(calls[0]!.tool_response, "file contents");
+  assert.equal(calls[0]!.is_error, false);
+  assert.equal(calls[0]!.agent, "claude-code");
+  assert.equal(calls[0]!.session_id, "s1");
+});
+
+test("parse: orphan tool_result without matching use is dropped", () => {
+  const resultLine = JSON.stringify({
+    type: "user",
+    message: { content: [{ type: "tool_result", tool_use_id: "orphan", content: "x" }] },
+  });
+  const calls = collect([resultLine]);
+  assert.equal(calls.length, 0);
+});
+
+test("parse: handles MCP list-shape content", () => {
+  const use = JSON.stringify({
+    type: "assistant",
+    timestamp: "2026-04-18T12:00:00Z",
+    message: { content: [{ type: "tool_use", id: "tu_2", name: "mcp__x__y", input: {} }] },
+  });
+  const result = JSON.stringify({
+    type: "user",
+    timestamp: "2026-04-18T12:00:05Z",
+    message: {
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "tu_2",
+          content: [
+            { type: "text", text: "hello" },
+            { type: "image", data: "base64" },
+          ],
+        },
+      ],
+    },
+  });
+  const calls = collect([use, result]);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.tool_name, "mcp__x__y");
+  assert.ok(Array.isArray(calls[0]!.tool_response));
+});
+
+test("parse: malformed JSON line is skipped", () => {
+  const calls = collect(["not json", "", "{"]);
+  assert.equal(calls.length, 0);
+});
+
+test("parse: Codex rollout tool_call is recognized", () => {
+  const line = JSON.stringify({
+    type: "event_msg",
+    timestamp: "2026-04-18T12:00:00Z",
+    payload: {
+      tool_call: {
+        name: "apply_patch",
+        arguments: { path: "x.ts" },
+        output: "patched",
+      },
+    },
+  });
+  const calls = collect([line]);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.tool_name, "apply_patch");
+  assert.equal(calls[0]!.agent, "codex");
+});

--- a/tests/unit/analyze-parse.test.ts
+++ b/tests/unit/analyze-parse.test.ts
@@ -198,6 +198,30 @@ test("parse: Codex wrapped JSON payload is parsed back into an object (MCP tool)
   assert.deepEqual(calls[0]!.tool_response, payload);
 });
 
+test("parse: Codex MCP output wrapped into {content:[text]} shape when bare JSON", () => {
+  const call = JSON.stringify({
+    type: "response_item",
+    payload: {
+      type: "function_call",
+      namespace: "mcp__codex_apps__github",
+      name: "_search_prs",
+      arguments: "{}",
+      call_id: "call_bare",
+    },
+  });
+  const bare = JSON.stringify({ issues: [{ id: 1, title: "x" }] });
+  const output = JSON.stringify({
+    type: "response_item",
+    payload: { type: "function_call_output", call_id: "call_bare", output: `Output:\n${bare}` },
+  });
+  const calls = collect([call, output]);
+  assert.equal(calls.length, 1);
+  const resp = calls[0]!.tool_response as { content?: unknown };
+  assert.ok(resp && typeof resp === "object");
+  // Wrapper inserted so mcpContentRule can traverse text blocks.
+  assert.ok(Array.isArray(resp.content));
+});
+
 test("parse: non-MCP Codex tool with JSON-looking output stays a string", () => {
   const call = JSON.stringify({
     type: "response_item",

--- a/tests/unit/analyze-parse.test.ts
+++ b/tests/unit/analyze-parse.test.ts
@@ -81,20 +81,39 @@ test("parse: malformed JSON line is skipped", () => {
   assert.equal(calls.length, 0);
 });
 
-test("parse: Codex rollout tool_call is recognized", () => {
-  const line = JSON.stringify({
-    type: "event_msg",
+test("parse: Codex rollout function_call + function_call_output pair", () => {
+  const call = JSON.stringify({
+    type: "response_item",
     timestamp: "2026-04-18T12:00:00Z",
     payload: {
-      tool_call: {
-        name: "apply_patch",
-        arguments: { path: "x.ts" },
-        output: "patched",
-      },
+      type: "function_call",
+      name: "exec_command",
+      arguments: JSON.stringify({ cmd: "ls", workdir: "/tmp" }),
+      call_id: "call_abc",
     },
   });
-  const calls = collect([line]);
+  const output = JSON.stringify({
+    type: "response_item",
+    timestamp: "2026-04-18T12:00:01Z",
+    payload: {
+      type: "function_call_output",
+      call_id: "call_abc",
+      output: "file1\nfile2\n",
+    },
+  });
+  const calls = collect([call, output]);
   assert.equal(calls.length, 1);
-  assert.equal(calls[0]!.tool_name, "apply_patch");
+  assert.equal(calls[0]!.tool_name, "exec_command");
   assert.equal(calls[0]!.agent, "codex");
+  assert.equal((calls[0]!.tool_input as { cmd?: string }).cmd, "ls");
+  assert.equal(calls[0]!.tool_response, "file1\nfile2\n");
+});
+
+test("parse: Codex function_call_output without matching call is dropped", () => {
+  const output = JSON.stringify({
+    type: "response_item",
+    payload: { type: "function_call_output", call_id: "orphan", output: "x" },
+  });
+  const calls = collect([output]);
+  assert.equal(calls.length, 0);
 });

--- a/tests/unit/analyze-render.test.ts
+++ b/tests/unit/analyze-render.test.ts
@@ -1,0 +1,98 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { render, renderProgress } from "../../src/analyze/render.js";
+import type { AggregateReport } from "../../src/analyze/report.js";
+
+const stub: AggregateReport = {
+  window: { first_ts: "2026-04-17T10:00:00Z", last_ts: "2026-04-18T12:00:00Z" },
+  totals: {
+    files: 3,
+    sessions: 2,
+    tool_calls: 12,
+    observed_bytes: 100_000,
+    observed_tokens: 25_000,
+    savings_bytes: 60_000,
+    savings_tokens: 15_000,
+    redact_matches: 2,
+    duplicate_calls: 4,
+    estimated_usd_saved: 0.045,
+    estimated_usd_observed: 0.075,
+  },
+  by_tool: [
+    { tool: "mcp__Atlassian__getJiraIssue", calls: 3, observed_tokens: 10_000, savings_tokens: 8_000, waste_pct: 0.8 },
+    { tool: "Read", calls: 5, observed_tokens: 9_000, savings_tokens: 5_000, waste_pct: 0.55 },
+  ],
+  by_rule: [
+    { rule: "profile", savings_tokens: 8_000, events: 3 },
+    { rule: "read_clamp", savings_tokens: 5_000, events: 4 },
+    { rule: "dedup", savings_tokens: 2_000, events: 2 },
+  ],
+  by_day: [
+    { day: "2026-04-17", observed_tokens: 10_000, savings_tokens: 6_000 },
+    { day: "2026-04-18", observed_tokens: 15_000, savings_tokens: 9_000 },
+  ],
+  hotspots: [{ tool: "mcp__Atlassian__getJiraIssue", calls: 3, wasted_tokens: 6_000 }],
+  outliers: [
+    { tool: "mcp__Atlassian__getJiraIssue", tokens: 4_000, bytes: 16_000, ts: "2026-04-17T11:00:00Z", session_id: "abcdef12" },
+  ],
+  tokenizer: { name: "heuristic", approximate: true },
+};
+
+test("render: plain output (no color) contains summary numbers", () => {
+  const out = render(stub, { color: false, width: 100, verbose: false });
+  assert.ok(out.includes("tokenomy analyze"));
+  assert.ok(out.includes("25,000")); // observed tokens
+  assert.ok(out.includes("15,000")); // savings tokens
+  assert.ok(out.includes("$0.0450"));
+});
+
+test("render: lists top tools and by_rule", () => {
+  const out = render(stub, { color: false, width: 100, verbose: false });
+  assert.ok(out.includes("mcp__Atlassian__getJiraIssue"));
+  assert.ok(out.includes("Schema-aware profile trim"));
+  assert.ok(out.includes("Read clamp"));
+});
+
+test("render: shows redact warning when matches > 0", () => {
+  const out = render(stub, { color: false, width: 100, verbose: false });
+  assert.ok(out.includes("Secret-pattern matches"));
+});
+
+test("render: verbose adds per-day table", () => {
+  const out = render(stub, { color: false, width: 100, verbose: true });
+  assert.ok(out.includes("2026-04-17"));
+  assert.ok(out.includes("2026-04-18"));
+});
+
+test("render: renderProgress produces carriage-returned status", () => {
+  const s = renderProgress(5, 10, 1_000_000, 2_000, false, 100);
+  assert.ok(s.startsWith("\r"));
+  assert.ok(s.includes("5/10"));
+});
+
+test("render: empty report doesn't throw", () => {
+  const empty: AggregateReport = {
+    window: { first_ts: null, last_ts: null },
+    totals: {
+      files: 0,
+      sessions: 0,
+      tool_calls: 0,
+      observed_bytes: 0,
+      observed_tokens: 0,
+      savings_bytes: 0,
+      savings_tokens: 0,
+      redact_matches: 0,
+      duplicate_calls: 0,
+      estimated_usd_saved: 0,
+      estimated_usd_observed: 0,
+    },
+    by_tool: [],
+    by_rule: [],
+    by_day: [],
+    hotspots: [],
+    outliers: [],
+    tokenizer: { name: "heuristic", approximate: true },
+  };
+  const out = render(empty, { color: false, width: 80, verbose: false });
+  assert.ok(out.includes("no events"));
+});

--- a/tests/unit/analyze-report.test.ts
+++ b/tests/unit/analyze-report.test.ts
@@ -54,16 +54,19 @@ test("aggregator: hotspots are session-scoped (same key in two sessions isn't a 
   assert.equal(r.hotspots.length, 0);
 });
 
-test("aggregator: hotspots only list keys with >1 call, sum wasted tokens", () => {
+test("aggregator: hotspots only surface simulator-confirmed duplicates", () => {
   const a = agg();
   a.feed(mk({ call_key: "k1", tool_name: "t1", observed_tokens: 100 }));
-  a.feed(mk({ call_key: "k1", tool_name: "t1", observed_tokens: 100 }));
-  a.feed(mk({ call_key: "k1", tool_name: "t1", observed_tokens: 100 }));
+  // These repeats were flagged as duplicates by the simulator → counted.
+  a.feed(mk({ call_key: "k1", tool_name: "t1", observed_tokens: 100, duplicate_of_index: 1 }));
+  a.feed(mk({ call_key: "k1", tool_name: "t1", observed_tokens: 100, duplicate_of_index: 1 }));
+  // A second key with only "repeat" count but no duplicate flag — should
+  // be filtered out of the hotspots list (simulator didn't credit savings).
+  a.feed(mk({ call_key: "k2", tool_name: "t2", observed_tokens: 500 }));
   a.feed(mk({ call_key: "k2", tool_name: "t2", observed_tokens: 500 }));
   const r = a.build();
   assert.equal(r.hotspots.length, 1);
   assert.equal(r.hotspots[0]!.calls, 3);
-  // 2 repeats * 100 = 200 wasted
   assert.equal(r.hotspots[0]!.wasted_tokens, 200);
 });
 

--- a/tests/unit/analyze-report.test.ts
+++ b/tests/unit/analyze-report.test.ts
@@ -1,0 +1,87 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Aggregator } from "../../src/analyze/report.js";
+import type { SimEvent } from "../../src/analyze/simulate.js";
+
+const mk = (over: Partial<SimEvent>): SimEvent => ({
+  agent: "claude-code",
+  session_id: "s1",
+  project_hint: "p1",
+  ts: "2026-04-18T10:00:00Z",
+  tool_name: "mcp__x",
+  observed_bytes: 1000,
+  observed_tokens: 200,
+  savings_bytes: 500,
+  savings_tokens: 100,
+  per_rule: { dedup: 0, redact_matches: 0, stacktrace: 0, profile: 100, mcp_trim: 0, read_clamp: 0 },
+  call_key: "k1",
+  ...over,
+});
+
+const agg = () =>
+  new Aggregator({
+    top_n: 5,
+    price_per_million: 3,
+    tokenizer_name: "heuristic",
+    tokenizer_approximate: true,
+  });
+
+test("aggregator: totals are summed correctly", () => {
+  const a = agg();
+  a.feed(mk({}));
+  a.feed(mk({ observed_tokens: 400, savings_tokens: 300, per_rule: { dedup: 300, redact_matches: 0, stacktrace: 0, profile: 0, mcp_trim: 0, read_clamp: 0 } }));
+  const r = a.build();
+  assert.equal(r.totals.tool_calls, 2);
+  assert.equal(r.totals.observed_tokens, 600);
+  assert.equal(r.totals.savings_tokens, 400);
+});
+
+test("aggregator: by_tool sorted by savings tokens desc", () => {
+  const a = agg();
+  a.feed(mk({ tool_name: "a", observed_tokens: 100, savings_tokens: 10, per_rule: { dedup: 0, redact_matches: 0, stacktrace: 0, profile: 10, mcp_trim: 0, read_clamp: 0 } }));
+  a.feed(mk({ tool_name: "b", observed_tokens: 100, savings_tokens: 80, per_rule: { dedup: 0, redact_matches: 0, stacktrace: 0, profile: 80, mcp_trim: 0, read_clamp: 0 } }));
+  const r = a.build();
+  assert.equal(r.by_tool[0]!.tool, "b");
+  assert.equal(r.by_tool[1]!.tool, "a");
+});
+
+test("aggregator: hotspots only list keys with >1 call, sum wasted tokens", () => {
+  const a = agg();
+  a.feed(mk({ call_key: "k1", tool_name: "t1", observed_tokens: 100 }));
+  a.feed(mk({ call_key: "k1", tool_name: "t1", observed_tokens: 100 }));
+  a.feed(mk({ call_key: "k1", tool_name: "t1", observed_tokens: 100 }));
+  a.feed(mk({ call_key: "k2", tool_name: "t2", observed_tokens: 500 }));
+  const r = a.build();
+  assert.equal(r.hotspots.length, 1);
+  assert.equal(r.hotspots[0]!.calls, 3);
+  // 2 repeats * 100 = 200 wasted
+  assert.equal(r.hotspots[0]!.wasted_tokens, 200);
+});
+
+test("aggregator: outliers top-N by observed tokens", () => {
+  const a = agg();
+  for (let i = 0; i < 20; i++) a.feed(mk({ observed_tokens: i * 100 }));
+  const r = a.build();
+  assert.equal(r.outliers.length, 5);
+  // First should be the largest (19*100 = 1900).
+  assert.equal(r.outliers[0]!.tokens, 1900);
+});
+
+test("aggregator: by_day bucketed by UTC date", () => {
+  const a = agg();
+  a.feed(mk({ ts: "2026-04-18T10:00:00Z", observed_tokens: 100 }));
+  a.feed(mk({ ts: "2026-04-18T22:00:00Z", observed_tokens: 200 }));
+  a.feed(mk({ ts: "2026-04-19T09:00:00Z", observed_tokens: 50 }));
+  const r = a.build();
+  assert.equal(r.by_day.length, 2);
+  assert.equal(r.by_day[0]!.day, "2026-04-18");
+  assert.equal(r.by_day[0]!.observed_tokens, 300);
+});
+
+test("aggregator: usd calculation", () => {
+  const a = new Aggregator({ top_n: 5, price_per_million: 10, tokenizer_name: "h", tokenizer_approximate: true });
+  a.feed(mk({ observed_tokens: 1_000_000, savings_tokens: 500_000 }));
+  const r = a.build();
+  assert.ok(Math.abs(r.totals.estimated_usd_saved - 5) < 1e-6);
+  assert.ok(Math.abs(r.totals.estimated_usd_observed - 10) < 1e-6);
+});

--- a/tests/unit/analyze-report.test.ts
+++ b/tests/unit/analyze-report.test.ts
@@ -45,6 +45,15 @@ test("aggregator: by_tool sorted by savings tokens desc", () => {
   assert.equal(r.by_tool[1]!.tool, "a");
 });
 
+test("aggregator: hotspots are session-scoped (same key in two sessions isn't a hotspot)", () => {
+  const a = agg();
+  a.feed(mk({ session_id: "s1", call_key: "k1", tool_name: "t1", observed_tokens: 100 }));
+  a.feed(mk({ session_id: "s2", call_key: "k1", tool_name: "t1", observed_tokens: 100 }));
+  const r = a.build();
+  // Same call_key across sessions ≠ hotspot; real dedup is session-scoped.
+  assert.equal(r.hotspots.length, 0);
+});
+
 test("aggregator: hotspots only list keys with >1 call, sum wasted tokens", () => {
   const a = agg();
   a.feed(mk({ call_key: "k1", tool_name: "t1", observed_tokens: 100 }));

--- a/tests/unit/analyze-simulate.test.ts
+++ b/tests/unit/analyze-simulate.test.ts
@@ -1,0 +1,133 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Simulator } from "../../src/analyze/simulate.js";
+import { heuristicTokenizer } from "../../src/analyze/tokens.js";
+import { DEFAULT_CONFIG } from "../../src/core/config.js";
+import type { ToolCall } from "../../src/analyze/parse.js";
+
+const mkCall = (over: Partial<ToolCall>): ToolCall => ({
+  agent: "claude-code",
+  session_id: "s1",
+  project_hint: "p",
+  ts: "2026-04-18T12:00:00Z",
+  tool_name: "mcp__x__y",
+  tool_input: {},
+  tool_response: null,
+  is_error: false,
+  response_bytes: 0,
+  ...over,
+});
+
+const makeSim = () =>
+  new Simulator({
+    cfg: { ...DEFAULT_CONFIG, aggression: "balanced" },
+    tokenizer: heuristicTokenizer,
+  });
+
+test("simulator: duplicate in same session is flagged and credits savings", () => {
+  const sim = makeSim();
+  const body = { content: [{ type: "text", text: "x".repeat(4000) }] };
+  const call = mkCall({
+    tool_input: { id: 1 },
+    tool_response: body,
+    response_bytes: Buffer.byteLength(JSON.stringify(body), "utf8"),
+  });
+
+  const first = sim.feed(call);
+  assert.equal(first.duplicate_of_index, undefined);
+
+  const second = sim.feed(call);
+  assert.equal(second.duplicate_of_index, 1);
+  assert.ok(second.per_rule.dedup > 0);
+  assert.ok(second.savings_tokens > 0);
+});
+
+test("simulator: different sessions do not cross-contaminate dedup", () => {
+  const sim = makeSim();
+  const body = { content: [{ type: "text", text: "x".repeat(4000) }] };
+  const call1 = mkCall({
+    session_id: "s1",
+    tool_input: { id: 1 },
+    tool_response: body,
+    response_bytes: 9999,
+  });
+  const call2 = mkCall({
+    session_id: "s2",
+    tool_input: { id: 1 },
+    tool_response: body,
+    response_bytes: 9999,
+  });
+  sim.feed(call1);
+  const r = sim.feed(call2);
+  assert.equal(r.duplicate_of_index, undefined);
+});
+
+test("simulator: stacktrace-shaped response is collapsed", () => {
+  const sim = makeSim();
+  const trace =
+    "Error: boom\n" +
+    "    at foo (/a.ts:1:1)\n".repeat(10) +
+    "    at root (/z.ts:1:1)";
+  const call = mkCall({
+    tool_name: "Bash",
+    tool_response: trace,
+    response_bytes: Buffer.byteLength(trace, "utf8"),
+  });
+  const r = sim.feed(call);
+  assert.ok(r.per_rule.stacktrace > 0);
+  assert.ok(r.savings_tokens > 0);
+});
+
+test("simulator: MCP trim produces savings for oversized JSON response", () => {
+  const sim = makeSim();
+  const body = {
+    content: [{ type: "text", text: "y".repeat(50_000) }],
+  };
+  const call = mkCall({
+    tool_name: "mcp__test__big",
+    tool_response: body,
+    response_bytes: Buffer.byteLength(JSON.stringify(body), "utf8"),
+  });
+  const r = sim.feed(call);
+  assert.ok(r.savings_tokens > 0);
+  // mcp_trim or profile must have fired.
+  assert.ok(r.per_rule.mcp_trim > 0 || r.per_rule.profile > 0);
+});
+
+test("simulator: secret pattern in response increments redact_matches", () => {
+  const sim = makeSim();
+  const text = `token=AKIA${"IOSFODNN7EXAMPLE"} here`;
+  const call = mkCall({
+    tool_name: "Bash",
+    tool_response: text,
+    response_bytes: Buffer.byteLength(text, "utf8"),
+  });
+  const r = sim.feed(call);
+  assert.equal(r.per_rule.redact_matches, 1);
+});
+
+test("simulator: Read with no explicit limit + large response fires read_clamp", () => {
+  const sim = makeSim();
+  const text = "x".repeat(80_000);
+  const call = mkCall({
+    tool_name: "Read",
+    tool_input: { file_path: "/big" },
+    tool_response: text,
+    response_bytes: text.length,
+  });
+  const r = sim.feed(call);
+  assert.ok(r.per_rule.read_clamp > 0);
+});
+
+test("simulator: Read with explicit limit does not fire read_clamp", () => {
+  const sim = makeSim();
+  const text = "x".repeat(80_000);
+  const call = mkCall({
+    tool_name: "Read",
+    tool_input: { file_path: "/big", limit: 100 },
+    tool_response: text,
+    response_bytes: text.length,
+  });
+  const r = sim.feed(call);
+  assert.equal(r.per_rule.read_clamp, 0);
+});

--- a/tests/unit/analyze-simulate.test.ts
+++ b/tests/unit/analyze-simulate.test.ts
@@ -146,6 +146,23 @@ test("simulator: non-MCP secret does NOT count redact_matches (matches dispatch)
   assert.equal(r.per_rule.redact_matches, 0);
 });
 
+test("simulator: dedup catches intermediate repeats in out-of-order streams", () => {
+  const sim = makeSim();
+  const body = { content: [{ type: "text", text: "x".repeat(4000) }] };
+  const bytes = Buffer.byteLength(JSON.stringify(body), "utf8");
+  // Stream is scan-order (not time-order): 12:02, then 12:00, then 12:01.
+  // A correct simulator should mark 12:01 as a duplicate of 12:00 (the
+  // earlier in-window prior), even though 12:02 arrived first in scan.
+  sim.feed(mkCall({ ts: "2026-04-18T12:02:00Z", tool_input: { id: 99 }, tool_response: body, response_bytes: bytes }));
+  sim.feed(mkCall({ ts: "2026-04-18T12:00:00Z", tool_input: { id: 99 }, tool_response: body, response_bytes: bytes }));
+  const third = sim.feed(
+    mkCall({ ts: "2026-04-18T12:01:00Z", tool_input: { id: 99 }, tool_response: body, response_bytes: bytes }),
+  );
+  // With the bounded per-key list, the 12:01 call should dedup against
+  // the 12:00 prior (the earliest-in-time entry still within window).
+  assert.ok(third.duplicate_of_index !== undefined, "expected third call to be marked duplicate");
+});
+
 test("simulator: dedup respects window_seconds", () => {
   const sim = new Simulator({
     cfg: {

--- a/tests/unit/analyze-simulate.test.ts
+++ b/tests/unit/analyze-simulate.test.ts
@@ -180,27 +180,42 @@ test("simulator: dedup respects window_seconds", () => {
   assert.equal(second.per_rule.dedup, 0);
 });
 
-test("simulator: Read with no explicit limit + large response fires read_clamp", () => {
+test("simulator: Read with no explicit limit + many-line large response fires read_clamp", () => {
   const sim = makeSim();
-  const text = "x".repeat(80_000);
+  // 2000 lines × 50 chars = 100 KB; default injected_limit is 500 lines.
+  const text = Array.from({ length: 2000 }, (_, i) => `line-${i}-padding-padding-padding-padding`).join("\n");
   const call = mkCall({
     tool_name: "Read",
     tool_input: { file_path: "/big" },
     tool_response: text,
-    response_bytes: text.length,
+    response_bytes: Buffer.byteLength(text, "utf8"),
   });
   const r = sim.feed(call);
   assert.ok(r.per_rule.read_clamp > 0);
 });
 
+test("simulator: Read of single-line minified bundle does NOT credit read_clamp", () => {
+  const sim = makeSim();
+  // One long line — limit: 500 lines returns the whole file, no savings.
+  const text = "x".repeat(80_000);
+  const call = mkCall({
+    tool_name: "Read",
+    tool_input: { file_path: "/minified" },
+    tool_response: text,
+    response_bytes: text.length,
+  });
+  const r = sim.feed(call);
+  assert.equal(r.per_rule.read_clamp, 0);
+});
+
 test("simulator: Read with explicit limit does not fire read_clamp", () => {
   const sim = makeSim();
-  const text = "x".repeat(80_000);
+  const text = Array.from({ length: 2000 }, () => "x".repeat(40)).join("\n");
   const call = mkCall({
     tool_name: "Read",
     tool_input: { file_path: "/big", limit: 100 },
     tool_response: text,
-    response_bytes: text.length,
+    response_bytes: Buffer.byteLength(text, "utf8"),
   });
   const r = sim.feed(call);
   assert.equal(r.per_rule.read_clamp, 0);

--- a/tests/unit/analyze-simulate.test.ts
+++ b/tests/unit/analyze-simulate.test.ts
@@ -24,19 +24,28 @@ const makeSim = () =>
     tokenizer: heuristicTokenizer,
   });
 
-test("simulator: duplicate in same session is flagged and credits savings", () => {
+test("simulator: duplicate in same session and within window is flagged", () => {
   const sim = makeSim();
   const body = { content: [{ type: "text", text: "x".repeat(4000) }] };
-  const call = mkCall({
-    tool_input: { id: 1 },
-    tool_response: body,
-    response_bytes: Buffer.byteLength(JSON.stringify(body), "utf8"),
-  });
-
-  const first = sim.feed(call);
+  const bytes = Buffer.byteLength(JSON.stringify(body), "utf8");
+  const first = sim.feed(
+    mkCall({
+      ts: "2026-04-18T12:00:00Z",
+      tool_input: { id: 1 },
+      tool_response: body,
+      response_bytes: bytes,
+    }),
+  );
   assert.equal(first.duplicate_of_index, undefined);
 
-  const second = sim.feed(call);
+  const second = sim.feed(
+    mkCall({
+      ts: "2026-04-18T12:01:00Z", // within default 1800s window
+      tool_input: { id: 1 },
+      tool_response: body,
+      response_bytes: bytes,
+    }),
+  );
   assert.equal(second.duplicate_of_index, 1);
   assert.ok(second.per_rule.dedup > 0);
   assert.ok(second.savings_tokens > 0);
@@ -62,20 +71,37 @@ test("simulator: different sessions do not cross-contaminate dedup", () => {
   assert.equal(r.duplicate_of_index, undefined);
 });
 
-test("simulator: stacktrace-shaped response is collapsed", () => {
+test("simulator: non-MCP stacktrace is NOT counted (matches real dispatch)", () => {
   const sim = makeSim();
   const trace =
     "Error: boom\n" +
     "    at foo (/a.ts:1:1)\n".repeat(10) +
     "    at root (/z.ts:1:1)";
   const call = mkCall({
-    tool_name: "Bash",
+    tool_name: "Bash", // non-MCP — live dispatch skips all PostToolUse rules
     tool_response: trace,
     response_bytes: Buffer.byteLength(trace, "utf8"),
   });
   const r = sim.feed(call);
-  assert.ok(r.per_rule.stacktrace > 0);
-  assert.ok(r.savings_tokens > 0);
+  assert.equal(r.per_rule.stacktrace, 0);
+  assert.equal(r.savings_tokens, 0);
+});
+
+test("simulator: MCP response with stacktrace is credited to mcp-content-rule (no double-count)", () => {
+  const sim = makeSim();
+  const trace =
+    "Error: boom\n" +
+    "    at foo (/a.ts:1:1)\n".repeat(20) +
+    "    at root (/z.ts:1:1)";
+  const body = { content: [{ type: "text", text: trace }] };
+  const call = mkCall({
+    tool_name: "mcp__x__y",
+    tool_response: body,
+    response_bytes: Buffer.byteLength(JSON.stringify(body), "utf8"),
+  });
+  const r = sim.feed(call);
+  // savings_tokens must never exceed observed_tokens (the double-count bug).
+  assert.ok(r.savings_tokens <= r.observed_tokens);
 });
 
 test("simulator: MCP trim produces savings for oversized JSON response", () => {
@@ -94,16 +120,64 @@ test("simulator: MCP trim produces savings for oversized JSON response", () => {
   assert.ok(r.per_rule.mcp_trim > 0 || r.per_rule.profile > 0);
 });
 
-test("simulator: secret pattern in response increments redact_matches", () => {
+test("simulator: secret pattern in MCP response increments redact_matches", () => {
   const sim = makeSim();
-  const text = `token=AKIA${"IOSFODNN7EXAMPLE"} here`;
+  const awsKey = "AKIA" + "IOSFODNN7" + "EXAMPLE";
+  const body = { content: [{ type: "text", text: `token=${awsKey} here` }] };
+  const call = mkCall({
+    tool_name: "mcp__x__y",
+    tool_response: body,
+    response_bytes: Buffer.byteLength(JSON.stringify(body), "utf8"),
+  });
+  const r = sim.feed(call);
+  assert.equal(r.per_rule.redact_matches, 1);
+});
+
+test("simulator: non-MCP secret does NOT count redact_matches (matches dispatch)", () => {
+  const sim = makeSim();
+  const awsKey = "AKIA" + "IOSFODNN7" + "EXAMPLE";
+  const text = `token=${awsKey} here`;
   const call = mkCall({
     tool_name: "Bash",
     tool_response: text,
     response_bytes: Buffer.byteLength(text, "utf8"),
   });
   const r = sim.feed(call);
-  assert.equal(r.per_rule.redact_matches, 1);
+  assert.equal(r.per_rule.redact_matches, 0);
+});
+
+test("simulator: dedup respects window_seconds", () => {
+  const sim = new Simulator({
+    cfg: {
+      ...DEFAULT_CONFIG,
+      aggression: "balanced",
+      dedup: { enabled: true, min_bytes: 1000, window_seconds: 60 },
+    },
+    tokenizer: heuristicTokenizer,
+  });
+  const body = { content: [{ type: "text", text: "x".repeat(4000) }] };
+  const bytes = Buffer.byteLength(JSON.stringify(body), "utf8");
+  // First call at t=0
+  const first = sim.feed(
+    mkCall({
+      ts: "2026-04-18T12:00:00Z",
+      tool_input: { id: 1 },
+      tool_response: body,
+      response_bytes: bytes,
+    }),
+  );
+  assert.equal(first.duplicate_of_index, undefined);
+  // Second call at t=61s (outside window) — should NOT be deduped.
+  const second = sim.feed(
+    mkCall({
+      ts: "2026-04-18T12:01:01Z",
+      tool_input: { id: 1 },
+      tool_response: body,
+      response_bytes: bytes,
+    }),
+  );
+  assert.equal(second.duplicate_of_index, undefined);
+  assert.equal(second.per_rule.dedup, 0);
 });
 
 test("simulator: Read with no explicit limit + large response fires read_clamp", () => {

--- a/tests/unit/analyze-simulate.test.ts
+++ b/tests/unit/analyze-simulate.test.ts
@@ -71,6 +71,18 @@ test("simulator: different sessions do not cross-contaminate dedup", () => {
   assert.equal(r.duplicate_of_index, undefined);
 });
 
+test("simulator: observed_tokens_override wins over tokenizer heuristic", () => {
+  const sim = makeSim();
+  const call = mkCall({
+    tool_name: "exec_command",
+    tool_response: "hello world", // heuristic would return ~2 tokens
+    response_bytes: 11,
+    observed_tokens_override: 423,
+  });
+  const r = sim.feed(call);
+  assert.equal(r.observed_tokens, 423);
+});
+
 test("simulator: non-MCP stacktrace is NOT counted (matches real dispatch)", () => {
   const sim = makeSim();
   const trace =

--- a/tests/unit/analyze-tokens.test.ts
+++ b/tests/unit/analyze-tokens.test.ts
@@ -1,0 +1,47 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { heuristicCount, heuristicTokenizer, loadTokenizer } from "../../src/analyze/tokens.js";
+
+test("heuristicCount: empty string → 0", () => {
+  assert.equal(heuristicCount(""), 0);
+});
+
+test("heuristicCount: pure ASCII prose is within ±30% of bytes/4", () => {
+  const text = "The quick brown fox jumps over the lazy dog. ".repeat(20);
+  const approx = heuristicCount(text);
+  const bytesOver4 = Math.ceil(text.length / 4);
+  // heuristic tends to overcount by 15-20% on English prose — that's okay.
+  assert.ok(approx > 0);
+  assert.ok(Math.abs(approx - bytesOver4) / bytesOver4 < 0.5, `got ${approx} vs ~${bytesOver4}`);
+});
+
+test("heuristicCount: JSON is more expensive per char than prose", () => {
+  const json = JSON.stringify({ id: 1, name: "x", values: [1, 2, 3], nested: { a: true } });
+  const prose = "x".repeat(json.length);
+  const jsonTok = heuristicCount(json);
+  const proseTok = heuristicCount(prose);
+  assert.ok(jsonTok > proseTok, `json=${jsonTok}, prose=${proseTok}`);
+});
+
+test("heuristicCount: newlines count as additional tokens", () => {
+  const a = heuristicCount("word word word");
+  const b = heuristicCount("word\nword\nword");
+  assert.ok(b > a);
+});
+
+test("loadTokenizer: heuristic path returns heuristic instance", async () => {
+  const t = await loadTokenizer("heuristic");
+  assert.equal(t.name, "heuristic");
+  assert.equal(t.approximate, true);
+  assert.equal(t.count("hello"), heuristicTokenizer.count("hello"));
+});
+
+test("loadTokenizer: auto falls back to heuristic when tiktoken missing", async () => {
+  // js-tiktoken isn't installed in this test environment.
+  const t = await loadTokenizer("auto");
+  assert.equal(t.name, "heuristic");
+});
+
+test("loadTokenizer: tiktoken mode throws when missing", async () => {
+  await assert.rejects(() => loadTokenizer("tiktoken"), /js-tiktoken not available/);
+});

--- a/tests/unit/profiles.test.ts
+++ b/tests/unit/profiles.test.ts
@@ -22,6 +22,14 @@ test("selectProfile: no match returns null", () => {
   assert.equal(p, null);
 });
 
+test("selectProfile: case-insensitive matching (Codex lowercase names)", () => {
+  const p = selectProfile(
+    "mcp__codex_apps__atlassian_rovo__getjiraissue",
+    BUILTIN_PROFILES,
+  );
+  assert.equal(p?.name, "atlassian-jira-issue");
+});
+
 test("applyProfile: keeps top-level dotted keys, drops others", () => {
   const profile: TrimProfile = {
     name: "t",

--- a/tests/unit/profiles.test.ts
+++ b/tests/unit/profiles.test.ts
@@ -30,6 +30,17 @@ test("selectProfile: case-insensitive matching (Codex lowercase names)", () => {
   assert.equal(p?.name, "atlassian-jira-issue");
 });
 
+test("selectProfile: Codex GitHub fetch_pr / search_prs hit github-pr-codex", () => {
+  for (const name of [
+    "mcp__codex_apps__github__fetch_pr",
+    "mcp__codex_apps__github__get_pr_info",
+    "mcp__codex_apps__github__search_prs",
+  ]) {
+    const p = selectProfile(name, BUILTIN_PROFILES);
+    assert.equal(p?.name, "github-pr-codex", `expected match for ${name}`);
+  }
+});
+
 test("applyProfile: keeps top-level dotted keys, drops others", () => {
   const profile: TrimProfile = {
     name: "t",


### PR DESCRIPTION
## Summary

- Phase 2 lands: **`tokenomy analyze`** walks Claude Code (`~/.claude/projects`) and Codex CLI (`~/.codex/sessions`) transcripts, replays the full Tokenomy rule pipeline with a real tokenizer, and renders a fancy stdlib-only CLI dashboard.
- Repositions the project as a toolkit for **both Claude Code and Codex CLI**. Live hooks remain Claude-Code-only (Codex has no hook contract yet); graph MCP server and `analyze` work with either agent.
- Bumps version to `0.1.0-alpha.7`. Tests grow from 128 → 179. Typecheck clean.

## New features

### `tokenomy analyze`
- **Streaming scanner** (`src/analyze/scan.ts`) — readline-based line-by-line ingest. Per-session dedup ledger in the simulator tolerates sidechain/resume files so no global buffering is needed.
- **Dual-agent transcript parser** (`src/analyze/parse.ts`) — Claude Code `tool_use`↔`tool_result` pairing AND Codex `response_item.payload.{function_call, function_call_output}` rollout shapes. Strips Codex's wrapper, wraps bare JSON into MCP `{content:[...]}` shape, and preserves Codex's authoritative `Original token count: N` as an override.
- **Tokenizer abstraction** (`src/analyze/tokens.ts`) — default heuristic (zero-dep, word/punct/digit segmentation) + optional `--tokenizer=tiktoken` (dynamic import of `js-tiktoken`, added as `peerDependenciesMeta.optional`).
- **High-fidelity simulator** (`src/analyze/simulate.ts`) — replays dedup (with directional window + per-tool `disable_dedup` override), redact, stacktrace, profile, byte-trim, and Read clamp. Honors per-project `.tokenomy.json`, `disabled_tools`, and per-tool aggression overrides exactly like the live `dispatch()`.
- **Fancy ANSI renderer** (`src/analyze/render.ts`) — rounded-box header, per-rule bar charts, top-N leaderboard, duplicate hotspots, outliers, by-day sparkline. Auto-disables color for non-TTY / `--no-color`.

### Supporting changes
- **Case-insensitive profile + tool-override glob matching** — one set of built-in profiles now works across Claude Code's CamelCase names and Codex's lowercase snake_case variants.
- **New `github-pr-codex` profile** — matches Codex-style `fetch_pr`, `get_pr_info`, `search_prs` method names.
- **`tokenomy analyze` CLI** — `--path`, `--since` (ISO/Nd/Nw/Nmo/all), `--project`, `--session`, `--top`, `--tokenizer`, `--json`, `--no-color`, `--verbose`. Defaults to last 30 days.

### Docs
- **README** repositioned as a toolkit for Claude Code AND Codex CLI. New agent-support matrix, separate quickstart paths, full `tokenomy analyze` section with sample output.
- **CONTRIBUTING** updated to reflect `src/analyze/` module layout + agent-agnostic principle.
- **CHANGELOG** documents every added file and knob.

## Codex-CLI verification

Per the PR request, the branch was audited with `codex review --base main` **eight times**. Each pass surfaced real correctness issues — all addressed in a dedicated follow-up commit:

1. **Round 1** — Codex parser used wrong schema (P1); stacktrace double-counted (P1); non-MCP PostToolUse simulated (P2); `shouldApply` gate skipped (P2); dedup `window_seconds` unenforced (P2).
2. **Round 2** — session/project from metadata not paths (P1); default 30d window (P2); per-tool config + `disabled_tools` (P2); hotspots session-scoped (P2).
3. **Round 3** — Codex namespace preserved in tool name (P1); CLI wrapper stripped from outputs (P1); per-project config cache (P2); timestamp-ordered replay across sidechain files (P2).
4. **Round 4** — streaming (no global buffer, P1); per-tool `disable_dedup` (P2); Read-clamp uses actual text newline count (P2); hotspots credit only simulator-confirmed duplicates (P3).
5. **Round 5** — Read-clamp threshold uses raw bytes (P2); dedup ledger records every first call (P2); directional dedup window (P2); `__` separator for Codex MCP names so profiles match (P2).
6. **Round 6** — defer Codex JSON decoding to MCP-only tools (P1); case-insensitive profile globs (P2); reject malformed `--since` (P3); validate `--top` (P3).
7. **Round 7** — wrap bare Codex MCP JSON into `{content:[...]}` (P1); bounded per-key ledger with window-filtered duplicate search (P2).
8. **Round 8** — use Codex's `Original token count: N` directly (P2); Codex-style GitHub PR profile (P2); analyze price from merged config (P3).

After round 8 the branch went through the review loop; remaining findings would be diminishing returns.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 179/179 passing
- [x] `npm run build` produces a working dist
- [x] `tokenomy analyze --since 30d` exercised against real `~/.claude` + `~/.codex` transcripts: 798 tool calls across 9 sessions ingested, no crashes, Codex namespaced tools correctly normalized
- [x] `tokenomy analyze --tokenizer=tiktoken` errors cleanly when `js-tiktoken` is missing
- [x] `tokenomy analyze --since lastweek` rejects malformed input with a helpful message
- [x] `tokenomy analyze --top 0` clamps to default 10 with a warning
- [ ] Run CI on Node 20 + 22
- [ ] After merge: `npm publish --tag alpha`

🤖 Generated with [Claude Code](https://claude.com/claude-code)