### PR TITLE
fix(init): stage {"type":"module"} package.json alongside the built hook

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -60,6 +60,18 @@ const stageHookBinary = (): string => {
   cpSync(distSrc, stagedDist, { recursive: true });
   chmodSync(join(stagedDist, "hook", "entry.js"), 0o755);
 
+  // Tokenomy is authored as ESM ("type":"module" in package.json) but the
+  // staged `dist/` lives under `~/.tokenomy/bin/` where Node's module
+  // resolution has no package.json to inherit from. Without a marker file
+  // here, Node parses the .js files as CommonJS and the first `import`
+  // statement throws "Cannot use import statement outside a module".
+  // Dropping a minimal `{"type":"module"}` next to the staged dist fixes
+  // this regardless of where the user invokes the hook from.
+  writeFileSync(
+    join(tokenomyBinDir(), "package.json"),
+    JSON.stringify({ type: "module", private: true }, null, 2) + "\n",
+  );
+
   const wrapper = `#!/bin/sh
 exec /usr/bin/env node "$(dirname "$0")/dist/hook/entry.js" "$@"
 `;

--- a/tests/integration/init-uninstall.test.ts
+++ b/tests/integration/init-uninstall.test.ts
@@ -115,6 +115,23 @@ test("init --aggression updates existing config", () => {
   }
 });
 
+test("init: stages package.json {type:module} alongside the hook", () => {
+  const h = setupHome();
+  try {
+    mkdirSync(join(h.home, ".claude"), { recursive: true });
+    runInit({});
+    const pkgPath = join(h.home, ".tokenomy", "bin", "package.json");
+    assert.ok(existsSync(pkgPath), `expected staged package.json at ${pkgPath}`);
+    const parsed = JSON.parse(readFileSync(pkgPath, "utf8"));
+    // Without {"type":"module"} here Node parses the ESM-built dist/ as
+    // CommonJS and the first `import` throws → hook exits 1 under the
+    // doctor's smoke test.
+    assert.equal(parsed.type, "module");
+  } finally {
+    h.restore();
+  }
+});
+
 test("uninstall --purge removes ~/.tokenomy/", () => {
   const h = setupHome();
   try {


### PR DESCRIPTION
## Summary

Dogfooding Tokenomy on its own repo surfaced a real install-path bug: `tokenomy doctor` reported

```
✗ Smoke spawn hook (empty mcp call) — exit=1 elapsed=361ms stdoutBytes=0
```

Root cause: `stageHookBinary()` in `src/cli/init.ts` copies `dist/` to `~/.tokenomy/bin/dist/` but never drops a `package.json`. The project's top-level `package.json` declares `"type": "module"`, but Node's resolver walks up from the staged `.js` files and finds no marker — so it defaults to CommonJS and the first `import` statement throws `Cannot use import statement outside a module`. Every PostToolUse / PreToolUse hook invocation exits 1, meaning **no trim or clamp fires live** even though unit tests all pass (they run via `tsx` which doesn't hit this path).

## Fix

Write a minimal `{"type":"module","private":true}` into `~/.tokenomy/bin/package.json` during `stageHookBinary()`. Node's module-scope lookup finds this first and loads the staged dist correctly.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — **215/215** passing (was 214; added a regression test asserting the staged `package.json` has `type:"module"`)
- [x] `tokenomy init && tokenomy doctor` → **13/13 ✓** (was 12/13 with smoke failing)
- [x] Manual: `cat <sample.json> | ~/.tokenomy/bin/tokenomy-hook` → exit 0, empty stdout (was exit 1, stderr throw)
- [ ] CI green on Node 20 + 22
- [ ] Real live hook exercise in a fresh Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)