### PR TITLE
fix(logo): use mark-primary-512-2x everywhere instead of the wide wor…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 <div align="center">
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/RahulDhiman93/Tokenomy/main/src/assets/png/wordmark-wide-dark.png">
-  <img alt="Tokenomy" src="https://raw.githubusercontent.com/RahulDhiman93/Tokenomy/main/src/assets/png/wordmark-wide-light.png" width="480">
-</picture>
+<img alt="Tokenomy" src="https://raw.githubusercontent.com/RahulDhiman93/Tokenomy/main/src/assets/png/mark-primary-512-2x.png" width="160">
 
 </div>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,6 @@
 <div align="center">
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/RahulDhiman93/Tokenomy/main/src/assets/png/wordmark-wide-dark.png">
-  <img alt="Tokenomy" src="https://raw.githubusercontent.com/RahulDhiman93/Tokenomy/main/src/assets/png/wordmark-wide-light.png" width="480">
-</picture>
+<img alt="Tokenomy" src="https://raw.githubusercontent.com/RahulDhiman93/Tokenomy/main/src/assets/png/mark-primary-512-2x.png" width="160">
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 <div align="center">
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/RahulDhiman93/Tokenomy/main/src/assets/png/wordmark-wide-dark.png">
-  <img alt="Tokenomy" src="https://raw.githubusercontent.com/RahulDhiman93/Tokenomy/main/src/assets/png/wordmark-wide-light.png" width="720">
-</picture>
+<img alt="Tokenomy" src="https://raw.githubusercontent.com/RahulDhiman93/Tokenomy/main/src/assets/png/mark-primary-512-2x.png" width="200">
 
 ### Stop burning tokens on tool chatter.
 
@@ -506,10 +503,7 @@ MIT — see [LICENSE](./LICENSE).
 
 <div align="center">
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/RahulDhiman93/Tokenomy/main/src/assets/png/mark-A-bracket-t-reversed.png">
-  <img alt="Tokenomy mark" src="https://raw.githubusercontent.com/RahulDhiman93/Tokenomy/main/src/assets/png/mark-primary-64.png" width="48" height="48">
-</picture>
+<img alt="Tokenomy mark" src="https://raw.githubusercontent.com/RahulDhiman93/Tokenomy/main/src/assets/png/mark-primary-512-2x.png" width="56">
 
 *Save tokens. Save money. Save the rainforest — or at least your API bill.*
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,6 @@
 <div align="center">
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/RahulDhiman93/Tokenomy/main/src/assets/png/wordmark-wide-dark.png">
-  <img alt="Tokenomy" src="https://raw.githubusercontent.com/RahulDhiman93/Tokenomy/main/src/assets/png/wordmark-wide-light.png" width="480">
-</picture>
+<img alt="Tokenomy" src="https://raw.githubusercontent.com/RahulDhiman93/Tokenomy/main/src/assets/png/mark-primary-512-2x.png" width="160">
 
 </div>
 


### PR DESCRIPTION
…dmark

Replace the <picture> wordmark blocks in README, CONTRIBUTING, SECURITY, and CHANGELOG with a single square mark-primary-512-2x.png. Also swap the README footer's mark-primary-64 + mark-A-bracket-t-reversed pair for the same 512-2x asset. Square 1024×1024 source renders crisply at every display density and removes the theme-aware <picture> complexity.

Widths: 200px on the README header, 160px on the other doc headers, 56px on the README footer.

<!--
Thanks for contributing to Tokenomy! Fill in the sections below and delete
any that genuinely don't apply. Keep the PR focused — one logical change per PR.
-->

## Summary

<!-- What changed and why. 1–3 sentences. Focus on behavior, not implementation. -->

## Surface

<!-- Which part of Tokenomy does this touch? Check all that apply. -->

- [ ] `PostToolUse` hook (MCP trim) — `src/rules/mcp-content.ts` / `src/hook/dispatch.ts`
- [ ] `PreToolUse` hook (Read clamp) — `src/rules/read-bound.ts` / `src/hook/pre-dispatch.ts`
- [ ] CLI — `src/cli/*`
- [ ] Config / types — `src/core/*`
- [ ] Install / settings-patch — `src/util/*`, `src/cli/init.ts`
- [ ] Tests only
- [ ] Docs / README / CONTRIBUTING
- [ ] CI / tooling
- [ ] Other (explain below)

## Why

<!--
The motivation. Examples:
- "Atlassian responses can come as a raw array, not {content:[...]} — passthrough bug in rule."
- "Users asked for a per-repo override that lowers read.clamp_above_bytes for monorepos with huge files."
-->

## How it works

<!--
A short walk-through of the change. For rules, show the before/after behavior on a
representative input. For init/uninstall, show the before/after settings.json shape.
-->

## Test plan

<!-- Markdown checklist of the checks you ran. Include exact commands. -->

- [ ] `npm test` green (report the test count: was / now)
- [ ] `npm run build` clean
- [ ] If touching rules: added at least one passthrough test + one trim test
- [ ] If touching init/uninstall: extended round-trip integration test
- [ ] End-to-end smoke against a tmp HOME:
  ```bash
  rm -rf /tmp/tok-smoke && mkdir -p /tmp/tok-smoke/.claude
  echo '{}' > /tmp/tok-smoke/.claude/settings.json
  HOME=/tmp/tok-smoke tokenomy init && HOME=/tmp/tok-smoke tokenomy doctor
  ```
- [ ] `tokenomy doctor` still 9/9 ✓ after install

## Invariants preserved

<!-- For rule changes, confirm these aren't violated. Delete lines that don't apply. -->

- [ ] Rule output never shrinks `content.length`
- [ ] Non-text MCP blocks (image, resource) keep their relative position
- [ ] Unknown top-level keys (`is_error`, etc.) flow through untouched
- [ ] Malformed stdin → exit 0 with empty stdout (fail-open)
- [ ] Exit code 2 is not used anywhere
- [ ] `Read` clamp preserves `file_path` and any other caller-supplied input keys

## Breaking changes

<!--
Flag any change to:
- ~/.claude/settings.json shape Tokenomy writes
- ~/.tokenomy/config.json schema
- ~/.tokenomy/savings.jsonl or debug.jsonl row shape
- ~/.tokenomy/installed.json manifest format
- Public CLI flags / subcommands
- Hook binary stdout JSON shape
-->

- [ ] No breaking changes
- [ ] Breaking change (describe migration path)

## Screenshots / logs

<!--
If you changed user-visible output (CLI, hook response, savings log), paste a sample.
-->

```
<paste here>
```

## Checklist

- [ ] Title follows `<type>(<scope>): <description>` (e.g. `feat(rules): add json-aware trim`)
- [ ] Rebased on `main`, no merge commits
- [ ] One logical change per PR (split unrelated cleanups)
- [ ] README / CONTRIBUTING / CHANGELOG updated if the change is user-visible
- [ ] `npm test` + `npm run build` green locally

<!--
By submitting this PR you agree your contribution is licensed under the project's MIT License.
-->
