### PR TITLE
chore(release): 0.1.0-alpha.10 (re-publish of alpha.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.1.0-alpha.10] — 2026-04-20
+
+Re-publish of `0.1.0-alpha.9` under a fresh version tag — no code changes. The alpha.9 publish never landed on npm (previous release workflow never completed successfully for that tag); this bump lets the workflow ship the same commit without the duplicate-version guard tripping.
+
 ## [0.1.0-alpha.9] — 2026-04-20
 
 Dogfood-driven hardening release. Three real install-path bugs surfaced the moment we ran Tokenomy against its own repo; fixed alongside a Bash bounder UX improvement, cross-agent auto-registration, the first measured real-savings data, and a refreshed architecture diagram.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ If you only have Codex (no Claude Code) or prefer to register manually:
 codex mcp add tokenomy-graph -- tokenomy graph serve --path "$PWD"
 ```
 
-> **Still pre-`1.0`.** Every release carries an `-alpha.N` suffix and breaking changes may land on minor bumps — the [CHANGELOG](./CHANGELOG.md) calls them out. Users who want stability should pin a specific version: `npm install -g tokenomy@0.1.0-alpha.9`.
+> **Still pre-`1.0`.** Every release carries an `-alpha.N` suffix and breaking changes may land on minor bumps — the [CHANGELOG](./CHANGELOG.md) calls them out. Users who want stability should pin a specific version: `npm install -g tokenomy@0.1.0-alpha.10`.
 
 > **Upgrading?** `npm install -g tokenomy` again — the install runs idempotently; existing config + logs are preserved.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenomy",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "description": "Surgical Claude Code hook that transparently trims bloated MCP tool responses and clamps oversized file reads — stop burning tokens on tool chatter.",
   "type": "module",
   "engines": {

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,1 +1,1 @@
-export const TOKENOMY_VERSION = "0.1.0-alpha.9";
+export const TOKENOMY_VERSION = "0.1.0-alpha.10";


### PR DESCRIPTION
## Summary

Same code as `0.1.0-alpha.9`, new version tag so the release workflow can publish without tripping the duplicate-version guard again.

- `package.json`: `0.1.0-alpha.9` → `0.1.0-alpha.10`
- `src/core/version.ts`: matching bump
- README pin hint: alpha.9 → alpha.10
- CHANGELOG: new `[0.1.0-alpha.10]` section noting the re-publish; alpha.9 section kept for history.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — **225/225**
- [x] `npm run build` clean
- [ ] After merge, re-trigger the publish workflow. Expect success to npm + GitHub Packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)