### PR TITLE
fix(pre-dispatch): resolve relative Read file_path against HookInput.cwd

### DIFF
--- a/src/hook/entry.ts
+++ b/src/hook/entry.ts
@@ -7,6 +7,23 @@ import { loadConfig } from "../core/config.js";
 import { tokenomyDir } from "../core/paths.js";
 import type { HookInput, PreHookInput } from "../core/types.js";
 
+// Returns a shallow, size-capped snapshot of the tool_input for diagnostics.
+// Strings longer than 200 chars are truncated; unknown types are stringified.
+const previewToolInput = (input: Record<string, unknown> | undefined): Record<string, unknown> => {
+  if (!input || typeof input !== "object") return {};
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(input)) {
+    if (typeof v === "string") {
+      out[k] = v.length > 200 ? v.slice(0, 200) + "…" : v;
+    } else if (typeof v === "number" || typeof v === "boolean" || v === null) {
+      out[k] = v;
+    } else {
+      out[k] = `<${typeof v}>`;
+    }
+  }
+  return out;
+};
+
 const debugLog = (entry: Record<string, unknown>): void => {
   try {
     const path = `${tokenomyDir()}/debug.jsonl`;
@@ -91,6 +108,10 @@ const main = async (): Promise<void> => {
         tool: preInput.tool_name,
         event: "PreToolUse",
         elapsed_ms: Date.now() - hookStart,
+        // Diagnostics for Phase-1 passthrough investigations: capture the
+        // first-order tool_input fields so we can see whether e.g. Claude
+        // Code sent a relative path or an explicit limit.
+        tool_input_preview: previewToolInput(preInput.tool_input),
       });
       if (preOut) process.stdout.write(JSON.stringify(preOut));
       process.exit(0);

--- a/src/hook/pre-dispatch.ts
+++ b/src/hook/pre-dispatch.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
 import type { Config, PreHookInput, PreHookOutput, SavingsLogEntry } from "../core/types.js";
 import { readBoundRule } from "../rules/read-bound.js";
 import { bashBoundRule } from "../rules/bash-bound.js";
@@ -6,6 +7,21 @@ import { estimateTokens } from "../core/gate.js";
 import { appendSavingsLog } from "../core/log.js";
 import { graphMetaPath, tokenomyGraphRootDir } from "../core/paths.js";
 import { resolveRepoId } from "../graph/repo-id.js";
+
+// Resolve tool_input.file_path against the HookInput.cwd before the rule
+// calls statSync(). Claude Code may send a path relative to the user's
+// prompt directory (e.g. "package-lock.json"); the spawned hook process
+// doesn't inherit that cwd, so a raw statSync() on the relative string
+// fails and the rule passes through, defeating the clamp. Absolute paths
+// pass through unchanged.
+const resolveReadPath = (input: PreHookInput): Record<string, unknown> => {
+  const ti = { ...(input.tool_input ?? {}) };
+  const raw = ti["file_path"];
+  if (typeof raw === "string" && raw.length > 0 && !isAbsolute(raw) && input.cwd) {
+    ti["file_path"] = resolve(input.cwd, raw);
+  }
+  return ti;
+};
 
 const graphHint = (cwd: string, cfg: Config): string | null => {
   if (!cfg.graph.enabled) return null;
@@ -26,7 +42,8 @@ const graphHint = (cwd: string, cfg: Config): string | null => {
 };
 
 const preDispatchRead = (input: PreHookInput, cfg: Config): PreHookOutput | null => {
-  const r = readBoundRule(input.tool_input ?? {}, cfg);
+  const resolved = resolveReadPath(input);
+  const r = readBoundRule(resolved, cfg);
   if (r.kind !== "clamp" || !r.updatedInput) return null;
 
   // Heuristic savings: we reduce the Read from its default (≈2000 lines) to

--- a/tests/unit/pre-dispatch.test.ts
+++ b/tests/unit/pre-dispatch.test.ts
@@ -56,6 +56,47 @@ test("preDispatch: appends graph-aware hint when a local graph snapshot exists",
   }
 });
 
+test("preDispatch: Read with relative file_path resolves against input.cwd", () => {
+  const home = mkdtempSync(join(tmpdir(), "tokenomy-pre-rel-"));
+  const repo = mkdtempSync(join(tmpdir(), "tokenomy-pre-rel-repo-"));
+  const prev = process.env["HOME"];
+  process.env["HOME"] = home;
+  try {
+    // 60KB file in the "project" dir — above the conservative 80KB default.
+    writeFileSync(join(repo, "big.json"), "x".repeat(90_000));
+
+    const output = preDispatch(
+      {
+        session_id: "s",
+        transcript_path: "/tmp/t",
+        cwd: repo, // Claude Code's CWD, NOT the hook subprocess's.
+        permission_mode: "default",
+        hook_event_name: "PreToolUse",
+        tool_name: "Read",
+        // Relative path — the regression we're protecting against. Before
+        // the fix, statSync() ran against process.cwd() of the hook
+        // subprocess, which had no 'big.json', so the rule returned
+        // "stat-failed" → passthrough → no clamp.
+        tool_input: { file_path: "big.json" },
+      },
+      {
+        ...DEFAULT_CONFIG,
+        log_path: join(home, ".tokenomy", "savings.jsonl"),
+      },
+    );
+    assert.ok(output, "expected a clamp output, got null (passthrough regression)");
+    const updated = output!.hookSpecificOutput.updatedInput as Record<string, unknown>;
+    assert.equal(typeof updated["limit"], "number");
+    // Resolved to absolute so Claude Code reads the right file.
+    assert.ok((updated["file_path"] as string).startsWith("/"));
+  } finally {
+    if (prev === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = prev;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
 test("preDispatch: Bash verbose command → bounded updatedInput", () => {
   const home = mkdtempSync(join(tmpdir(), "tokenomy-pre-bash-"));
   const prev = process.env["HOME"];


### PR DESCRIPTION
## Summary

Dogfood exposed that `Read package-lock.json` (relative path) never got clamped in real Claude Code sessions, even with the rule enabled and the file (91 KB) well over the 80 KB threshold. `debug.jsonl` showed `pre-passthrough` every time.

**Root cause:** Claude Code sends the user-typed path verbatim. `readBoundRule`'s `statSync(filePath)` runs against the hook subprocess's cwd (the shell that launched Claude Code, not the project). stat fails → rule returns passthrough.

**Fix:** In `preDispatchRead`, resolve relative paths against `input.cwd` (which Claude Code *does* populate correctly) before calling the rule. Absolute paths flow through unchanged. `readBoundRule` itself stays pure — the resolution is a pre-dispatch concern.

Also added `tool_input_preview` to the PreToolUse debug log for future regressions (truncates long strings, omits complex values).

## Verified end-to-end

Simulated Claude Code payload:
```json
{"cwd":"/Users/.../Tokenomy","tool_name":"Read","tool_input":{"file_path":"package-lock.json"}}
```
Hook output:
```json
{"hookSpecificOutput":{"updatedInput":{"file_path":"/Users/.../Tokenomy/package-lock.json","limit":1000},"additionalContext":"[tokenomy: clamped Read to 1000 lines of a ~89 KB file...]"}}
```

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — **222/222** (was 221; added regression test in `tests/unit/pre-dispatch.test.ts`)
- [x] Manual: piped a real relative-path payload through the staged hook → exit 0, correct clamp + absolute file_path returned
- [ ] CI green on Node 20 + 22
- [ ] Re-run Read prompt in a real Claude Code session → `pre-clamped` in debug log, `read-clamp` row in savings.jsonl

🤖 Generated with [Claude Code](https://claude.com/claude-code)