### PR TITLE
feat(rules,analyze): enumeration trim fixes + probe detector + docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+Dogfood-driven pass at the trim pipeline's two worst failure modes: (1) enumeration-shaped MCP responses were being head+tail-trimmed so hard that callers had to probe items one at a time (net-negative savings); (2) clamping self-contained docs like source files. Five targeted fixes — surgical profiles for the specific Jira cases, a shape-heuristic fallback so new tools don't re-hit the same bug, a report-level signal that flags when this goes wrong, a caller opt-out primitive, and a Read-clamp exception for markdown.
+
+### Added
+
+- **Four Jira enumeration profiles** (`src/rules/profiles.ts`): `atlassian-jira-transitions`, `atlassian-jira-issue-types`, `atlassian-jira-projects`, `atlassian-confluence-spaces`. Row-keep style — `max_array_items` generous (50–100), `max_string_bytes` tight (120–200). Fixes the specific case where `getTransitionsForJiraIssue` was being trimmed to ~330 B and the agent had to probe transition IDs one-by-one to rediscover the list.
+- **Shape-heuristic fallback** (`src/rules/shape-trim.ts`, new). Stage 2.5 between profile match and byte-trim. When no profile applies and the response is over budget, detects homogeneous record arrays (top-level or wrapped in `{transitions|issues|values|results|data|entries|records: [...]}`) and compacts per-row (string trim + depth-limited nesting) instead of head+tail-slicing the JSON. Keeps row count intact so enumerations survive. Config: `cfg.mcp.shape_trim` (enabled/max_items/max_string_bytes).
+- **Wasted-probe detector in `tokenomy analyze`** (`src/analyze/report.ts`, `src/analyze/render.ts`). New `AggregateReport.wasted_probes[]` — 60s sliding-window session-scoped detector for ≥3 distinct-arg calls to the same tool. Rendered as a `⚠ Wasted-probe incidents` section. Surfaces the over-trim failure mode that the existing savings-first `by_tool` ranking hides.
+- **Caller-intent plumbing through the MCP pipeline.** `mcpContentRule` now actually uses `tool_input`. Two new primitives: `{_tokenomy: "full", ...args}` in tool input is a first-class opt-out (skip every stage, return passthrough); optional `TrimProfile.skip_when?: (input) => boolean` lets built-in or user profiles gate themselves on caller intent.
+- **Read clamp: markdown/doc passthrough** (`src/rules/read-bound.ts`). New `ReadRuleConfig.doc_passthrough_extensions` (default: `.md/.mdx/.rst/.txt/.adoc`) and `doc_passthrough_max_bytes` (default: 64 KB, aggression-scaled). Files matching both pass through unclamped — self-contained docs read poorly when offset-paged. Regular source files still clamp at the existing threshold.
+
+### Tests
+
+- +23 unit tests: 4 profile + 10 shape-trim (incl. MCP integration) + 6 wasted-probe + 4 Read-clamp doc-passthrough + 2 MCP caller opt-out. Full suite: 249/249 passing.
+
 ## [0.1.0-alpha.10] — 2026-04-20
 
 Re-publish of `0.1.0-alpha.9` under a fresh version tag — no code changes. The alpha.9 publish never landed on npm (previous release workflow never completed successfully for that tag); this bump lets the workflow ship the same commit without the duplicate-version guard tripping.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A surgical hook + analysis toolkit for **Claude Code and Codex CLI** that transp
 [![Node](https://img.shields.io/badge/node-%E2%89%A520-brightgreen)](#quickstart)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](#license)
 [![Phase](https://img.shields.io/badge/phase%204-alpha-blue)](#roadmap)
-[![Tests](https://img.shields.io/badge/tests-213%20passing-brightgreen)](#contribute)
+[![Tests](https://img.shields.io/badge/tests-249%20passing-brightgreen)](#contribute)
 
 </div>
 
@@ -50,10 +50,10 @@ Each live trim appends a row to `~/.tokenomy/savings.jsonl` with measured bytes-
 
 ## 💸 Real savings from one dogfood session
 
-Tokenomy was run on its own repo in a fresh Claude Code session exercising the standard test matrix (Bash verbose commands, Read on a large file, five graph MCP queries). `tokenomy report` output, verbatim:
+Tokenomy run on its own repo in a fresh Claude Code session (Bash verbose commands, Read on a large file, five graph MCP queries). `tokenomy report`, verbatim:
 
 ```
-Window:             2026-04-20T01:32:56Z  →  2026-04-20T01:55:10Z   (~22 minutes)
+Window:             2026-04-20T01:32:56Z → 2026-04-20T01:55:10Z   (~22 minutes)
 Total events:       14
 Bytes trimmed:      1,374,113 → 260,000   (−1,114,113)
 Tokens saved (est): 285,000
@@ -62,159 +62,95 @@ Tokens saved (est): 285,000
 Top tools by tokens saved
   Bash    11 calls   247,500 tok      (bash-bound:git-log / :find / :ls-recursive / :ps)
   Read     3 calls    37,500 tok      (read-clamp on 89 KB package-lock.json + 2 others)
-
-By reason
-  bash-bound   11 calls   247,500 tok
-  read-clamp    3 calls    37,500 tok
 ```
 
-**Per event: ~20,000 tokens saved on average.** `bash-bound` alone — a single feature — prevented ~250 K tokens from being sent back to the LLM in this 22-minute session. Extrapolated, a dev spending 4 agent-hours a day on a coding project hits ~$10/week of waste that Tokenomy reclaims, without changing their workflow.
-
-Numbers come from `~/.tokenomy/savings.jsonl` (one row per live trim, measured bytes-in / bytes-out) via `tokenomy report`. Reproduce with the dogfood playbook in `CONTRIBUTING.md`.
+~20 K tokens saved per event. A dev spending 4 agent-hours a day reclaims ~$10/week. Numbers come from `~/.tokenomy/savings.jsonl` — reproduce via `CONTRIBUTING.md`'s dogfood playbook.
 
 ---
 
 ## ⚡ Quickstart
 
-### Claude Code (full integration: live hooks + graph + analyze)
+**Claude Code** (full integration — live hooks + graph + analyze):
 
 ```bash
 npm install -g tokenomy
 tokenomy init          # patches ~/.claude/settings.json (backed up first)
 tokenomy doctor        # 13/13 ✓
-# restart Claude Code
+# restart Claude Code — then use it normally
 ```
 
-That's it. Use Claude Code normally. Tokenomy does the rest.
-
-### Codex CLI (graph MCP server + transcript analysis)
-
-Codex doesn't expose PostToolUse/PreToolUse hooks yet, so the live trim features are Claude-Code-only. But the two **agent-agnostic** features work great with Codex, and `tokenomy init --graph-path` auto-registers the graph MCP server with **both** Claude Code and Codex when each CLI is on your PATH:
+**Codex CLI** (graph MCP + transcript analysis; no live hooks yet — Codex doesn't expose the PreToolUse/PostToolUse contract). `tokenomy init --graph-path` auto-registers the graph MCP server with **both** agents when each CLI is on your PATH:
 
 ```bash
 npm install -g tokenomy
 tokenomy init --graph-path "$PWD"    # registers tokenomy-graph in both agents
 tokenomy graph build --path "$PWD"
-# Both Claude Code and Codex can now call build_or_update_graph /
-# get_minimal_context / get_impact_radius / get_review_context /
-# find_usages over stdio.
-
-tokenomy analyze                     # benchmarks ~/.claude and ~/.codex transcripts
+tokenomy analyze                     # benchmarks ~/.claude + ~/.codex transcripts
 ```
 
-If you only have Codex (no Claude Code) or prefer to register manually:
+Codex-only / manual registration: `codex mcp add tokenomy-graph -- tokenomy graph serve --path "$PWD"`.
 
-```bash
-codex mcp add tokenomy-graph -- tokenomy graph serve --path "$PWD"
-```
+> **Pre-`1.0`.** Every release is `-alpha.N`; breaking changes may land on minor bumps (see [CHANGELOG](./CHANGELOG.md)). Pin for stability: `npm install -g tokenomy@0.1.0-alpha.10`. Upgrade: re-run the install — idempotent; config + logs preserved. Bleeding edge: see [Development](#development).
 
-> **Still pre-`1.0`.** Every release carries an `-alpha.N` suffix and breaking changes may land on minor bumps — the [CHANGELOG](./CHANGELOG.md) calls them out. Users who want stability should pin a specific version: `npm install -g tokenomy@0.1.0-alpha.10`.
-
-> **Upgrading?** `npm install -g tokenomy` again — the install runs idempotently; existing config + logs are preserved.
-
-> **Want the bleeding edge?** Scroll to [Development](#development) for the clone-build-link flow.
-
-To watch the magic live:
-
-```bash
-tail -f ~/.tokenomy/savings.jsonl
-```
-
-Each row is one transparent trim. Sample from a real session:
+Watch trims live — `tail -f ~/.tokenomy/savings.jsonl`:
 
 ```jsonl
 {"ts":"...","tool":"mcp__claude_ai_Atlassian__searchJiraIssuesUsingJql","bytes_in":28520,"bytes_out":2800,"tokens_saved_est":6430,"reason":"mcp-content-trim"}
 {"ts":"...","tool":"Read","bytes_in":48920,"bytes_out":15000,"tokens_saved_est":8480,"reason":"read-clamp"}
 ```
 
-One-liner to tally:
-
-```bash
-grep -oE '"tokens_saved_est":[0-9]+' ~/.tokenomy/savings.jsonl \
-  | awk -F: '{s+=$2; n++} END{printf "trims: %d   tokens saved: %d\n", n, s}'
-```
+Tally one-liner: `grep -oE '"tokens_saved_est":[0-9]+' ~/.tokenomy/savings.jsonl | awk -F: '{s+=$2;n++}END{printf "trims:%d tokens:%d\n",n,s}'`.
 
 ---
 
 ## 🧠 How it actually works
 
 ```
-   ┌─────────────────────── Claude Code (live hooks) ─────────────────────────┐
-   │                                                                          │
-   │   user prompt → LLM → tool call                                          │
-   │                          │                                               │
-   │   ┌──────────────────────┼───────────────────────────────────────────┐  │
-   │   │                      ▼                                           │  │
-   │   │   PreToolUse (Read)   ──► tokenomy-hook ──► resolve cwd +       │  │
-   │   │                            │                  inject  limit: N  │  │
-   │   │                            │                                     │  │
-   │   │   PreToolUse (Bash)   ──► tokenomy-hook ──► rewrite command to  │  │
-   │   │                            │   `set -o pipefail; CMD            │  │
-   │   │                            │    | awk 'NR<=N'`                   │  │
-   │   │                      ▼     ▼                                     │  │
-   │   │                   tool runs (narrower)                           │  │
-   │   │                      │                                           │  │
-   │   │   PostToolUse (mcp__.*) ──► tokenomy-hook runs stages:          │  │
-   │   │                            dedup → redact → stacktrace →        │  │
-   │   │                            profile → byte-trim                   │  │
-   │   │                      ▼     ▼                                     │  │
-   │   │                   LLM sees the trimmed response                  │  │
-   │   └──────────────────────────────────────────────────────────────────┘  │
-   │                          │                                               │
-   │              savings.jsonl  ◄──  best-effort append                      │
-   │                          │                                               │
-   │              tokenomy report ─► TUI + HTML digest                        │
-   └──────────────────────────────────────────────────────────────────────────┘
+  Claude Code live hooks
+    PreToolUse (Read)  ─► clamp huge files (doc-passthrough for .md/.mdx/.rst/.txt/.adoc)
+    PreToolUse (Bash)  ─► rewrite `CMD` → `set -o pipefail; CMD | awk 'NR<=N'`
+    PostToolUse (mcp__.*) ─► dedup → redact → stacktrace → profile → shape-trim → byte-trim
+                             └─ `{_tokenomy:"full"}` in args = passthrough (caller opt-out)
+    every trim → ~/.tokenomy/savings.jsonl → `tokenomy report` (TUI + HTML)
 
-   ┌──────────────── Claude Code · Codex CLI (shared, stdio) ─────────────────┐
-   │                                                                          │
-   │   tokenomy-graph MCP   ──► 5 tools over stdio                            │
-   │                            • build_or_update_graph                       │
-   │                            • get_minimal_context                         │
-   │                            • get_impact_radius                           │
-   │                            • get_review_context                          │
-   │                            • find_usages                                 │
-   │                            (LRU-cached on meta.built_at)                 │
-   │                                                                          │
-   │   tokenomy analyze     ──► walks ~/.claude/projects + ~/.codex/sessions  │
-   │                            replays the full rule pipeline with a real   │
-   │                            tokenizer → fancy CLI dashboard               │
-   └──────────────────────────────────────────────────────────────────────────┘
+  Shared (Claude Code + Codex CLI, stdio)
+    tokenomy-graph MCP  ─► 5 tools: build_or_update_graph, get_minimal_context,
+                           get_impact_radius, get_review_context, find_usages
+                           (LRU-cached on meta.built_at)
+    tokenomy analyze    ─► walks ~/.claude/projects + ~/.codex/sessions,
+                           replays the full pipeline with a real tokenizer,
+                           surfaces Wasted-probe incidents (over-trim failure mode)
 ```
 
 ### Under the hood
 
-**Multi-stage MCP pipeline (`PostToolUse`).** For every `mcp__.*` response, Tokenomy runs four stages in order:
+**Multi-stage MCP pipeline (`PostToolUse`)**, stage order:
 
-1. **Duplicate dedup** — if this exact `(tool, canonicalized-args)` was seen earlier in the same session and is still within `cfg.dedup.window_seconds`, the body is replaced with a short pointer stub (`[tokenomy: duplicate of call #N at <time> — no refetch required.]`). Session-scoped ledger lives under `~/.tokenomy/dedup/<session>.jsonl`.
-2. **Secret redactor** — regex sweep catches AWS access keys, GitHub PATs, OpenAI/Anthropic API keys, Slack tokens, Stripe keys, Google API keys, JWTs, Bearer tokens, and PEM private key blocks. Replaced with `[tokenomy: redacted <kind>]`. Force-applies even when byte savings are below the gate threshold (security > tokens).
-3. **Stacktrace collapser** — detects Node, Python, Java, Ruby error shapes and keeps error header + first frame + last 3 frames, eliding the middle.
-4. **Schema-aware trim profiles** — parses JSON responses and keeps a curated set of keys (title/status/assignee/body/etc.), truncating long strings and overflowing arrays with explicit markers. Ships with built-ins for Atlassian Jira/Confluence, Linear, Slack, Gmail, and GitHub; users can register custom profiles in config.
-5. **Byte-trim fallback** — if stages 1–4 together still exceed `cfg.mcp.max_text_bytes`, the remaining text block is head+tail trimmed with an explicit `[tokenomy: elided N bytes]` marker. A footer block tells Claude how to re-invoke for full detail.
+1. **Caller opt-out.** If `tool_input._tokenomy === "full"`, skip every stage and return passthrough. Note: some strict MCP servers may reject the extra key — fallback is a per-tool `tools: {"<glob>": {disable_profiles: true}}` config override.
+2. **Duplicate dedup.** Same `(tool, canonicalized-args)` seen earlier in-session within `cfg.dedup.window_seconds` → body replaced by a pointer stub. Session-scoped ledger at `~/.tokenomy/dedup/<session>.jsonl`.
+3. **Secret redactor.** Regex sweep for AWS/GitHub/OpenAI/Anthropic/Slack/Stripe/Google keys, JWTs, Bearer tokens, PEM blocks → `[tokenomy: redacted <kind>]`. Force-applies regardless of gate (security > tokens).
+4. **Stacktrace collapser.** Node/Python/Java/Ruby — keeps header + first + last 3 frames.
+5. **Schema-aware profiles.** Keep a curated key-set (title/status/assignee/body/…), trim long strings, mark overflowing arrays. Built-ins for Atlassian Jira (issue, search, transitions, issue-types, projects) + Confluence (page, spaces) + Linear + Slack + Gmail + GitHub; users can register custom profiles. Optional `skip_when?(input)` predicate lets a profile opt out based on caller intent.
+6. **Shape-aware trim (fallback).** If no profile matched and the payload is still over budget, detect homogeneous row arrays (top-level or wrapped in `{transitions|issues|values|results|data|entries|records: [...]}`) and compact per-row instead of blind head+tail. Protects enumeration endpoints from losing rows.
+7. **Byte-trim fallback.** If the total still exceeds `cfg.mcp.max_text_bytes`, head+tail the remaining text with `[tokenomy: elided N bytes]` + a footer hinting Claude how to refetch full detail.
 
-`content.length` never shrinks, `is_error` flows through, non-text blocks (images, resources) pass through untouched, and unknown top-level keys are preserved. Each trim's `reason` reports which stages fired (e.g. `redact:3+profile:atlassian-jira-issue`).
+Invariants: `content.length` never shrinks, `is_error` flows through, non-text blocks (images, resources) pass untouched, unknown top-level keys preserved. `reason` reports which stages fired (e.g. `redact:3+profile:atlassian-jira-issue`, `shape-trim+mcp-content-trim`).
 
-**Read clamp (`PreToolUse`).** If the agent's `Read` call has an explicit `limit` or `offset`, passthrough — respect user intent. Otherwise, stat the file. Under threshold → passthrough. Over threshold → inject `limit: N` plus an `additionalContext` note so the agent knows it can offset-Read more regions.
+**Read clamp (`PreToolUse`).** Explicit `limit`/`offset` → passthrough. Self-contained docs (`.md/.mdx/.rst/.txt/.adoc` under `doc_passthrough_max_bytes`) → passthrough unclamped. Otherwise stat; under threshold → passthrough; over → inject `limit: N` + an `additionalContext` note so the agent knows it can offset-Read more regions.
 
-**Bash input-bounder (`PreToolUse`).** Detects output-focused shell invocations (`git log`, `find`, `ls -R`, `ps aux`, `docker logs`, `journalctl`, `kubectl logs`, `tree`) that aren't already bounded and rewrites the command to cap its output:
+**Bash input-bounder (`PreToolUse`).** Detects unbounded verbose shell invocations (`git log`, `find`, `ls -R`, `ps aux`, `docker logs`, `journalctl`, `kubectl logs`, `tree`) and rewrites to `set -o pipefail; <cmd> | awk 'NR<=200'`. Awk consumes producer output (no SIGPIPE); `pipefail` preserves exit codes. Excludes exit-status-sensitive commands (`git diff --exit-code`, `npm ls`, `git status --porcelain`), streaming forms (`-f`/`--follow`/`watch`/`top`), and destructive `find` actions (`-exec`, `-delete`). User pipelines, redirections, compound commands (`;`/`&&`/`||`), subshells, heredocs all passthrough. `head_limit` validated as integer in `[20, 10_000]` before interpolation (no command injection).
 
-```
-set -o pipefail; <your command> | awk 'NR<=200'
-```
-
-Awk consumes the producer's full output (no SIGPIPE) and prints the first N lines; `set -o pipefail` preserves the producer's real exit code so `git log` failing still returns non-zero. Defaults explicitly exclude exit-status-sensitive commands (`git diff --exit-code`, `npm ls`, `git status --porcelain`), streaming forms (`-f` / `--follow` / `watch` / `top`), and destructive `find` actions (`-exec`, `-delete`). User-owned pipelines (`find . | xargs rm`), redirections (`> file`), compound commands (`;`, `&&`, `||`), subshells, and heredocs all passthrough. `head_limit` is validated as an integer in `[20, 10_000]` before shell interpolation to rule out config-driven command injection.
-
-**Fail-open is a non-negotiable.** Malformed stdin, parse errors, unknown shapes → exit 0 with empty stdout (true passthrough). 10 MB stdin cap. 2.5 s internal timeout. Exit code 2 (blocking) is never used. Breaking the agent is worse than wasting tokens.
+**Fail-open is non-negotiable.** Malformed stdin / parse errors / unknown shapes → exit 0 with empty stdout. 10 MB stdin cap. 2.5 s internal timeout. Exit code 2 (blocking) never used. Breaking the agent is worse than wasting tokens.
 
 ---
 
 ## 🎛️ Configure
 
-`~/.tokenomy/config.json` (per-repo override: `./.tokenomy.json`).
+`~/.tokenomy/config.json` (per-repo override: `./.tokenomy.json`). Config changes take effect **immediately** — only the initial `init` requires a Claude Code restart.
 
 ```jsonc
 {
-  "aggression": "conservative",        // × 2 thresholds. balanced=× 1, aggressive=× 0.5
+  "aggression": "conservative",        // ×2 thresholds. balanced=×1, aggressive=×0.5
   "gate": {
     "always_trim_above_bytes": 40000,  // huge responses: always trim
     "min_saved_bytes":          4000,  // tiny savings: not worth the context-switch
@@ -225,12 +161,19 @@ Awk consumes the producer's full output (no SIGPIPE) and prints the first N line
     "per_block_head":      4000,
     "per_block_tail":      2000,
     "profiles":              [],       // user-defined schema-aware trim profiles
-    "disabled_profiles":     []        // names of built-in profiles to skip
+    "disabled_profiles":     [],       // names of built-in profiles to skip
+    "shape_trim": {                    // row-preserving fallback for unprofiled inventory responses
+      "enabled":          true,
+      "max_items":          50,
+      "max_string_bytes":  200
+    }
   },
   "read": {
-    "enabled":            true,
-    "clamp_above_bytes": 40000,
-    "injected_limit":      500
+    "enabled":                     true,
+    "clamp_above_bytes":          40000,
+    "injected_limit":               500,
+    "doc_passthrough_extensions": [".md", ".mdx", ".rst", ".txt", ".adoc"],
+    "doc_passthrough_max_bytes":  64000 // docs below this cap skip clamping
   },
   "redact": {
     "enabled":            true,
@@ -245,30 +188,25 @@ Awk consumes the producer's full output (no SIGPIPE) and prints the first N line
     "mcp__Atlassian__*": { "aggression": "aggressive" },
     "mcp__Linear__*":    { "disable_profiles": true }
   },
-  "perf": {
-    "p95_budget_ms":       50,         // doctor flags when hook p95 exceeds this
-    "sample_size":        100
-  },
-  "report": {
-    "price_per_million":    3.0        // USD/M tokens — used for ~$ saved estimate
-  },
+  "perf":   { "p95_budget_ms": 50, "sample_size": 100 },
+  "report": { "price_per_million": 3.0 },
   "log_path":       "~/.tokenomy/savings.jsonl",
   "disabled_tools": []
 }
 ```
 
-Common tweaks:
+Common tweaks — `tokenomy config set <key> <value>`:
 
 ```bash
-tokenomy config set aggression aggressive             # trim harder, save more
-tokenomy config set read.enabled false                # just do MCP, leave Read alone
+tokenomy config set aggression aggressive             # trim harder
+tokenomy config set read.enabled false                # leave Read alone
 tokenomy config set read.clamp_above_bytes 20000      # clamp 20 KB+ files
 tokenomy config set mcp.max_text_bytes 8000           # tighter MCP budget
-tokenomy config set dedup.window_seconds 600          # only dedup repeats within 10 min
-tokenomy config set redact.enabled false              # opt out of secret redaction
+tokenomy config set dedup.window_seconds 600          # 10-min dedup window
+tokenomy config set redact.enabled false              # opt out of redaction
 ```
 
-Config changes take effect **immediately** — no Claude Code restart needed. Only the initial `init` requires a restart.
+**Caller opt-out.** An agent that knows it needs the full response can pass `{"_tokenomy": "full", ...real_args}` in the MCP tool input — the pipeline skips every stage. Safer fallback: set `tools: {"<glob>": {"disable_profiles": true}}` for the specific tool (works even with strict MCP servers that reject unknown keys).
 
 ---
 
@@ -298,160 +236,114 @@ Every check has an actionable remediation hint on failure. For routine repair, r
 
 ## 📊 `tokenomy report`
 
-Once the hooks have been running for a while, `savings.jsonl` is hard to eyeball. `tokenomy report` turns it into a digest:
+Digest of `~/.tokenomy/savings.jsonl`:
 
 ```bash
-tokenomy report                          # TUI summary + writes ~/.tokenomy/report.html
-tokenomy report --since 2026-04-01       # filter by date
+tokenomy report                          # TUI + writes ~/.tokenomy/report.html
+tokenomy report --since 2026-04-01       # date filter
 tokenomy report --top 20                 # more tools in the ranking
-tokenomy report --json                   # machine-readable output
+tokenomy report --json                   # machine-readable
 tokenomy report --out /tmp/report.html   # custom HTML path
 ```
 
-Sample output:
-
 ```
-tokenomy report
-===============
-
-Window:            2026-04-16T10:00:00Z  →  2026-04-17T12:30:00Z
-Total events:      4
-Bytes trimmed:     185,000 → 32,000  (−153,000)
-Tokens saved (est): 38,250
-~USD saved:        $0.1147
+Window:             2026-04-16T10:00:00Z → 2026-04-17T12:30:00Z
+Total events:       4   Bytes trimmed: 185,000 → 32,000   Tokens saved: 38,250   ~USD: $0.1147
 
 Top tools by tokens saved
-  mcp__Atlassian__getJiraIssue                  2 calls        16,750 tok
-  Read                                          1 calls        15,000 tok
-  mcp__Slack__slack_read_channel                1 calls         6,500 tok
+  mcp__Atlassian__getJiraIssue     2×   16,750 tok
+  Read                             1×   15,000 tok
+  mcp__Slack__slack_read_channel   1×    6,500 tok
 
 By reason
-  profile                   3 calls        23,250 tok
-  read-clamp                1 calls        15,000 tok
+  profile       3×   23,250 tok
+  read-clamp    1×   15,000 tok
 ```
 
-The HTML variant renders a daily bar chart you can screenshot for PR descriptions. Pricing is configurable — set `tokenomy config set report.price_per_million 15` for Opus-input rates.
+HTML variant adds a daily bar chart. Pricing: `tokenomy config set report.price_per_million 15` (Opus-input rate).
 
 ---
 
 ## 🔬 `tokenomy analyze`
 
-`report` shows what the live hooks already saved. `analyze` goes further: it walks the **raw session transcripts** of Claude Code (`~/.claude/projects/**/*.jsonl`) *and* Codex CLI (`~/.codex/sessions/**/*.jsonl`), replays the full Tokenomy rule pipeline over every historical tool call with a real tokenizer, and tells you exactly how much you *would have* saved if Tokenomy had been installed from day one — plus where the waste actually concentrates today.
+Where `report` shows live-hook savings, `analyze` walks the raw session transcripts — Claude Code (`~/.claude/projects/**/*.jsonl`) + Codex (`~/.codex/sessions/**/*.jsonl`) — replays the full pipeline over every historical tool call with a real tokenizer, and reports what Tokenomy *would have* saved.
 
 ```bash
-tokenomy analyze                              # default: scan last 30 days, top 10 tools
-tokenomy analyze --since 7d                   # last week
-tokenomy analyze --since 2026-04-01           # from a specific date
-tokenomy analyze --project Tokenomy           # filter by project dir substring
-tokenomy analyze --session 6689da94           # one session
-tokenomy analyze --tokenizer tiktoken         # accurate cl100k counts (see below)
-tokenomy analyze --json                       # machine-readable
-tokenomy analyze --verbose                    # include per-day breakdown
+tokenomy analyze                          # last 30d, top 10 tools
+tokenomy analyze --since 7d               # last week
+tokenomy analyze --project Tokenomy       # project-dir substring filter
+tokenomy analyze --session 6689da94       # one session
+tokenomy analyze --tokenizer tiktoken     # accurate cl100k counts (see below)
+tokenomy analyze --json                   # machine-readable
+tokenomy analyze --verbose                # per-day breakdown
 ```
 
-The default output is a fancy CLI dashboard: rounded-box header, per-rule savings bars, top-N waste leaderboard, duplicate hotspots, largest individual tool results, and an inline sparkline by day. Pipe to a file or use `--no-color` to disable ANSI.
+Output: rounded-box header, per-rule savings bars, top-N waste leaderboard, duplicate hotspots, **⚠ Wasted-probe incidents** (same tool, ≥3 distinct-arg calls within 60s — surfaces over-trim failure mode), largest individual results, by-day sparkline. `--no-color` to disable ANSI.
 
-### Tokenizer choice
-
-- **`heuristic`** (default) — zero-dep word/punctuation splitter calibrated for code + JSON. Accurate to ~±10% on typical tool responses.
-- **`tiktoken`** — real `cl100k_base` counts via `js-tiktoken`. A solid Claude-token approximation (Anthropic doesn't publish Claude 4's BPE). Install with `npm i -g js-tiktoken` and pass `--tokenizer=tiktoken`.
-- **`auto`** — use tiktoken if present, else heuristic.
-
-### Sample output
+**Tokenizers.** `heuristic` (default, zero-dep, ~±10% on code/JSON); `tiktoken` (real `cl100k_base` via `js-tiktoken` — `npm i -g js-tiktoken` then `--tokenizer=tiktoken`); `auto` picks tiktoken if present.
 
 ```
-╭────────────────────────── tokenomy analyze ──────────────────────────╮
-│ Window: 2026-04-17T10:00:00Z  →  2026-04-18T19:59:18Z                │
-│ Tokenizer: heuristic (approximate)                                   │
-╰──────────────────────────────────────────────────────────────────────╯
+╭──────────── tokenomy analyze ────────────╮
+│ Window: 2026-04-17 → 2026-04-18          │
+│ Tokenizer: heuristic (approximate)       │
+╰──────────────────────────────────────────╯
 
 Summary
-  Files scanned              4     Sessions       2
-  Tool calls parsed        299     Duplicate calls 1
-  Tokens observed       89,562     ~USD observed  $0.2687
-  Tokens Tokenomy would save  1,926  (2.2% of observed)
-  ~USD Tokenomy would save   $0.0058
+  Files 4   Sessions 2   Tool calls 299   Duplicates 1
+  Observed 89,562 tok ($0.2687)   Tokenomy would save 1,926 (2.2%)
 
 Savings by rule
-  Duplicate-response dedup       ████████████████████████   1,926 tok
-  Read clamp                     ████░░░░░░░░░░░░░░░░░░░░     324 tok
+  Duplicate-response dedup   ████████████████████████   1,926 tok
+  Read clamp                 ████░░░░░░░░░░░░░░░░░░░░     324 tok
 
-Duplicate hotspots  (same args, repeated within a session)
-  Read                     2×      2,263 tok wasted
-  Read                     2×      1,965 tok wasted
-  ...
+Duplicate hotspots (same args)
+  Read   2×   2,263 tok wasted
+
+⚠ Wasted-probe incidents (≥3 distinct-arg calls / 60s)
+  mcp__Atlassian__getTransitionsForJiraIssue   4×   10:00:00→10:00:45   2,400 tok observed
 ```
 
-`analyze` never modifies anything; it just reads. The transcript parser handles both Claude Code's `assistant.message.content[].tool_use` → `user.message.content[].tool_result` pairing and Codex CLI's `payload.tool_call` rollout shape.
+`analyze` is read-only. The parser handles Claude Code's `assistant.content[].tool_use` → `user.content[].tool_result` pairing and Codex's `payload.tool_call` rollout shape.
 
 ---
 
 ## 🕸️ Code-graph MCP server (agent-agnostic, Phase 3)
 
-Once the live hooks stop bleeding tokens on tool chatter, the next waste is the agent reading half a codebase to find one function. The optional **`tokenomy-graph` MCP server** gives the agent five surgical tools over stdio — the graph is built once, queries return focused neighborhoods, budgets are hard-capped. Works with both Claude Code and Codex CLI.
-
-### Install + register (both agents in one command)
+Once live hooks stop bleeding tokens on tool chatter, the next waste is the agent reading half a codebase to find one function. **`tokenomy-graph`** gives the agent five surgical tools over stdio — graph built once, queries return focused neighborhoods, budgets hard-capped. Works with Claude Code + Codex.
 
 ```bash
 npm install -g typescript              # peer-optional; required for the graph
 tokenomy init --graph-path "$PWD"      # registers with Claude Code AND Codex
-                                       #   • writes ~/.claude.json mcpServers entry
-                                       #   • shells out to `codex mcp add` if Codex is on PATH
-tokenomy graph build --path "$PWD"     # parses TS/JS into ~/.tokenomy/graphs/<id>/
+                                       #   (writes ~/.claude.json, shells `codex mcp add` if on PATH)
+tokenomy graph build --path "$PWD"     # parses TS/JS → ~/.tokenomy/graphs/<id>/
 tokenomy doctor                        # 13/13 ✓
 # fully quit + relaunch Claude Code (Cmd+Q) so it reloads MCP servers
-```
 
-Verify:
+# verify
+claude mcp list | grep tokenomy
+codex mcp list | grep tokenomy        # (Codex path, if used)
 
-```bash
-claude mcp list | grep tokenomy        # ✓ Connected
-codex mcp list | grep tokenomy         # tokenomy-graph ...   (if you use Codex)
-```
-
-### Manual registration (if you only run Codex)
-
-```bash
+# manual registration (Codex-only)
 codex mcp add tokenomy-graph -- tokenomy graph serve --path "$PWD"
 ```
 
-### The five tools
+**The five tools:**
 
 | Tool | Input | Output | Budget |
 |---|---|---|---|
 | `build_or_update_graph` | `{force?, path?}` | build stats | 4 KB |
-| `get_minimal_context` | `{target: {file, symbol?}, depth?}` | focal + ranked neighbors (imports/exports/contains) | 4 KB |
-| `get_impact_radius` | `{changed: [{file, symbols?}], max_depth?}` | reverse deps + suggested tests | 6 KB |
-| `get_review_context` | `{files: [...]}` | fanout + hotspots across changed files | 1 KB |
-| `find_usages` | `{target: {file, symbol?}}` | direct callers, references, importers (forward lookup) | 4 KB |
+| `get_minimal_context` | `{target:{file,symbol?}, depth?}` | focal + ranked neighbors | 4 KB |
+| `get_impact_radius` | `{changed:[{file,symbols?}], max_depth?}` | reverse deps + suggested tests | 6 KB |
+| `get_review_context` | `{files:[...]}` | fanout + hotspots across changed files | 1 KB |
+| `find_usages` | `{target:{file,symbol?}}` | direct callers, references, importers | 4 KB |
 
-Stale detection is always-on: queries return `{stale, stale_files}` so the agent knows whether to trust the result. `tokenomy graph build --force` regenerates. An in-memory LRU cache keyed on `(tool, args, meta.built_at)` keeps repeated queries fast and auto-invalidates when the graph is rebuilt.
+Stale detection always-on (`{stale, stale_files}` on every query); `tokenomy graph build --force` regenerates. In-memory LRU cache keyed on `(tool, args, meta.built_at)` auto-invalidates on rebuild.
 
-### Good prompt to test it
+**Good prompt to test it:** *"Call `build_or_update_graph` if needed, then `get_minimal_context` for `{\"target\":{\"file\":\"src/index.ts\"},\"depth\":1}`, then `get_review_context` for `{\"files\":[\"src/index.ts\",\"src/foo.ts\"]}`. Only use Read if the graph result is insufficient."*
 
-> First call `build_or_update_graph` if needed.
-> Then call `get_minimal_context` for `{"target":{"file":"src/index.ts"},"depth":1}`.
-> Then call `get_review_context` for `{"files":["src/index.ts","src/foo.ts"]}`.
-> Only use `Read` if the graph result is insufficient.
+**Dev CLI (no MCP needed):** `tokenomy graph status | query minimal|impact|review|usages | purge [--all]`.
 
-### Dev CLI (no MCP needed)
-
-```bash
-tokenomy graph status --path "$PWD"
-tokenomy graph query minimal --path "$PWD" --file src/index.ts
-tokenomy graph query impact  --path "$PWD" --file src/index.ts
-tokenomy graph query review  --path "$PWD" --files src/index.ts,src/foo.ts
-tokenomy graph query usages  --path "$PWD" --file src/foo.ts
-tokenomy graph purge [--all]
-```
-
-### Scope + limits (v1)
-
-- **TypeScript + JavaScript only** (`.ts`/`.tsx`/`.js`/`.jsx`/`.mjs`/`.cjs`, with `.mts`/`.cts` probed). Python / 23-lang support explicitly out of scope.
-- **Soft cap 2 000 files, hard cap 5 000** — larger repos abort cleanly with `repo-too-large`.
-- **AST-only** via the TypeScript compiler API (no type checker); type-only imports and JSX element references skipped in v1.
-- **No `tsconfig.paths`, no `node_modules` resolution** — bare specifiers become `external-module` nodes. Will revisit in v2.
-- **Fail-open always:** every tool and CLI subcommand returns `{ok: false, reason}` rather than throwing; graph features never break the core hook path.
+**Scope + limits (v1).** TypeScript + JavaScript only (`.ts/.tsx/.js/.jsx/.mjs/.cjs`, `.mts/.cts` probed). Soft cap 2 000 files, hard cap 5 000 (abort with `repo-too-large`). AST-only via TypeScript compiler API (no type checker); type-only imports + JSX element references skipped. No `tsconfig.paths`, no `node_modules` resolution — bare specifiers become `external-module` nodes. Fail-open: every tool returns `{ok: false, reason}` rather than throwing.
 
 ---
 
@@ -478,78 +370,57 @@ Removes both hook entries from `~/.claude/settings.json` (matched by absolute co
 
 ## 🤝 Contribute
 
-Contributions are very welcome. The repo is still small, dependency-light (zero runtime deps in the hot hook path; `@modelcontextprotocol/sdk` loaded dynamically for the graph server only; `js-tiktoken` is an optional peer dep for accurate `analyze` token counts), and test-first (213/213 currently green).
+Contributions welcome. Dependency-light (zero runtime deps in the hot hook path; `@modelcontextprotocol/sdk` loaded dynamically for the graph server; `js-tiktoken` optional peer for accurate `analyze`), test-first (249/249 currently green, 96% stmt / 85% branch / 100% func coverage).
 
-### Good first issues
+**Good first issues:**
 
-| Difficulty | What | Where |
+| Level | What | Where |
 |---|---|---|
-| 🟢 easy | Add a synthetic fixture for a real-world MCP tool you use (Asana, HubSpot, etc.) and a rule-level test | `tests/fixtures/` + `tests/unit/mcp-content.test.ts` |
-| 🟢 easy | Add more `analyze` transcript parser support (other Codex rollout shapes, OpenCode, Aider) | `src/analyze/parse.ts` |
-| 🟡 medium | Add a built-in trim profile for another MCP server you use | `src/rules/profiles.ts` |
-| 🟡 medium | Statusline script (`bin/tokenomy-statusline`) that consumes Claude Code's statusline stdin and renders live savings | new `src/statusline/` |
-| 🔴 hard | Phase 4 Bash input-bounder — shell-aware parsing to detect commands lacking any existing bound | new `src/rules/bash-bound.ts` |
-| 🔴 hard | Python parser plugin for the graph MCP server — spawn `python -c "import ast"` and extract imports/defs | new `src/parsers/py/` |
+| 🟢 | Fixture + rule-level test for an MCP tool you use (Asana, HubSpot, …) | `tests/fixtures/` + `tests/unit/mcp-content.test.ts` |
+| 🟢 | More `analyze` parser support (other Codex shapes, OpenCode, Aider) | `src/analyze/parse.ts` |
+| 🟡 | Built-in trim profile for another MCP server | `src/rules/profiles.ts` |
+| 🟡 | Statusline script rendering live savings from Claude Code stdin | new `src/statusline/` |
+| 🔴 | Python parser plugin for the graph MCP server | new `src/parsers/py/` |
 
-### Architecture tour
+**Architecture tour:**
 
 ```
 src/
   core/     — types, config (+ per-tool overrides), paths, gate, log, dedup, recovery hint
-  rules/    — pure transforms: mcp-content, read-bound, bash-bound, text-trim, profiles, stacktrace, redact
-  hook/     — entry.ts + dispatch.ts + pre-dispatch.ts (stdin → rule → stdout)
-  analyze/  — transcript scanner (Claude Code + Codex), parse, tokens, simulate, report, render
-  graph/    — schema, build, stale detection, repo-id, query/{minimal,impact,review,usages,budget,common}
-  mcp/      — stdio server, tool handlers, schema definitions, query-cache (LRU), budget-clip
+  rules/    — pure transforms: mcp-content, read-bound, bash-bound, text-trim, profiles,
+              shape-trim, stacktrace, redact
+  hook/     — entry + dispatch + pre-dispatch (stdin → rule → stdout)
+  analyze/  — scanner (Claude Code + Codex), parse, tokens, simulate, report, render
+  graph/    — schema, build, stale detection, repo-id, query/{minimal,impact,review,usages,…}
+  mcp/      — stdio server, tool handlers, query-cache (LRU), budget-clip
   parsers/  — TS/JS AST extraction
   cli/      — init, doctor (+ --fix), uninstall, config-cmd, report, analyze, graph, entry
   util/     — settings-patch, manifest, atomic-write, backup, json helpers
 
 tests/
   unit/         — one file per module, ≥1 trim + ≥1 passthrough per rule
-  integration/  — spawn compiled dist/hook/entry.js or dist/cli/entry.js as subprocess
+  integration/  — spawn compiled dist/hook/entry.js or dist/cli/entry.js
   fixtures/     — synthetic graph repos + synthesized transcripts for analyze
 ```
 
-Rules are pure functions: `(toolName, toolInput, toolResponse, config) → { kind: "passthrough" | "trim", ... }`. Adding a new rule is a one-file drop-in.
+Rules are pure: `(toolName, toolInput, toolResponse, config) → { kind: "passthrough" | "trim", ... }`. New rule = one-file drop-in.
 
-### Development
-
-Clone, build, and `npm link` so the `tokenomy` command points at your local checkout:
+**Development:**
 
 ```bash
-git clone https://github.com/RahulDhiman93/Tokenomy.git
-cd Tokenomy
-npm install
-npm run build        # tsc + chmod +x
-npm test             # node:test runner, 213 tests, ~2 s
-npm run coverage     # c8 → coverage/lcov.info + HTML report
+git clone https://github.com/RahulDhiman93/Tokenomy && cd Tokenomy
+npm install && npm run build
+npm test             # 249 tests, ~2s
+npm run coverage     # c8 → coverage/lcov.info + HTML
 npm run typecheck    # tsc --noEmit
-npm link             # overrides any installed `tokenomy` with your local build
+npm link             # point `tokenomy` at your local build
 tokenomy doctor      # 13/13 ✓
-tokenomy analyze     # benchmarks your real transcripts
+# revert: npm unlink -g tokenomy && npm install -g tokenomy
 ```
 
-Revert to the published version later with `npm unlink -g tokenomy && npm install -g tokenomy`.
+**Guiding principles.** (1) Fail-open always — broken hook worse than no hook; never exit 2. (2) Schema invariants over trust — outputs never fabricate keys, flip types, shrink arrays. (3) Path-match over markers — uninstall identifies entries by absolute command path. (4) Measure before bragging — no "X % savings" claims without Phase 2 benchmark data. (5) Small + legible — a dozen lines aren't worth a 200 KB install.
 
-Current coverage: **96 % statements · 85 % branches · 100 % functions.**
-
-### Guiding principles
-
-1. **Fail-open always.** A broken hook is worse than no hook. Never exit 2, never break Claude's workflow.
-2. **Schema invariants over trust.** Test that rule outputs never fabricate keys, flip types, or shrink arrays.
-3. **Path-match over markers.** Uninstall identifies entries by absolute command path, not by injected `_tokenomy: true` keys — Claude Code's schema may tighten tomorrow.
-4. **Measure before bragging.** No "X % savings" claims in code or docs until Phase 2 benchmarks them against a real corpus.
-5. **Small and legible.** If a dependency shaves a dozen lines at the cost of a 200 KB install, it's a no.
-
-### Before opening a PR
-
-- `npm test` green (including any new unit + integration tests for your change)
-- If you touched a rule: add a fixture-pair or inline-assertion test for passthrough *and* trim cases
-- If you touched `init`/`uninstall`: extend the round-trip integration test
-- If you added a config field: document in the README config block
-
-Questions? Open a discussion. This is an alpha — design-level feedback is as welcome as code.
+**Before opening a PR.** `npm test` green (including new unit + integration). Touched a rule → add passthrough *and* trim tests. Touched `init`/`uninstall` → extend the round-trip integration test. Added a config field → document in the Configure block above. Questions? Open a discussion — design feedback is as welcome as code.
 
 ---
 

--- a/src/analyze/render.ts
+++ b/src/analyze/render.ts
@@ -209,6 +209,27 @@ export const render = (report: AggregateReport, opts: RenderOptions): string => 
     out.push("");
   }
 
+  // Wasted-probe incidents. Different from dedup hotspots — these are
+  // runs of DIFFERENT args to the same tool in a tight window, which
+  // usually means an over-aggressive trim destroyed the enumeration and
+  // the agent had to rediscover items one at a time.
+  if (report.wasted_probes.length > 0) {
+    out.push(
+      `${c.yellow}⚠ Wasted-probe incidents${c.reset}  ` +
+        `${c.dim}(≥3 distinct-arg calls to same tool within 60s — likely over-trimmed enumeration)${c.reset}`,
+    );
+    for (const p of report.wasted_probes) {
+      const start = p.first_ts.slice(11, 19);
+      const end = p.last_ts.slice(11, 19);
+      out.push(
+        `  ${pad(p.tool, 40)}  ${pad(n(p.call_count) + "×", 7, "r")}  ` +
+          `${c.dim}${start}→${end}${c.reset}  ` +
+          `${c.red}${pad(n(p.observed_tokens), 12, "r")}${c.reset} tok observed`,
+      );
+    }
+    out.push("");
+  }
+
   // Outliers.
   if (report.outliers.length > 0) {
     out.push(`${c.bold}Largest individual tool results${c.reset}`);

--- a/src/analyze/report.ts
+++ b/src/analyze/report.ts
@@ -29,6 +29,19 @@ export interface AggregateReport {
     calls: number;
     wasted_tokens: number; // observed tokens of repeats beyond the first
   }>;
+  // Probe runs: same tool called ≥ PROBE_MIN_CALLS times within a session
+  // with distinct inputs inside a PROBE_WINDOW_SECONDS sliding window. Signals
+  // that a profile/shape-trim over-compressed an enumeration and the agent
+  // had to re-query to rediscover items. Net-negative savings — surfaces a
+  // failure mode that `by_tool` savings-first ranking hides.
+  wasted_probes: Array<{
+    tool: string;
+    session_id: string;
+    first_ts: string;
+    last_ts: string;
+    call_count: number;
+    observed_tokens: number;
+  }>;
   outliers: Array<{
     tool: string;
     tokens: number;
@@ -64,6 +77,21 @@ interface DayBucket {
   savings_tokens: number;
 }
 
+// Probe-run detection. Tuned conservatively: 3 calls (not 2 — one repeat is
+// often legitimate) to the same tool with DIFFERENT args within 60s marks
+// it as a run that a better trim would have prevented.
+const PROBE_WINDOW_SECONDS = 60;
+const PROBE_MIN_CALLS = 3;
+
+interface OpenProbeRun {
+  tool: string;
+  session_id: string;
+  first_ts: string;
+  last_ts: string;
+  call_keys: Set<string>;
+  observed_tokens: number;
+}
+
 export class Aggregator {
   private readonly opts: AggregatorOptions;
   private files = 0;
@@ -83,6 +111,12 @@ export class Aggregator {
   private byDay = new Map<string, DayBucket>();
   private byKey = new Map<string, KeyBucket>();
   private outliers: AggregateReport["outliers"] = [];
+  // Sliding-window probe detection. Open runs are keyed by session+tool.
+  // When a new call on the same (session, tool) is > PROBE_WINDOW_SECONDS
+  // after the run's last_ts, we close the run and start a fresh one. Only
+  // runs with ≥ PROBE_MIN_CALLS distinct call_keys survive into the report.
+  private probeOpen = new Map<string, OpenProbeRun>();
+  private probeClosed: AggregateReport["wasted_probes"] = [];
 
   constructor(opts: AggregatorOptions) {
     this.opts = opts;
@@ -160,6 +194,61 @@ export class Aggregator {
 
     // Maintain a top-N outliers list (by observed tokens).
     this.maybeRecordOutlier(e);
+
+    // Probe-run tracking: same tool, ≥ PROBE_MIN_CALLS distinct call_keys
+    // within a sliding PROBE_WINDOW_SECONDS window.
+    this.trackProbe(e);
+  }
+
+  private trackProbe(e: SimEvent): void {
+    if (!e.ts) return;
+    const runKey = `${e.session_id}\u0000${e.tool_name}`;
+    const open = this.probeOpen.get(runKey);
+    const curMs = Date.parse(e.ts);
+    if (!open) {
+      this.probeOpen.set(runKey, {
+        tool: e.tool_name,
+        session_id: e.session_id,
+        first_ts: e.ts,
+        last_ts: e.ts,
+        call_keys: new Set([e.call_key]),
+        observed_tokens: e.observed_tokens,
+      });
+      return;
+    }
+    const lastMs = Date.parse(open.last_ts);
+    const gapSeconds = Number.isFinite(curMs) && Number.isFinite(lastMs)
+      ? (curMs - lastMs) / 1000
+      : 0;
+    if (gapSeconds > PROBE_WINDOW_SECONDS) {
+      // Close the current run; start a new one for this event.
+      this.closeProbe(open);
+      this.probeOpen.set(runKey, {
+        tool: e.tool_name,
+        session_id: e.session_id,
+        first_ts: e.ts,
+        last_ts: e.ts,
+        call_keys: new Set([e.call_key]),
+        observed_tokens: e.observed_tokens,
+      });
+      return;
+    }
+    // Extend the run.
+    open.last_ts = e.ts;
+    open.call_keys.add(e.call_key);
+    open.observed_tokens += e.observed_tokens;
+  }
+
+  private closeProbe(run: OpenProbeRun): void {
+    if (run.call_keys.size < PROBE_MIN_CALLS) return;
+    this.probeClosed.push({
+      tool: run.tool,
+      session_id: run.session_id,
+      first_ts: run.first_ts,
+      last_ts: run.last_ts,
+      call_count: run.call_keys.size,
+      observed_tokens: run.observed_tokens,
+    });
   }
 
   private maybeRecordOutlier(e: SimEvent): void {
@@ -227,6 +316,13 @@ export class Aggregator {
 
     const outliers = [...this.outliers].sort((a, b) => b.tokens - a.tokens);
 
+    // Flush still-open probe runs into the closed list — they're complete
+    // from the aggregator's perspective (no more events will arrive).
+    for (const open of this.probeOpen.values()) this.closeProbe(open);
+    const wasted_probes = [...this.probeClosed]
+      .sort((a, b) => b.observed_tokens - a.observed_tokens)
+      .slice(0, top);
+
     const usd_saved = (this.savings_tokens / 1_000_000) * this.opts.price_per_million;
     const usd_observed = (this.observed_tokens / 1_000_000) * this.opts.price_per_million;
 
@@ -249,6 +345,7 @@ export class Aggregator {
       by_rule: byRule,
       by_day: byDay,
       hotspots,
+      wasted_probes,
       outliers,
       tokenizer: {
         name: this.opts.tokenizer_name,

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -13,11 +13,18 @@ export const DEFAULT_CONFIG: Config = {
     max_text_bytes: 16_000,
     per_block_head: 4_000,
     per_block_tail: 2_000,
+    shape_trim: {
+      enabled: true,
+      max_items: 50,
+      max_string_bytes: 200,
+    },
   },
   read: {
     enabled: true,
     clamp_above_bytes: 40_000,
     injected_limit: 500,
+    doc_passthrough_extensions: [".md", ".mdx", ".rst", ".txt", ".adoc"],
+    doc_passthrough_max_bytes: 64_000,
   },
   bash: {
     enabled: true,
@@ -115,6 +122,18 @@ const applyAggression = (cfg: Config): Config => {
       max_text_bytes: Math.round(cfg.mcp.max_text_bytes * m),
       per_block_head: Math.round(cfg.mcp.per_block_head * m),
       per_block_tail: Math.round(cfg.mcp.per_block_tail * m),
+      profiles: cfg.mcp.profiles,
+      disabled_profiles: cfg.mcp.disabled_profiles,
+      shape_trim: cfg.mcp.shape_trim
+        ? {
+            enabled: cfg.mcp.shape_trim.enabled,
+            max_items: cfg.mcp.shape_trim.max_items,
+            max_string_bytes: Math.max(
+              60,
+              Math.round(cfg.mcp.shape_trim.max_string_bytes * m),
+            ),
+          }
+        : undefined,
     },
     read: {
       enabled: cfg.read.enabled,
@@ -122,6 +141,8 @@ const applyAggression = (cfg: Config): Config => {
       // larger injected limit). Aggressive (×0.5) is stricter on both.
       clamp_above_bytes: Math.round(cfg.read.clamp_above_bytes * m),
       injected_limit: Math.max(50, Math.round(cfg.read.injected_limit * m)),
+      doc_passthrough_extensions: cfg.read.doc_passthrough_extensions,
+      doc_passthrough_max_bytes: Math.round(cfg.read.doc_passthrough_max_bytes * m),
     },
     bash: {
       ...cfg.bash,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -80,6 +80,17 @@ export interface McpRuleConfig {
   // Disable built-in profiles by name if a user wants to override them with
   // their own version without mutating the array from the CLI.
   disabled_profiles?: string[];
+  // Shape-aware fallback between profile match and byte trim. Kicks in for
+  // unprofiled inventory-shaped JSON responses (arrays of homogeneous
+  // records or {transitions|issues|values|results: [...]}) where head+tail
+  // byte trimming would destroy row structure.
+  shape_trim?: ShapeTrimConfig;
+}
+
+export interface ShapeTrimConfig {
+  enabled: boolean;
+  max_items: number;
+  max_string_bytes: number;
 }
 
 export interface RedactConfig {
@@ -92,6 +103,12 @@ export interface ReadRuleConfig {
   enabled: boolean;
   clamp_above_bytes: number;
   injected_limit: number;
+  // Files with these extensions (lowercase, incl. leading dot) passthrough
+  // unclamped when their size is <= doc_passthrough_max_bytes. Self-contained
+  // docs (READMEs, changelogs) read poorly when clamped — the agent wants the
+  // whole thing in one shot, not offset-paged.
+  doc_passthrough_extensions: string[];
+  doc_passthrough_max_bytes: number;
 }
 
 export interface BashRuleConfig {

--- a/src/rules/mcp-content.ts
+++ b/src/rules/mcp-content.ts
@@ -5,6 +5,7 @@ import { headTailTrim, utf8Bytes } from "./text-trim.js";
 import { BUILTIN_PROFILES, applyProfile, selectProfile } from "./profiles.js";
 import { collapseStacktrace } from "./stacktrace.js";
 import { redactSecrets, BUILTIN_PATTERNS } from "./redact.js";
+import { shapeTrim } from "./shape-trim.js";
 
 const isTextBlock = (b: McpContentBlock): b is { type: "text"; text: string } =>
   b.type === "text" && typeof (b as { text?: unknown }).text === "string";
@@ -22,11 +23,18 @@ const activeProfiles = (cfg: Config) => {
 // blocks that were compressed by a profile.
 const applyProfilesToBlocks = (
   toolName: string,
+  toolInput: Record<string, unknown>,
   blocks: McpContentBlock[],
   cfg: Config,
 ): { blocks: McpContentBlock[]; applied: number; profileName: string | null } => {
   const profile = selectProfile(toolName, activeProfiles(cfg));
   if (!profile) return { blocks, applied: 0, profileName: null };
+  // Caller-intent gate: profiles can opt out when the input signals the
+  // agent needs the full payload (e.g. `searchJiraIssuesUsingJql` with a
+  // tight maxResults).
+  if (profile.skip_when && profile.skip_when(toolInput)) {
+    return { blocks, applied: 0, profileName: null };
+  }
 
   let applied = 0;
   const next = blocks.map((b) => {
@@ -39,8 +47,17 @@ const applyProfilesToBlocks = (
   return { blocks: next, applied, profileName: profile.name };
 };
 
-export const mcpContentRule: Rule = (toolName, _toolInput, toolResponse, cfg) => {
+export const mcpContentRule: Rule = (toolName, toolInput, toolResponse, cfg) => {
   if (!toolResponse || typeof toolResponse !== "object") return { kind: "passthrough" };
+
+  // First-class caller opt-out: `{_tokenomy: "full", ...real_args}` in the
+  // tool input is a signal from the agent that it knows it needs the
+  // complete response. Skip every stage. Note: some strict MCP servers may
+  // reject the extra key; users who hit that should prefer a per-tool
+  // `tools: {"<glob>": {disable_profiles: true}}` config override instead.
+  if (toolInput && (toolInput as Record<string, unknown>)["_tokenomy"] === "full") {
+    return { kind: "passthrough" };
+  }
 
   // Claude Code surfaces MCP tool_response in one of two shapes:
   //   1. The raw content array, e.g. [{type:"text",text:"..."}]
@@ -97,11 +114,44 @@ export const mcpContentRule: Rule = (toolName, _toolInput, toolResponse, cfg) =>
   const profileResult =
     toolOverride?.disable_profiles === true
       ? { blocks: afterStacktrace, applied: 0, profileName: null as string | null }
-      : applyProfilesToBlocks(toolName, afterStacktrace, cfg);
-  const blocks = profileResult.blocks;
+      : applyProfilesToBlocks(toolName, toolInput as Record<string, unknown>, afterStacktrace, cfg);
+  let blocks = profileResult.blocks;
   let postProfileBytes = 0;
   for (const b of blocks) {
     if (isTextBlock(b)) postProfileBytes += utf8Bytes(b.text);
+  }
+
+  // Stage 2.5: shape-aware trim. When no profile matched and the response is
+  // still over budget, try to detect a homogeneous row array and compact it
+  // per-row instead of falling through to blind head+tail byte trim (which
+  // would destroy row structure for enumeration endpoints).
+  let shapeApplied = 0;
+  const shapeCfg = cfg.mcp.shape_trim;
+  const shapeEnabled =
+    shapeCfg?.enabled !== false && toolOverride?.disable_profiles !== true;
+  if (
+    shapeEnabled &&
+    profileResult.applied === 0 &&
+    postProfileBytes > cfg.mcp.max_text_bytes
+  ) {
+    const opts = {
+      max_items: shapeCfg?.max_items ?? 50,
+      max_string_bytes: shapeCfg?.max_string_bytes ?? 200,
+    };
+    const shaped = blocks.map((b) => {
+      if (!isTextBlock(b)) return b;
+      const r = shapeTrim(b.text, opts);
+      if (!r.ok || !r.trimmed) return b;
+      shapeApplied++;
+      return { type: "text" as const, text: r.trimmed };
+    });
+    if (shapeApplied > 0) {
+      blocks = shaped;
+      postProfileBytes = 0;
+      for (const b of blocks) {
+        if (isTextBlock(b)) postProfileBytes += utf8Bytes(b.text);
+      }
+    }
   }
 
   // If neither the original nor profile-compressed version exceeds the budget,
@@ -111,7 +161,8 @@ export const mcpContentRule: Rule = (toolName, _toolInput, toolResponse, cfg) =>
     if (
       profileResult.applied === 0 &&
       stacktraceApplied === 0 &&
-      redactCount === 0
+      redactCount === 0 &&
+      shapeApplied === 0
     ) {
       return { kind: "passthrough" };
     }
@@ -123,6 +174,7 @@ export const mcpContentRule: Rule = (toolName, _toolInput, toolResponse, cfg) =>
     if (redactCount > 0) reasonParts.push(`redact:${redactCount}`);
     if (stacktraceApplied > 0) reasonParts.push("stacktrace");
     if (profileResult.applied > 0) reasonParts.push(`profile:${profileResult.profileName}`);
+    if (shapeApplied > 0) reasonParts.push("shape-trim");
     return {
       kind: "trim",
       output,
@@ -184,6 +236,7 @@ export const mcpContentRule: Rule = (toolName, _toolInput, toolResponse, cfg) =>
   if (redactCount > 0) reasonParts.push(`redact:${redactCount}`);
   if (stacktraceApplied > 0) reasonParts.push("stacktrace");
   if (profileResult.applied > 0) reasonParts.push(`profile:${profileResult.profileName}`);
+  if (shapeApplied > 0) reasonParts.push("shape-trim");
   reasonParts.push("mcp-content-trim");
   const reason = reasonParts.join("+");
 

--- a/src/rules/profiles.ts
+++ b/src/rules/profiles.ts
@@ -21,6 +21,12 @@ export interface TrimProfile {
   max_string_bytes?: number;
   // Max items to keep in any surviving array. Excess is dropped with a marker.
   max_array_items?: number;
+  // Optional predicate: inspect the caller's tool_input and decide to skip
+  // this profile entirely. Returning true is a passthrough signal — used for
+  // cases like "caller asked for a single item by ID, give them the whole
+  // thing". The pipeline falls back to downstream stages (shape-trim, byte
+  // trim) if this returns true.
+  skip_when?: (input: Record<string, unknown>) => boolean;
 }
 
 export const BUILTIN_PROFILES: TrimProfile[] = [
@@ -181,6 +187,70 @@ export const BUILTIN_PROFILES: TrimProfile[] = [
     ],
     max_string_bytes: 1_500,
     max_array_items: 20,
+  },
+  {
+    // Row-keep profile for Jira transitions. Each row is tiny (id + name +
+    // to.statusCategory) and the value of the response is the *complete*
+    // enumeration — a trimmed set forces the agent to probe IDs one by one.
+    name: "atlassian-jira-transitions",
+    match: "mcp__*Atlassian*__getTransitionsForJiraIssue",
+    keep: [
+      "transitions.*.id",
+      "transitions.*.name",
+      "transitions.*.to.id",
+      "transitions.*.to.name",
+      "transitions.*.to.statusCategory.key",
+      "transitions.*.to.statusCategory.name",
+    ],
+    max_string_bytes: 120,
+    max_array_items: 50,
+  },
+  {
+    // Row-keep profile for Jira issue-type enumerations. Covers both
+    // getJiraIssueTypeMetaWithFields and getJiraProjectIssueTypesMetadata
+    // — different top-level shapes but similar inventory flavor.
+    name: "atlassian-jira-issue-types",
+    match: "mcp__*Atlassian*__*JiraIssueType*",
+    keep: [
+      "issueTypes.*.id",
+      "issueTypes.*.name",
+      "issueTypes.*.description",
+      "issueTypes.*.subtask",
+      "values.*.id",
+      "values.*.name",
+      "values.*.description",
+      "values.*.subtask",
+    ],
+    max_string_bytes: 200,
+    max_array_items: 50,
+  },
+  {
+    // Row-keep profile for visible Jira projects.
+    name: "atlassian-jira-projects",
+    match: "mcp__*Atlassian*__getVisibleJiraProjects",
+    keep: [
+      "values.*.id",
+      "values.*.key",
+      "values.*.name",
+      "values.*.projectTypeKey",
+      "values.*.simplified",
+    ],
+    max_string_bytes: 120,
+    max_array_items: 100,
+  },
+  {
+    // Row-keep profile for Confluence spaces enumeration.
+    name: "atlassian-confluence-spaces",
+    match: "mcp__*Atlassian*__getConfluenceSpaces",
+    keep: [
+      "results.*.id",
+      "results.*.key",
+      "results.*.name",
+      "results.*.type",
+      "results.*.status",
+    ],
+    max_string_bytes: 120,
+    max_array_items: 100,
   },
 ];
 

--- a/src/rules/read-bound.ts
+++ b/src/rules/read-bound.ts
@@ -39,6 +39,17 @@ export const readBoundRule = (
     return { kind: "passthrough", reason: "stat-failed" };
   }
 
+  // Self-contained docs (READMEs, changelogs, plain text) read poorly when
+  // clamped. If the extension matches the doc list and the file fits the doc
+  // cap, let it through whole — skip the regular threshold.
+  const dot = filePath.lastIndexOf(".");
+  const ext = dot >= 0 ? filePath.slice(dot).toLowerCase() : "";
+  const docExts = cfg.read.doc_passthrough_extensions ?? [];
+  const docCap = cfg.read.doc_passthrough_max_bytes ?? 0;
+  if (ext && docExts.includes(ext) && fileBytes <= docCap) {
+    return { kind: "passthrough", reason: "doc-passthrough", fileBytes };
+  }
+
   if (fileBytes < cfg.read.clamp_above_bytes) {
     return { kind: "passthrough", reason: "below-threshold", fileBytes };
   }

--- a/src/rules/shape-trim.ts
+++ b/src/rules/shape-trim.ts
@@ -1,0 +1,180 @@
+import { utf8Bytes } from "./text-trim.js";
+
+export interface ShapeTrimOptions {
+  max_items: number;
+  max_string_bytes: number;
+}
+
+export interface ShapeTrimResult {
+  ok: boolean;
+  trimmed?: string;
+  bytesIn?: number;
+  bytesOut?: number;
+  kept?: number;
+  dropped?: number;
+  shape?: "array" | `wrapped:${string}`;
+  reason?: string;
+}
+
+// Shape-trim preserves row structure for inventory-shaped JSON responses the
+// profile system doesn't cover. Unlike head+tail byte trim, every row
+// survives — only per-row strings get truncated and deeply nested objects
+// get dropped. This is the right fallback for enumeration endpoints where
+// the *set* is what the caller needs (transition lists, issue-type menus,
+// project rosters) rather than any single row's detail.
+
+// Common keys that wrap an array of records in a single top-level property.
+// Order matters — first hit wins when multiple are present.
+const WRAPPER_KEYS = [
+  "transitions",
+  "issues",
+  "items",
+  "values",
+  "results",
+  "data",
+  "entries",
+  "records",
+] as const;
+
+const isObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null && !Array.isArray(v);
+
+// ≥ 80 % of the sampled rows must share ≥ 80 % of the first row's keys.
+// Not a strict equality — rows with occasional missing keys (e.g. null
+// assignee) are still considered homogeneous.
+const HOMOGENEITY_RATIO = 0.8;
+const HOMOGENEITY_KEY_RATIO = 0.8;
+
+const isHomogeneousRecordArray = (arr: unknown[]): boolean => {
+  if (arr.length === 0) return false;
+  const objects = arr.filter(isObject);
+  if (objects.length / arr.length < HOMOGENEITY_RATIO) return false;
+  const first = objects[0]!;
+  const baseline = Object.keys(first);
+  if (baseline.length === 0) return false;
+  const threshold = Math.ceil(baseline.length * HOMOGENEITY_KEY_RATIO);
+  let hits = 0;
+  for (const row of objects) {
+    const keys = new Set(Object.keys(row));
+    let shared = 0;
+    for (const k of baseline) if (keys.has(k)) shared++;
+    if (shared >= threshold) hits++;
+  }
+  return hits / objects.length >= HOMOGENEITY_RATIO;
+};
+
+// Truncate a string value to max_string_bytes with an explicit marker. Keeps
+// head; drops the middle/tail. Arrays and objects pass through to the
+// depth-aware path below.
+const trimString = (s: string, maxBytes: number): string => {
+  if (utf8Bytes(s) <= maxBytes) return s;
+  const buf = Buffer.from(s, "utf8");
+  const head = buf.subarray(0, Math.max(1, maxBytes)).toString("utf8");
+  return `${head}…[tokenomy: elided ${utf8Bytes(s) - utf8Bytes(head)} bytes]`;
+};
+
+// Depth-aware row compactor. Keeps primitives, truncates strings, recurses
+// one level into nested objects, but drops anything deeper than depth 2 and
+// any nested arrays (those are where payloads balloon).
+const compactValue = (
+  v: unknown,
+  depth: number,
+  maxStringBytes: number,
+): unknown => {
+  if (v === null) return null;
+  if (typeof v === "string") return trimString(v, maxStringBytes);
+  if (typeof v === "number" || typeof v === "boolean") return v;
+  if (Array.isArray(v)) {
+    // Nested arrays are the most common source of row bloat (labels,
+    // history, comments). Drop the contents but keep the length as a hint.
+    return v.length === 0 ? [] : [`[tokenomy: elided ${v.length} items]`];
+  }
+  if (isObject(v)) {
+    if (depth >= 3) return "[tokenomy: nested object elided]";
+    const out: Record<string, unknown> = {};
+    for (const [k, child] of Object.entries(v)) {
+      out[k] = compactValue(child, depth + 1, maxStringBytes);
+    }
+    return out;
+  }
+  return v;
+};
+
+const compactRow = (row: Record<string, unknown>, maxStringBytes: number): Record<string, unknown> => {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(row)) {
+    out[k] = compactValue(v, 1, maxStringBytes);
+  }
+  return out;
+};
+
+interface ShapeDetected {
+  rows: unknown[];
+  rebuild: (trimmedRows: unknown[]) => unknown;
+  shape: ShapeTrimResult["shape"];
+}
+
+const detectShape = (parsed: unknown): ShapeDetected | null => {
+  if (Array.isArray(parsed) && isHomogeneousRecordArray(parsed)) {
+    return {
+      rows: parsed,
+      rebuild: (rows) => rows,
+      shape: "array",
+    };
+  }
+  if (isObject(parsed)) {
+    for (const key of WRAPPER_KEYS) {
+      const child = parsed[key];
+      if (Array.isArray(child) && isHomogeneousRecordArray(child)) {
+        return {
+          rows: child,
+          rebuild: (rows) => ({ ...parsed, [key]: rows }),
+          shape: `wrapped:${key}`,
+        };
+      }
+    }
+  }
+  return null;
+};
+
+export const shapeTrim = (text: string, opts: ShapeTrimOptions): ShapeTrimResult => {
+  const bytesIn = utf8Bytes(text);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { ok: false, reason: "not-json", bytesIn };
+  }
+  const detected = detectShape(parsed);
+  if (!detected) return { ok: false, reason: "no-inventory-shape", bytesIn };
+
+  const keep = Math.max(1, opts.max_items);
+  const head = detected.rows.slice(0, keep);
+  const dropped = Math.max(0, detected.rows.length - keep);
+  const compacted = head.map((r) =>
+    isObject(r) ? compactRow(r, opts.max_string_bytes) : r,
+  );
+  const withMarker =
+    dropped > 0
+      ? [...compacted, `[tokenomy: elided ${dropped} rows]`]
+      : compacted;
+  const rebuilt = detected.rebuild(withMarker);
+  const trimmed = JSON.stringify(rebuilt);
+  const bytesOut = utf8Bytes(trimmed);
+
+  // Bail if the compact form grew (pathological: every field was already
+  // under max_string_bytes and the marker overhead outweighed savings).
+  if (bytesOut >= bytesIn) {
+    return { ok: false, reason: "no-savings", bytesIn };
+  }
+
+  return {
+    ok: true,
+    trimmed,
+    bytesIn,
+    bytesOut,
+    kept: head.length,
+    dropped,
+    shape: detected.shape,
+  };
+};

--- a/tests/unit/analyze-render.test.ts
+++ b/tests/unit/analyze-render.test.ts
@@ -32,6 +32,16 @@ const stub: AggregateReport = {
     { day: "2026-04-18", observed_tokens: 15_000, savings_tokens: 9_000 },
   ],
   hotspots: [{ tool: "mcp__Atlassian__getJiraIssue", calls: 3, wasted_tokens: 6_000 }],
+  wasted_probes: [
+    {
+      tool: "mcp__claude_ai_Atlassian__getTransitionsForJiraIssue",
+      session_id: "abcdef12",
+      first_ts: "2026-04-20T10:00:00Z",
+      last_ts: "2026-04-20T10:00:45Z",
+      call_count: 4,
+      observed_tokens: 2_400,
+    },
+  ],
   outliers: [
     { tool: "mcp__Atlassian__getJiraIssue", tokens: 4_000, bytes: 16_000, ts: "2026-04-17T11:00:00Z", session_id: "abcdef12" },
   ],
@@ -70,6 +80,14 @@ test("render: renderProgress produces carriage-returned status", () => {
   assert.ok(s.includes("5/10"));
 });
 
+test("render: wasted-probe section appears when incidents present", () => {
+  const out = render(stub, { color: false, width: 120, verbose: false });
+  assert.ok(out.includes("Wasted-probe incidents"));
+  assert.ok(out.includes("getTransitionsForJiraIssue"));
+  assert.ok(out.includes("4×"));
+  assert.ok(out.includes("10:00:00→10:00:45"));
+});
+
 test("render: empty report doesn't throw", () => {
   const empty: AggregateReport = {
     window: { first_ts: null, last_ts: null },
@@ -90,6 +108,7 @@ test("render: empty report doesn't throw", () => {
     by_rule: [],
     by_day: [],
     hotspots: [],
+    wasted_probes: [],
     outliers: [],
     tokenizer: { name: "heuristic", approximate: true },
   };

--- a/tests/unit/analyze-report.test.ts
+++ b/tests/unit/analyze-report.test.ts
@@ -97,3 +97,72 @@ test("aggregator: usd calculation", () => {
   assert.ok(Math.abs(r.totals.estimated_usd_saved - 5) < 1e-6);
   assert.ok(Math.abs(r.totals.estimated_usd_observed - 10) < 1e-6);
 });
+
+test("aggregator: wasted_probes detects 4-call run with distinct args in 60s window", () => {
+  const a = agg();
+  const tool = "mcp__claude_ai_Atlassian__getTransitionsForJiraIssue";
+  // Four calls 10s apart, each with different call_keys (the agent probing
+  // different transitionIds / issueKeys). Total window: 30s < 60s.
+  a.feed(mk({ tool_name: tool, call_key: "k-a", ts: "2026-04-20T10:00:00Z", observed_tokens: 500 }));
+  a.feed(mk({ tool_name: tool, call_key: "k-b", ts: "2026-04-20T10:00:10Z", observed_tokens: 500 }));
+  a.feed(mk({ tool_name: tool, call_key: "k-c", ts: "2026-04-20T10:00:20Z", observed_tokens: 500 }));
+  a.feed(mk({ tool_name: tool, call_key: "k-d", ts: "2026-04-20T10:00:30Z", observed_tokens: 500 }));
+  const r = a.build();
+  assert.equal(r.wasted_probes.length, 1);
+  assert.equal(r.wasted_probes[0]!.tool, tool);
+  assert.equal(r.wasted_probes[0]!.call_count, 4);
+  assert.equal(r.wasted_probes[0]!.observed_tokens, 2000);
+  assert.equal(r.wasted_probes[0]!.first_ts, "2026-04-20T10:00:00Z");
+  assert.equal(r.wasted_probes[0]!.last_ts, "2026-04-20T10:00:30Z");
+});
+
+test("aggregator: wasted_probes ignores 2-call run (below threshold)", () => {
+  const a = agg();
+  const tool = "mcp__x__y";
+  a.feed(mk({ tool_name: tool, call_key: "k-a", ts: "2026-04-20T10:00:00Z" }));
+  a.feed(mk({ tool_name: tool, call_key: "k-b", ts: "2026-04-20T10:00:10Z" }));
+  const r = a.build();
+  assert.equal(r.wasted_probes.length, 0);
+});
+
+test("aggregator: wasted_probes ignores same-key repeats (dedup territory)", () => {
+  const a = agg();
+  const tool = "mcp__x__y";
+  // Same call_key repeated 5 times — this is dedup's job, not a probe run.
+  for (let i = 0; i < 5; i++) {
+    a.feed(mk({
+      tool_name: tool,
+      call_key: "k-same",
+      ts: `2026-04-20T10:00:${String(i * 5).padStart(2, "0")}Z`,
+    }));
+  }
+  const r = a.build();
+  assert.equal(r.wasted_probes.length, 0);
+});
+
+test("aggregator: wasted_probes splits runs when gap exceeds 60s", () => {
+  const a = agg();
+  const tool = "mcp__x__y";
+  // Run 1: 3 calls at t=0,10,20 (distinct keys). Then gap. Run 2: 3 calls at t=120,130,140.
+  a.feed(mk({ tool_name: tool, call_key: "r1-a", ts: "2026-04-20T10:00:00Z" }));
+  a.feed(mk({ tool_name: tool, call_key: "r1-b", ts: "2026-04-20T10:00:10Z" }));
+  a.feed(mk({ tool_name: tool, call_key: "r1-c", ts: "2026-04-20T10:00:20Z" }));
+  a.feed(mk({ tool_name: tool, call_key: "r2-a", ts: "2026-04-20T10:02:00Z" }));
+  a.feed(mk({ tool_name: tool, call_key: "r2-b", ts: "2026-04-20T10:02:10Z" }));
+  a.feed(mk({ tool_name: tool, call_key: "r2-c", ts: "2026-04-20T10:02:20Z" }));
+  const r = a.build();
+  assert.equal(r.wasted_probes.length, 2);
+});
+
+test("aggregator: wasted_probes is per-session", () => {
+  const a = agg();
+  const tool = "mcp__x__y";
+  // Same tool, distinct args, but spread across two sessions — neither
+  // session alone crosses the 3-call threshold.
+  a.feed(mk({ tool_name: tool, session_id: "s1", call_key: "a", ts: "2026-04-20T10:00:00Z" }));
+  a.feed(mk({ tool_name: tool, session_id: "s2", call_key: "b", ts: "2026-04-20T10:00:10Z" }));
+  a.feed(mk({ tool_name: tool, session_id: "s1", call_key: "c", ts: "2026-04-20T10:00:20Z" }));
+  a.feed(mk({ tool_name: tool, session_id: "s2", call_key: "d", ts: "2026-04-20T10:00:30Z" }));
+  const r = a.build();
+  assert.equal(r.wasted_probes.length, 0);
+});

--- a/tests/unit/mcp-content.test.ts
+++ b/tests/unit/mcp-content.test.ts
@@ -96,6 +96,64 @@ test("mcp: supports raw-array shape (Atlassian/Claude Code wire format)", () => 
   assert.match(last.text!, /response trimmed/);
 });
 
+test("mcp: {_tokenomy: 'full'} in tool_input returns passthrough (caller opt-out)", () => {
+  const resp: McpToolResponse = {
+    content: [{ type: "text", text: makeBlob(5_000) }],
+  };
+  const r = mcpContentRule(
+    "mcp__x__y",
+    { _tokenomy: "full", issueKey: "LX-1" },
+    resp,
+    CFG,
+  );
+  assert.equal(r.kind, "passthrough");
+});
+
+test("mcp: regular call without opt-out still trims", () => {
+  const resp: McpToolResponse = {
+    content: [{ type: "text", text: makeBlob(5_000) }],
+  };
+  const r = mcpContentRule("mcp__x__y", { issueKey: "LX-1" }, resp, CFG);
+  assert.equal(r.kind, "trim");
+});
+
+test("mcp: unprofiled inventory response gets shape-trimmed (not head+tail)", () => {
+  // Simulate a tool with no built-in profile that returns a homogeneous
+  // {values: [...]} inventory over the default max_text_bytes (200).
+  const inventory = {
+    values: Array.from({ length: 40 }, (_, i) => ({
+      id: String(i),
+      name: `Thing ${i}`,
+      description: "x".repeat(800),
+      metadata: { created: "2026-01-01", owner: { name: "A" } },
+    })),
+  };
+  const resp: McpToolResponse = {
+    content: [{ type: "text", text: JSON.stringify(inventory) }],
+  };
+  const r = mcpContentRule("mcp__madeup_tool__listThings", {}, resp, {
+    ...CFG,
+    mcp: {
+      ...CFG.mcp,
+      // Input (~35 KB) exceeds this; shape-trim output (~5 KB) fits under it,
+      // so shape-trim produces the final result without byte-trim on top.
+      max_text_bytes: 16_000,
+      shape_trim: { enabled: true, max_items: 50, max_string_bytes: 40 },
+    },
+  });
+  assert.equal(r.kind, "trim");
+  if (r.kind !== "trim") return;
+  // Reason should reflect shape-trim firing (not +mcp-content-trim).
+  assert.equal(r.reason, "shape-trim");
+  // The single text block survived as structured JSON (can be parsed back).
+  const text = (r.output.content![0] as { text: string }).text;
+  const parsed = JSON.parse(text);
+  // All 40 rows preserved — not head+tail-sliced.
+  assert.equal(parsed.values.length, 40);
+  assert.equal(parsed.values[0].id, "0");
+  assert.equal(parsed.values[39].id, "39");
+});
+
 test("mcp: unknown top-level keys flow through unchanged", () => {
   const resp: McpToolResponse = {
     content: [{ type: "text", text: makeBlob(1_000) }],

--- a/tests/unit/profiles.test.ts
+++ b/tests/unit/profiles.test.ts
@@ -144,6 +144,83 @@ test("applyProfile: no-savings returns ok:false", () => {
   assert.equal(r.ok, false);
 });
 
+test("builtin atlassian-jira-transitions: keeps all rows, trims bodies", () => {
+  // Mirror a realistic getTransitionsForJiraIssue response: ~15 transitions,
+  // each row ~400 B of JSON. Raw ~6 KB. Expectation: all rows kept, names
+  // and IDs preserved, bulk fields (fields array, expand wrapper) dropped.
+  const payload = {
+    expand: "transitions",
+    transitions: Array.from({ length: 15 }, (_, i) => ({
+      id: String(i + 1),
+      name: `Transition-${i + 1}`,
+      hasScreen: false,
+      isGlobal: true,
+      isInitial: i === 0,
+      isAvailable: true,
+      isConditional: false,
+      to: {
+        id: `1000${i}`,
+        name: `State-${i + 1}`,
+        description: "x".repeat(300),
+        iconUrl: "https://example.atlassian.net/icon",
+        statusCategory: {
+          id: 4,
+          key: i % 2 === 0 ? "indeterminate" : "done",
+          name: "In Progress",
+          colorName: "yellow",
+          self: "https://example.atlassian.net/rest/api/3/statuscategory/4",
+        },
+      },
+    })),
+  };
+  const profile = selectProfile(
+    "mcp__claude_ai_Atlassian__getTransitionsForJiraIssue",
+    BUILTIN_PROFILES,
+  );
+  assert.equal(profile?.name, "atlassian-jira-transitions");
+  const r = applyProfile(JSON.stringify(payload), profile!);
+  assert.equal(r.ok, true);
+  const parsed = JSON.parse(r.trimmed!.replace(/\n\[tokenomy:[^\]]+\]$/, ""));
+  assert.equal(parsed.transitions.length, 15);
+  assert.equal(parsed.transitions[0].id, "1");
+  assert.equal(parsed.transitions[0].name, "Transition-1");
+  assert.equal(parsed.transitions[0].to.statusCategory.key, "indeterminate");
+  // Bulk per-row fields dropped
+  assert.equal(parsed.transitions[0].hasScreen, undefined);
+  assert.equal(parsed.transitions[0].to.description, undefined);
+  assert.ok(
+    r.bytesOut < r.bytesIn / 2,
+    `expected >50% reduction, got ${r.bytesIn} → ${r.bytesOut}`,
+  );
+});
+
+test("builtin atlassian-jira-projects: keeps all rows", () => {
+  const payload = {
+    self: "https://example.atlassian.net/rest/api/3/project/search",
+    maxResults: 50,
+    startAt: 0,
+    total: 3,
+    isLast: true,
+    values: [
+      { id: "10000", key: "LX", name: "LiveX", projectTypeKey: "software", description: "x".repeat(500), lead: { displayName: "A" }, avatarUrls: { "16x16": "a", "24x24": "b" } },
+      { id: "10001", key: "ENG", name: "Engineering", projectTypeKey: "software", description: "y".repeat(500), lead: {}, avatarUrls: {} },
+      { id: "10002", key: "OPS", name: "Operations", projectTypeKey: "business", description: "z".repeat(500), lead: {}, avatarUrls: {} },
+    ],
+  };
+  const profile = selectProfile(
+    "mcp__claude_ai_Atlassian__getVisibleJiraProjects",
+    BUILTIN_PROFILES,
+  );
+  assert.equal(profile?.name, "atlassian-jira-projects");
+  const r = applyProfile(JSON.stringify(payload), profile!);
+  assert.equal(r.ok, true);
+  const parsed = JSON.parse(r.trimmed!.replace(/\n\[tokenomy:[^\]]+\]$/, ""));
+  assert.equal(parsed.values.length, 3);
+  assert.equal(parsed.values[0].key, "LX");
+  assert.equal(parsed.values[0].description, undefined);
+  assert.equal(parsed.values[0].avatarUrls, undefined);
+});
+
 test("builtin atlassian-jira-issue profile reduces a realistic payload", () => {
   const big = {
     key: "PROJ-42",

--- a/tests/unit/read-bound.test.ts
+++ b/tests/unit/read-bound.test.ts
@@ -10,7 +10,13 @@ const CFG: Config = {
   aggression: "balanced",
   gate: { always_trim_above_bytes: 40_000, min_saved_bytes: 4_000, min_saved_pct: 0.25 },
   mcp: { max_text_bytes: 16_000, per_block_head: 4_000, per_block_tail: 2_000 },
-  read: { enabled: true, clamp_above_bytes: 1_000, injected_limit: 100 },
+  read: {
+    enabled: true,
+    clamp_above_bytes: 1_000,
+    injected_limit: 100,
+    doc_passthrough_extensions: [".md", ".txt"],
+    doc_passthrough_max_bytes: 4_000,
+  },
   log_path: "/tmp/nope",
   disabled_tools: [],
 };
@@ -55,6 +61,50 @@ test("read-bound: clamps when file exceeds threshold", () => {
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test("read-bound: .md under doc cap passthroughs even above clamp threshold", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tok-read-"));
+  try {
+    const f = join(dir, "README.md");
+    writeFileSync(f, "X".repeat(2_000));
+    const r = readBoundRule({ file_path: f }, CFG);
+    assert.equal(r.kind, "passthrough");
+    assert.equal(r.reason, "doc-passthrough");
+    assert.equal(r.fileBytes, 2_000);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("read-bound: .md above doc cap still clamps", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tok-read-"));
+  try {
+    const f = join(dir, "huge.md");
+    writeFileSync(f, "X".repeat(8_000));
+    const r = readBoundRule({ file_path: f }, CFG);
+    assert.equal(r.kind, "clamp");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("read-bound: source file extension still clamps above threshold", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tok-read-"));
+  try {
+    const f = join(dir, "code.ts");
+    writeFileSync(f, "X".repeat(2_000));
+    const r = readBoundRule({ file_path: f }, CFG);
+    assert.equal(r.kind, "clamp");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("read-bound: .md with explicit limit still passthroughs via explicit-limit branch", () => {
+  const r = readBoundRule({ file_path: "/tmp/whatever.md", limit: 50 }, CFG);
+  assert.equal(r.kind, "passthrough");
+  assert.equal(r.reason, "explicit-limit");
 });
 
 test("read-bound: disabled config short-circuits", () => {

--- a/tests/unit/shape-trim.test.ts
+++ b/tests/unit/shape-trim.test.ts
@@ -1,0 +1,131 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { shapeTrim } from "../../src/rules/shape-trim.js";
+
+const OPTS = { max_items: 50, max_string_bytes: 200 };
+
+test("shape-trim: top-level homogeneous array of records keeps all rows", () => {
+  const rows = Array.from({ length: 12 }, (_, i) => ({
+    id: String(i),
+    name: `Row ${i}`,
+    description: "x".repeat(500),
+  }));
+  const r = shapeTrim(JSON.stringify(rows), OPTS);
+  assert.equal(r.ok, true);
+  const parsed = JSON.parse(r.trimmed!);
+  assert.equal(parsed.length, 12);
+  assert.equal(parsed[0].id, "0");
+  assert.match(parsed[0].description, /\[tokenomy: elided/);
+  assert.ok(r.bytesOut! < r.bytesIn!);
+  assert.equal(r.shape, "array");
+});
+
+test("shape-trim: wrapped {transitions: [...]} detected and preserved", () => {
+  const payload = {
+    expand: "transitions",
+    transitions: Array.from({ length: 15 }, (_, i) => ({
+      id: String(i),
+      name: `T-${i}`,
+      hasScreen: false,
+      to: { id: String(100 + i), name: `S-${i}`, description: "y".repeat(400) },
+    })),
+  };
+  const r = shapeTrim(JSON.stringify(payload), OPTS);
+  assert.equal(r.ok, true);
+  const parsed = JSON.parse(r.trimmed!);
+  assert.equal(parsed.transitions.length, 15);
+  assert.equal(parsed.expand, "transitions"); // sibling key preserved
+  assert.equal(parsed.transitions[0].id, "0");
+  assert.equal(r.shape, "wrapped:transitions");
+});
+
+test("shape-trim: mixed array (not homogeneous) bails", () => {
+  const mixed = [1, "string", { a: 1 }, null, { b: 2 }];
+  const r = shapeTrim(JSON.stringify(mixed), OPTS);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "no-inventory-shape");
+});
+
+test("shape-trim: non-JSON text bails", () => {
+  const r = shapeTrim("this is not json", OPTS);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "not-json");
+});
+
+test("shape-trim: nested arrays inside rows get elided", () => {
+  const payload = [
+    { id: "A", labels: ["one", "two", "three"], comments: Array(50).fill({ body: "x" }) },
+    { id: "B", labels: ["four"], comments: [] },
+  ];
+  const r = shapeTrim(JSON.stringify(payload), OPTS);
+  assert.equal(r.ok, true);
+  const parsed = JSON.parse(r.trimmed!);
+  assert.equal(parsed.length, 2);
+  // Nested arrays replaced with an elision marker row count (for non-empty).
+  assert.equal(Array.isArray(parsed[0].labels), true);
+  assert.match(String(parsed[0].labels[0]), /elided 3 items/);
+  assert.match(String(parsed[0].comments[0]), /elided 50 items/);
+  // Empty nested arrays stay empty (no marker needed).
+  assert.deepEqual(parsed[1].comments, []);
+});
+
+test("shape-trim: depth > 2 nested objects collapsed", () => {
+  // Bulk up the payload so depth elision produces net savings.
+  const payload = Array.from({ length: 5 }, (_, i) => ({
+    id: `A${i}`,
+    user: {
+      name: `Alice-${i}`,
+      profile: {
+        bio: "nested-bio-" + "x".repeat(100),
+        more: { deep: "too-deep-" + "y".repeat(500) },
+      },
+    },
+  }));
+  const r = shapeTrim(JSON.stringify(payload), OPTS);
+  assert.equal(r.ok, true);
+  const parsed = JSON.parse(r.trimmed!);
+  assert.equal(parsed[0].user.name, "Alice-0");
+  // user.profile is depth 2 — it's kept but its children are compacted.
+  // user.profile.more is depth 3 — elided.
+  assert.equal(typeof parsed[0].user.profile, "object");
+  assert.match(String(parsed[0].user.profile.more), /nested object elided/);
+});
+
+test("shape-trim: max_items caps row count with marker", () => {
+  const rows = Array.from({ length: 200 }, (_, i) => ({ id: String(i), name: `r${i}` }));
+  const r = shapeTrim(JSON.stringify(rows), { max_items: 10, max_string_bytes: 200 });
+  assert.equal(r.ok, true);
+  const parsed = JSON.parse(r.trimmed!);
+  // 10 rows + 1 marker string
+  assert.equal(parsed.length, 11);
+  assert.match(String(parsed[10]), /elided 190 rows/);
+});
+
+test("shape-trim: small payload that can't be compacted bails with no-savings", () => {
+  // Two tiny identical rows — compact form is same size as input.
+  const tiny = [{ a: 1 }, { a: 2 }];
+  const r = shapeTrim(JSON.stringify(tiny), OPTS);
+  // Either ok:false no-savings, or ok:true (if compaction adds nothing). Either
+  // way, no grow. Assert no regression.
+  if (r.ok) {
+    assert.ok(r.bytesOut! <= r.bytesIn!);
+  } else {
+    assert.equal(r.reason, "no-savings");
+  }
+});
+
+test("shape-trim: rows with occasional missing fields still homogeneous", () => {
+  const rows = [
+    { id: "1", name: "A", email: "a@x" },
+    { id: "2", name: "B", email: "b@x" },
+    { id: "3", name: "C" }, // email missing — still homogeneous (≥80%)
+    { id: "4", name: "D", email: "d@x" },
+    { id: "5", name: "E", email: "e@x" },
+  ];
+  // Make it big enough to compact.
+  const big = rows.map((r) => ({ ...r, description: "x".repeat(500) }));
+  const r = shapeTrim(JSON.stringify(big), OPTS);
+  assert.equal(r.ok, true);
+  const parsed = JSON.parse(r.trimmed!);
+  assert.equal(parsed.length, 5);
+});


### PR DESCRIPTION
## Summary

Dogfood surfaced two failure modes in the trim pipeline: (1) enumeration-shaped MCP responses (e.g. `getTransitionsForJiraIssue`) were byte-trimmed to ~330 B, forcing the agent to probe IDs one-by-one; (2) self-contained docs like READMEs were clamped as if they were source. Five targeted fixes — surgical profiles for the specific Jira cases, a shape-heuristic fallback so new tools don't re-hit the same bug, a report-level signal that flags when this goes wrong, a caller opt-out primitive, and a Read-clamp exception for markdown. README tightened from 566 → 437 lines without losing information.

## Surface

- [x] `PostToolUse` hook (MCP trim) — `src/rules/mcp-content.ts` / `src/rules/profiles.ts` / `src/rules/shape-trim.ts` (new)
- [x] `PreToolUse` hook (Read clamp) — `src/rules/read-bound.ts`
- [x] Config / types — `src/core/config.ts` / `src/core/types.ts`
- [x] CLI — `src/analyze/{report,render}.ts`
- [x] Tests only — 23 new
- [x] Docs / README / CONTRIBUTING

## Why

Real session: calling `getTransitionsForJiraIssue` needed the full `(id, name, to.statusCategory)` list to map Jira transitions. The response had no profile; it hit the byte-trim fallback and was head+tail-sliced into a ~330 B stub. Agent spent ~15 follow-up calls probing individual transition IDs — net-negative on tokens. Separately: a ~32 KB README.md was clamped twice in the same session; docs want read-through, not offset-paging. Both failures were invisible in \`tokenomy report\` (it only shows bytes saved, never probes caused).

## How it works

**1. Four Jira/Confluence enumeration profiles** (\`src/rules/profiles.ts\`) — row-keep: \`atlassian-jira-transitions\`, \`atlassian-jira-issue-types\`, \`atlassian-jira-projects\`, \`atlassian-confluence-spaces\`. Generous \`max_array_items\` (50–100), tight \`max_string_bytes\` (120–200). \`selectProfile\`'s existing specificity ordering picks them over broader globs.

**2. Shape-aware fallback** (\`src/rules/shape-trim.ts\`, new) — Stage 2.5 between profile and byte-trim. When no profile matches and the payload is over budget, detects inventory shapes (top-level array of homogeneous records OR \`{transitions|issues|values|results|data|entries|records: [...]}\`) and compacts per-row: strings truncated to \`max_string_bytes\`, nested objects preserved to depth 2, nested arrays elided with count markers. Row count preserved so enumerations survive. Config: \`cfg.mcp.shape_trim\`, aggression-scaled.

**3. Wasted-probe detector** (\`src/analyze/report.ts\` + \`render.ts\`) — \`AggregateReport.wasted_probes[]\`: per-session sliding window, ≥3 distinct call-key calls to the same tool within 60s marks a run. Rendered as \`⚠ Wasted-probe incidents\` in \`tokenomy analyze\`. Detection lives in analyze (not report) because \`savings.jsonl\` intentionally doesn't log \`tool_input\`; the transcript parser has it.

**4. Caller opt-out** — \`mcpContentRule\` now threads \`tool_input\` through the pipeline (was \`_toolInput\`). \`{_tokenomy: "full", ...real_args}\` in tool input returns passthrough unconditionally. \`TrimProfile.skip_when?(input)\` is a new optional predicate for profile-level input-aware gating.

**5. Read-clamp doc-passthrough** — \`.md/.mdx/.rst/.txt/.adoc\` under 64 KB passthrough unclamped. New \`ReadRuleConfig.doc_passthrough_extensions\` + \`doc_passthrough_max_bytes\`, aggression-scaled. Regular source files still clamp.

## Test plan

- [x] \`npm test\` green — **249/249** passing (was 226, +23 new)
- [x] \`npm run build\` clean
- [x] \`npm run typecheck\` clean
- [x] Added passthrough + trim tests for every new rule path (profile, shape-trim, opt-out, doc-passthrough, probe detector split/same-key/session isolation)
- [x] Integration test \`analyze-cli\` still passes after rebuild (\`dist/\`)
- [x] Manual smoke: 4-call Jira transitions sequence surfaces in \`⚠ Wasted-probe incidents\`; unprofiled inventory response with 40 rows survives as structured JSON (not head+tail)

## Invariants preserved

- [x] Rule output never shrinks \`content.length\`
- [x] Non-text MCP blocks keep their relative position
- [x] Unknown top-level keys flow through untouched
- [x] Malformed stdin → exit 0 with empty stdout (fail-open)
- [x] Exit code 2 is not used anywhere
- [x] \`Read\` clamp preserves \`file_path\` and any other caller-supplied input keys

## Breaking changes

- [x] No breaking changes (new config fields default-initialized; \`mcp-content.ts\` signature change is internal; \`TrimProfile.skip_when?\` is optional)

## Screenshots / logs

New \`reason\` values in \`savings.jsonl\`:

\`\`\`
profile:atlassian-jira-transitions
shape-trim+mcp-content-trim
\`\`\`

\`tokenomy analyze\` new section:

\`\`\`
⚠ Wasted-probe incidents  (≥3 distinct-arg calls to same tool within 60s — likely over-trimmed enumeration)
  mcp__claude_ai_Atlassian__getTransitionsForJiraIssue   4×   10:00:00→10:00:45   2,400 tok observed
\`\`\`

Read-clamp passthrough reason: \`doc-passthrough\` (vs existing \`below-threshold\` / \`clamped\`).

## Checklist

- [x] Title follows \`<type>(<scope>): <description>\`
- [x] Rebased on \`main\`, no merge commits
- [x] One logical change per PR (all five features target the same failure class)
- [x] README + CHANGELOG updated (unreleased section)
- [x] \`npm test\` + \`npm run build\` green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)