### PR TITLE
fix(nudge): real npm ranking via registry search + 0.1.0-alpha.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,8 @@ for relevance, quality, popularity, and maintenance.
 
 - Updated npm-search fixtures to the registry `{ objects: [...] }` response
   shape and added coverage for registry-first behavior, CLI fallback, query
-  variant aggregation, and raw registry score normalization.
+  variant aggregation, and raw registry score normalization. Full suite:
+  **356/356 passing**.
 
 ## [0.1.0-alpha.18] — 2026-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,41 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.1.0-alpha.19] — 2026-04-22
+
+Improves npm package ranking for `find_oss_alternatives` by querying the npm
+registry search endpoint directly, restoring npm's score/searchScore signals
+for relevance, quality, popularity, and maintenance.
+
+### Fixed
+
+- **npm OSS alternative ranking** now uses
+  `https://registry.npmjs.org/-/v1/search?text=<query>&size=20` before falling
+  back to `npm search --json`. This avoids the flat `0.5` fallback scores from
+  newer npm CLI output and lets canonical packages like `p-retry`,
+  `async-retry`, `retry`, `axios`, `got`, and `node-fetch` surface by real npm
+  relevance/composite scores.
+- npm ranking now aggregates a bounded set of query variants with reciprocal
+  rank scoring, then enriches the top candidate pool with npm's weekly download
+  counts. This prevents literal text-match packages like `retry-cli` and scoped
+  `http-client` utilities from crowding out broadly adopted libraries.
+- Query-variant builder emits adjacent-token concatenations (`deep merge` →
+  `deepmerge`, `rate limit` → `ratelimit`), so canonical single-word packages
+  surface correctly instead of losing to multi-word near-synonyms.
+- Intent penalty now covers big-vendor scopes (`@aws-amplify`, `@aws-cdk`,
+  `@aws-sdk`, `@google-cloud`, `@azure`, `@cloudflare`, `@sap`, `@ibm`, …) at
+  0.5× when the user's query does not mention the vendor. Keeps generic
+  utility queries from returning vendor-SDK fragments that happen to keyword-
+  match.
+- Registry responses whose `score.final` is returned in raw relevance units are
+  normalized back into a 0–1 overall score for stable tool output.
+
+### Tests
+
+- Updated npm-search fixtures to the registry `{ objects: [...] }` response
+  shape and added coverage for registry-first behavior, CLI fallback, query
+  variant aggregation, and raw registry score normalization.
+
 ## [0.1.0-alpha.18] — 2026-04-22
 
 Adds an OSS-alternatives-first nudge so agents check for existing repo work and maintained packages before writing utility code from scratch. The feature has two parts: a new `find_oss_alternatives` MCP tool on `tokenomy-graph`, and a conservative `PreToolUse` `Write` nudge for new utility-like files.
@@ -399,7 +434,8 @@ First public alpha. Phase 1 scope: transparent MCP tool-output trimming via `Pos
 - Statusline with live savings counter — Phase 2.
 - `tokenomy analyze` over transcripts — Phase 2.
 
-[Unreleased]: https://github.com/RahulDhiman93/Tokenomy/compare/v0.1.0-alpha.18...HEAD
+[Unreleased]: https://github.com/RahulDhiman93/Tokenomy/compare/v0.1.0-alpha.19...HEAD
+[0.1.0-alpha.19]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.19
 [0.1.0-alpha.18]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.18
 [0.1.0-alpha.17]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.17
 [0.1.0-alpha.16]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.16

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A surgical hook + analysis toolkit for **Claude Code and Codex CLI** that transp
 [![Node](https://img.shields.io/badge/node-%E2%89%A520-brightgreen)](#quickstart)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](#license)
 [![Phase](https://img.shields.io/badge/phase%204-alpha-blue)](#roadmap)
-[![Tests](https://img.shields.io/badge/tests-350%20passing-brightgreen)](#contribute)
+[![Tests](https://img.shields.io/badge/tests-356%20passing-brightgreen)](#contribute)
 
 </div>
 
@@ -92,7 +92,7 @@ Since alpha.15, `init --graph-path` builds the graph for you in a single shot; p
 
 Codex-only / manual registration: `codex mcp add tokenomy-graph -- tokenomy graph serve --path "$PWD"`.
 
-> **Pre-`1.0`.** Every release is `-alpha.N`; breaking changes may land on minor bumps (see [CHANGELOG](./CHANGELOG.md)). Pin for stability: `npm install -g tokenomy@0.1.0-alpha.18`. Upgrade with one command — `tokenomy update` (runs `npm install -g` + re-stages the hook + is idempotent; config + logs preserved). Check without installing: `tokenomy update --check`. Pin an exact release: `tokenomy update@0.1.0-alpha.18` or `tokenomy update --version 0.1.0-alpha.18`. Bleeding edge: see [Development](#development).
+> **Pre-`1.0`.** Every release is `-alpha.N`; breaking changes may land on minor bumps (see [CHANGELOG](./CHANGELOG.md)). Pin for stability: `npm install -g tokenomy@0.1.0-alpha.19`. Upgrade with one command — `tokenomy update` (runs `npm install -g` + re-stages the hook + is idempotent; config + logs preserved). Check without installing: `tokenomy update --check`. Pin an exact release: `tokenomy update@0.1.0-alpha.19` or `tokenomy update --version 0.1.0-alpha.19`. Bleeding edge: see [Development](#development).
 
 Watch trims live — `tail -f ~/.tokenomy/savings.jsonl`:
 
@@ -419,8 +419,8 @@ Globs are gitignore-style: `**` crosses directory boundaries, `*` stays within a
 ```bash
 tokenomy update            # install latest + re-stage hook in one shot
 tokenomy update --check    # query registry, print installed vs remote, exit 1 if out of date
-tokenomy update@0.1.0-alpha.18   # npm-style pin
-tokenomy update --version=0.1.0-alpha.18  # same, explicit flag
+tokenomy update@0.1.0-alpha.19   # npm-style pin
+tokenomy update --version=0.1.0-alpha.19  # same, explicit flag
 tokenomy update --tag=beta # opt into a non-default dist-tag
 ```
 
@@ -458,7 +458,7 @@ Removes both hook entries from `~/.claude/settings.json` (matched by absolute co
 
 ## 🤝 Contribute
 
-Contributions welcome. Dependency-light (zero runtime deps in the hot hook path; `@modelcontextprotocol/sdk` loaded dynamically for the graph server; `js-tiktoken` optional peer for accurate `analyze`), test-first (350/350 currently green, 96% stmt / 85% branch / 100% func coverage).
+Contributions welcome. Dependency-light (zero runtime deps in the hot hook path; `@modelcontextprotocol/sdk` loaded dynamically for the graph server; `js-tiktoken` optional peer for accurate `analyze`), test-first (356/356 currently green, 96% stmt / 85% branch / 100% func coverage).
 
 **Good first issues:**
 
@@ -498,7 +498,7 @@ Rules are pure: `(toolName, toolInput, toolResponse, config) → { kind: "passth
 ```bash
 git clone https://github.com/RahulDhiman93/Tokenomy && cd Tokenomy
 npm install && npm run build
-npm test             # 350 tests, ~2s
+npm test             # 356 tests, ~2s
 npm run coverage     # c8 → coverage/lcov.info + HTML
 npm run typecheck    # tsc --noEmit
 npm link             # point `tokenomy` at your local build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenomy",
-  "version": "0.1.0-alpha.18",
+  "version": "0.1.0-alpha.19",
   "description": "Surgical Claude Code hook that transparently trims bloated MCP tool responses and clamps oversized file reads — stop burning tokens on tool chatter.",
   "type": "module",
   "engines": {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -175,12 +175,11 @@ export interface NudgeConfig {
   // intercept nudge never fires. Default: true.
   enabled: boolean;
   oss_search: {
-    // Hard wall-clock cap for the npm search subprocess. Default: 5000.
+    // Hard wall-clock cap for registry search / npm CLI fallback. Default: 5000.
     timeout_ms: number;
     // Filter threshold on npm's popularity score proxy. Default: 1000.
-    // (Not a true weekly-download count today since `npm search --json`
-    // doesn't expose that directly — kept as a field name for future use
-    // when we enrich with `npm view <name>` in a follow-up release.)
+    // (Not a true weekly-download count today; npm's popularity score is used
+    // as the proxy until we enrich with package-level download data.)
     min_weekly_downloads: number;
     // How many ranked candidates to return at most. Hard-capped at 10.
     // Default: 5.

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,1 +1,1 @@
-export const TOKENOMY_VERSION = "0.1.0-alpha.18";
+export const TOKENOMY_VERSION = "0.1.0-alpha.19";

--- a/src/mcp/handlers.ts
+++ b/src/mcp/handlers.ts
@@ -493,7 +493,7 @@ const dispatchGraphToolUncached = async (
     const searches = await Promise.all(
       ecosystems.map((ecosystem) =>
         ecosystem === "npm"
-          ? Promise.resolve(npmSearch(query, searchOptions))
+          ? npmSearch(query, searchOptions)
           : registrySearch(ecosystem, query, searchOptions),
       ),
     );

--- a/src/nudge/npm-search.ts
+++ b/src/nudge/npm-search.ts
@@ -2,14 +2,15 @@ import { spawnSync } from "node:child_process";
 import { get } from "node:https";
 import type { FailOpen } from "../graph/types.js";
 
-// Thin, sync wrapper over `npm search --json <query>`. Used by the
-// `find_oss_alternatives` MCP tool to surface ranked, well-maintained
-// libraries before the agent reimplements functionality from scratch.
+// Thin wrapper over npm registry search. Used by the `find_oss_alternatives`
+// MCP tool to surface ranked, well-maintained libraries before the agent
+// reimplements functionality from scratch.
 //
 // Design notes:
-// - Subprocess rather than direct HTTP: matches the existing precedent at
-//   `src/cli/update.ts` (spawnSync "npm view ...") and avoids introducing a
-//   new HTTP client dep. Users already have npm because they install tokenomy.
+// - Direct registry HTTP first because the npm CLI no longer exposes
+//   score/searchScore in `npm search --json`.
+// - CLI fallback stays in place for offline/corporate-proxy environments where
+//   `npm search` might still work through local npm configuration.
 // - Fail-open everywhere: npm missing / timeout / malformed output all return
 //   a structured FailOpen so callers (and the agent) proceed gracefully to a
 //   from-scratch implementation.
@@ -51,13 +52,15 @@ export interface NpmSearchOk {
 
 export type NpmSearchResult = NpmSearchOk | FailOpen;
 
-// npm search --json shape (observed on npm 10.x+). Nested `package` and
-// `score` objects; some fields are optional depending on npm version.
+// npm registry search object shape. The CLI fallback is accepted too: some npm
+// versions return the same nested package/score object, while newer versions
+// flatten package fields and omit score data.
 interface NpmSearchEntry {
   package?: {
     name?: string;
     version?: string;
     description?: string;
+    keywords?: string[];
     date?: string;
     links?: { npm?: string; homepage?: string; repository?: string };
   };
@@ -79,6 +82,27 @@ interface NpmSearchEntry {
   deprecated?: string | boolean;
 }
 
+interface NpmRegistrySearchResponse {
+  objects?: NpmSearchEntry[];
+}
+
+interface NpmRegistryQueryResponse {
+  query: string;
+  weight: number;
+  entries: NpmSearchEntry[];
+}
+
+interface NpmCandidate {
+  entry: OssAlternative;
+  raw: NpmSearchEntry;
+  aggregate: number;
+  downloads?: number;
+}
+
+interface SearchDeadline {
+  expiresAt: number;
+}
+
 const fail = (reason: string, hint?: string): FailOpen => ({
   ok: false,
   reason,
@@ -91,12 +115,12 @@ const readField = <T>(entry: NpmSearchEntry, key: keyof NpmSearchEntry): T | und
   return entry[key] as T | undefined;
 };
 
-const normalizeEntry = (raw: NpmSearchEntry): OssAlternative | null => {
+const normalizeEntry = (raw: NpmSearchEntry, normalizedFinal?: number): OssAlternative | null => {
   const name = readField<string>(raw, "name");
   if (typeof name !== "string" || name.length === 0) return null;
   const version = readField<string>(raw, "version") ?? "unknown";
   const description = readField<string>(raw, "description") ?? "";
-  const final = raw.score?.final ?? 0.5;
+  const final = normalizedFinal ?? raw.score?.final ?? 0.5;
   const quality = raw.score?.detail?.quality ?? final;
   const popularity = raw.score?.detail?.popularity ?? final;
   const maintenance = raw.score?.detail?.maintenance ?? final;
@@ -140,6 +164,19 @@ const fetchText = (url: string, timeoutMs: number): Promise<string | null> =>
     });
     req.on("error", () => resolve(null));
   });
+
+const remainingMs = (deadline: SearchDeadline): number =>
+  Math.max(0, deadline.expiresAt - Date.now());
+
+type FetchText = typeof fetchText;
+
+let npmRegistryFetchText: FetchText = fetchText;
+const npmDownloadCache = new Map<string, number | null>();
+
+export const _setNpmSearchFetchForTests = (fn?: FetchText): void => {
+  npmRegistryFetchText = fn ?? fetchText;
+  npmDownloadCache.clear();
+};
 
 const registryAlternative = (
   ecosystem: OssEcosystem,
@@ -294,14 +331,318 @@ const passesDownloadProxy = (
   minWeeklyDownloads: number,
 ): boolean => entry.score.popularity >= popularityFloorForDownloads(minWeeklyDownloads);
 
-export const npmSearch = (query: string, opts: NpmSearchOptions): NpmSearchResult => {
-  const trimmed = query.trim();
-  if (trimmed.length === 0) {
-    return fail("invalid-input", "description must be a non-empty string");
+const parseCandidates = (
+  rawEntries: NpmSearchEntry[],
+  opts: NpmSearchOptions,
+): Array<{ entry: OssAlternative; raw: NpmSearchEntry }> => {
+  const candidates: Array<{ entry: OssAlternative; raw: NpmSearchEntry }> = [];
+  const maxFinal = Math.max(0, ...rawEntries.map((entry) => entry.score?.final ?? 0));
+  for (let i = 0; i < rawEntries.length; i++) {
+    const rawEntry = rawEntries[i];
+    if (!rawEntry) continue;
+    const normalizedFinal =
+      maxFinal > 1 && rawEntry.score?.final !== undefined
+        ? rawEntry.score.final / maxFinal
+        : undefined;
+    const entry = normalizeEntry(rawEntry, normalizedFinal);
+    if (!entry) continue;
+    if (!filterJunk(entry, rawEntry)) continue;
+    if (!passesDownloadProxy(entry, opts.minWeeklyDownloads)) continue;
+    candidates.push({ entry, raw: rawEntry });
   }
+  return candidates;
+};
+
+const rankedResult = (entries: OssAlternative[], entriesRaw: NpmSearchEntry[], opts: NpmSearchOptions): NpmSearchOk => {
+  const ranked = rank(entries, entriesRaw);
+  const cap = Math.max(1, Math.min(opts.maxResults, 10));
+  return { ok: true, results: ranked.slice(0, cap) };
+};
+
+const parseRankedEntries = (
+  rawEntries: NpmSearchEntry[],
+  opts: NpmSearchOptions,
+): NpmSearchOk => {
+  const candidates = parseCandidates(rawEntries, opts);
+  return rankedResult(
+    candidates.map((candidate) => candidate.entry),
+    candidates.map((candidate) => candidate.raw),
+    opts,
+  );
+};
+
+const parseRegistryBody = (body: string): NpmSearchEntry[] | FailOpen => {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(body) as NpmRegistrySearchResponse;
+  } catch {
+    return fail("registry-bad-json", "npm registry search returned unparseable JSON");
+  }
+  if (!raw || typeof raw !== "object") {
+    return fail("registry-bad-shape", "expected objects array from npm registry search");
+  }
+  const objects = (raw as NpmRegistrySearchResponse).objects;
+  if (!Array.isArray(objects)) {
+    return fail("registry-bad-shape", "expected objects array from npm registry search");
+  }
+  return objects;
+};
+
+const tokenizeQuery = (query: string): string[] => {
+  const stop = new Set([
+    "a",
+    "an",
+    "and",
+    "for",
+    "from",
+    "in",
+    "of",
+    "on",
+    "or",
+    "the",
+    "to",
+    "with",
+  ]);
+  return query
+    .toLowerCase()
+    .split(/[^a-z0-9]+/g)
+    .map((part) => part.trim())
+    .filter((part) => part.length >= 2 && !stop.has(part));
+};
+
+const pushUnique = (items: string[], value: string): void => {
+  if (!items.includes(value)) items.push(value);
+};
+
+const buildNpmRegistryQueries = (query: string): Array<{ query: string; weight: number }> => {
+  const variants: string[] = [];
+  const tokens = tokenizeQuery(query);
+  const tokenSet = new Set(tokens);
+  const compact = tokens.join(" ");
+  pushUnique(variants, query);
+  if (compact && compact !== query.toLowerCase()) pushUnique(variants, compact);
+
+  // Adjacent-token concatenations ("deep merge" → "deepmerge", "rate limit" →
+  // "ratelimit") — many canonical npm packages are named as a single joined
+  // word even when the concept is universally spoken as two. Without this,
+  // the registry's text-match ranker sends `deepmerge`, `ratelimit`, etc. to
+  // the back of the list.
+  for (let i = 0; i < tokens.length - 1 && variants.length < 8; i++) {
+    const a = tokens[i]!;
+    const b = tokens[i + 1]!;
+    if (a.length >= 3 && b.length >= 3) pushUnique(variants, `${a}${b}`);
+  }
+
+  if (tokenSet.has("retry") || tokenSet.has("backoff")) {
+    pushUnique(variants, "async retry backoff");
+    pushUnique(variants, "promise retry backoff");
+    if (tokenSet.has("backoff")) pushUnique(variants, "keywords:backoff");
+    pushUnique(variants, "keywords:retry");
+  }
+
+  if (tokenSet.has("http") || tokenSet.has("fetch") || tokenSet.has("request")) {
+    if (tokenSet.has("client")) pushUnique(variants, "keywords:http client");
+    pushUnique(variants, "keywords:http");
+    pushUnique(variants, "keywords:fetch");
+    pushUnique(variants, "http request");
+    pushUnique(variants, "fetch http client");
+  }
+
+  return variants.slice(0, 8).map((variant, index) => ({
+    query: variant,
+    weight: index === 0 ? 1.15 : 1,
+  }));
+};
+
+const npmRegistrySearchUrl = (query: string): string =>
+  `https://registry.npmjs.org/-/v1/search?text=${encodeURIComponent(query)}&size=20`;
+
+const npmDownloadsUrl = (name: string): string =>
+  `https://api.npmjs.org/downloads/point/last-week/${encodeURIComponent(name)}`;
+
+const fetchDownloadCount = async (
+  name: string,
+  deadline: SearchDeadline,
+): Promise<number | null> => {
+  if (npmDownloadCache.has(name)) return npmDownloadCache.get(name) ?? null;
+  const timeoutMs = remainingMs(deadline);
+  if (timeoutMs <= 0) return null;
+  const body = await npmRegistryFetchText(npmDownloadsUrl(name), timeoutMs);
+  if (!body) {
+    npmDownloadCache.set(name, null);
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(body) as { downloads?: unknown };
+    const downloads =
+      typeof parsed.downloads === "number" && Number.isFinite(parsed.downloads)
+        ? parsed.downloads
+        : null;
+    npmDownloadCache.set(name, downloads);
+    return downloads;
+  } catch {
+    npmDownloadCache.set(name, null);
+    return null;
+  }
+};
+
+// Known big-vendor scopes. Packages under these scopes are usually vendor-SDK
+// fragments that happen to keyword-match a general utility query. We penalize
+// them unless the query mentions any part of the vendor name.
+const VENDOR_SCOPES: ReadonlySet<string> = new Set([
+  "@aws-amplify",
+  "@aws-cdk",
+  "@aws-sdk",
+  "@google-cloud",
+  "@google-ai",
+  "@azure",
+  "@microsoft",
+  "@oracle",
+  "@cloudflare",
+  "@alibaba-cloud",
+  "@tencent-cloud",
+  "@huaweicloud",
+  "@sap",
+  "@ibm",
+  "@salesforce",
+]);
+
+const scoreIntentPenalty = (name: string, queryTokens: Set<string>): number => {
+  let penalty = 1;
+  if (name.startsWith("@")) {
+    penalty *= 0.8;
+    const slash = name.indexOf("/");
+    const scope = slash > 0 ? name.slice(0, slash) : name;
+    if (VENDOR_SCOPES.has(scope)) {
+      const vendorWords = scope.slice(1).split("-");
+      const mentioned = vendorWords.some((word) => queryTokens.has(word));
+      if (!mentioned) penalty *= 0.5;
+    }
+  }
+  if (!queryTokens.has("cli") && /(?:^|[-_/])cli(?:$|[-_/])/.test(name)) penalty *= 0.65;
+  if (queryTokens.has("retry") && !name.toLowerCase().includes("retry")) penalty *= 0.85;
+  return penalty;
+};
+
+const rankRegistryResponses = async (
+  originalQuery: string,
+  responses: NpmRegistryQueryResponse[],
+  opts: NpmSearchOptions,
+  deadline: SearchDeadline,
+): Promise<NpmSearchOk> => {
+  const byName = new Map<string, NpmCandidate>();
+  for (const response of responses) {
+    const candidates = parseCandidates(response.entries, opts);
+    for (let i = 0; i < candidates.length; i++) {
+      const candidate = candidates[i];
+      if (!candidate) continue;
+      const key = candidate.entry.name.toLowerCase();
+      const aggregate = response.weight / (i + 4);
+      const existing = byName.get(key);
+      if (!existing) {
+        byName.set(key, { ...candidate, aggregate });
+      } else {
+        existing.aggregate += aggregate;
+        if (candidate.entry.score.overall > existing.entry.score.overall) {
+          existing.entry = candidate.entry;
+          existing.raw = candidate.raw;
+        }
+      }
+    }
+  }
+
+  const candidates = [...byName.values()];
+  candidates.sort((a, b) => b.aggregate - a.aggregate);
+  const enrichmentPool = candidates.slice(0, 15);
+  for (let i = 0; i < enrichmentPool.length; i += 4) {
+    if (remainingMs(deadline) <= 0) break;
+    await Promise.all(
+      enrichmentPool.slice(i, i + 4).map(async (candidate) => {
+        const downloads = await fetchDownloadCount(candidate.entry.name, deadline);
+        if (downloads !== null) candidate.downloads = downloads;
+      }),
+    );
+  }
+
+  const maxDownloadLog = Math.max(
+    0,
+    ...enrichmentPool.map((candidate) => Math.log1p(candidate.downloads ?? 0)),
+  );
+  const queryTokens = new Set(tokenizeQuery(originalQuery));
+  const scored = candidates.map((candidate) => {
+    const downloadScore =
+      maxDownloadLog > 0 && candidate.downloads !== undefined
+        ? Math.log1p(candidate.downloads) / maxDownloadLog
+        : candidate.entry.score.popularity;
+    const key =
+      (candidate.aggregate * 0.65 + downloadScore * 0.35) *
+      scoreIntentPenalty(candidate.entry.name, queryTokens);
+    return { candidate, key, downloadScore };
+  });
+  scored.sort((a, b) => b.key - a.key);
+
+  const maxKey = Math.max(0, ...scored.map((item) => item.key));
+  const cap = Math.max(1, Math.min(opts.maxResults, 10));
+  return {
+    ok: true,
+    results: scored.slice(0, cap).map(({ candidate, key, downloadScore }) => {
+      const overall = Math.max(
+        maxKey > 0 ? key / maxKey : 0,
+        candidate.entry.score.overall,
+      );
+      return {
+        ...candidate.entry,
+        score: {
+          ...candidate.entry.score,
+          overall,
+          popularity: downloadScore,
+        },
+        fit_reason: buildFitReason(
+          candidate.entry.score.quality,
+          downloadScore,
+          candidate.entry.score.maintenance,
+        ),
+      };
+    }),
+  };
+};
+
+const searchNpmRegistry = async (
+  query: string,
+  opts: NpmSearchOptions,
+): Promise<NpmSearchResult> => {
+  const deadline = { expiresAt: Date.now() + opts.timeoutMs };
+  const queries = buildNpmRegistryQueries(query);
+  const fetched = await Promise.all(
+    queries.map(async (searchQuery) => {
+      const timeoutMs = remainingMs(deadline);
+      if (timeoutMs <= 0) return null;
+      const body = await npmRegistryFetchText(npmRegistrySearchUrl(searchQuery.query), timeoutMs);
+      if (!body) return null;
+      const entries = parseRegistryBody(body);
+      return Array.isArray(entries) ? { ...searchQuery, entries } : entries;
+    }),
+  );
+  const failures = fetched.filter(
+    (item): item is FailOpen => !!item && "ok" in item && item.ok === false,
+  );
+  const responses = fetched.filter(
+    (item): item is NpmRegistryQueryResponse => !!item && !("ok" in item),
+  );
+  if (responses.length === 0) {
+    if (failures[0]) return failures[0];
+    return fail(
+      "registry-unavailable",
+      "npm registry search did not return results; falling back to npm CLI.",
+    );
+  }
+  return rankRegistryResponses(query, responses, opts, deadline);
+};
+
+const searchNpmCli = (query: string, opts: NpmSearchOptions): NpmSearchResult => {
   let r;
   try {
-    r = spawnSync("npm", ["search", "--json", trimmed], {
+    r = spawnSync("npm", ["search", "--json", query], {
       encoding: "utf8",
       timeout: opts.timeoutMs,
       stdio: ["ignore", "pipe", "pipe"],
@@ -328,21 +669,25 @@ export const npmSearch = (query: string, opts: NpmSearchOptions): NpmSearchResul
   }
   if (!Array.isArray(raw)) return fail("bad-shape", "expected JSON array from npm search");
 
-  const rawEntries = raw as NpmSearchEntry[];
-  const normalized: OssAlternative[] = [];
-  const rawForRanked: NpmSearchEntry[] = [];
-  for (let i = 0; i < rawEntries.length; i++) {
-    const rawEntry = rawEntries[i];
-    if (!rawEntry) continue;
-    const entry = normalizeEntry(rawEntry);
-    if (!entry) continue;
-    if (!filterJunk(entry, rawEntry)) continue;
-    if (!passesDownloadProxy(entry, opts.minWeeklyDownloads)) continue;
-    normalized.push(entry);
-    rawForRanked.push(rawEntry);
+  return parseRankedEntries(raw as NpmSearchEntry[], opts);
+};
+
+const shouldFallbackToCli = (result: NpmSearchResult): boolean =>
+  !result.ok &&
+  (result.reason === "registry-unavailable" ||
+    result.reason === "registry-bad-json" ||
+    result.reason === "registry-bad-shape");
+
+export const npmSearch = async (
+  query: string,
+  opts: NpmSearchOptions,
+): Promise<NpmSearchResult> => {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) {
+    return fail("invalid-input", "description must be a non-empty string");
   }
 
-  const ranked = rank(normalized, rawForRanked);
-  const cap = Math.max(1, Math.min(opts.maxResults, 10));
-  return { ok: true, results: ranked.slice(0, cap) };
+  const registry = await searchNpmRegistry(trimmed, opts);
+  if (!shouldFallbackToCli(registry)) return registry;
+  return searchNpmCli(trimmed, opts);
 };

--- a/tests/integration/find-oss-alternatives-cli.test.ts
+++ b/tests/integration/find-oss-alternatives-cli.test.ts
@@ -14,6 +14,7 @@ import {
   _resetQueryCacheForTests,
   dispatchGraphTool,
 } from "../../src/mcp/handlers.js";
+import { _setNpmSearchFetchForTests } from "../../src/nudge/npm-search.js";
 
 interface FakeNpmSetup {
   stdout: string;
@@ -36,6 +37,7 @@ const withFakeNpm = async <T>(
     chmodSync(npmPath, 0o755);
     process.env["PATH"] = `${bin}${delimiter}${originalPath ?? ""}`;
     process.env["HOME"] = home;
+    _setNpmSearchFetchForTests(async () => null);
     _resetQueryCacheForTests();
     return await fn(repo, home);
   } finally {
@@ -43,6 +45,7 @@ const withFakeNpm = async <T>(
     else process.env["PATH"] = originalPath;
     if (originalHome === undefined) delete process.env["HOME"];
     else process.env["HOME"] = originalHome;
+    _setNpmSearchFetchForTests();
     _resetQueryCacheForTests();
     rmSync(home, { recursive: true, force: true });
     rmSync(repo, { recursive: true, force: true });

--- a/tests/unit/nudge-npm-search.test.ts
+++ b/tests/unit/nudge-npm-search.test.ts
@@ -3,19 +3,24 @@ import assert from "node:assert/strict";
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
-import { npmSearch } from "../../src/nudge/npm-search.js";
+import {
+  _setNpmSearchFetchForTests,
+  npmSearch,
+} from "../../src/nudge/npm-search.js";
 
-// Controls the fake npm binary's behavior via env vars. The fake is a tiny
-// shell script that outputs whatever NPM_FAKE_STDOUT says and exits with
-// NPM_FAKE_STATUS. Lets us exercise every branch of npmSearch without
-// hitting the real npm or the network.
+// The fake npm binary is a tiny shell script that outputs configured JSON and
+// exits with the configured status. It exercises CLI fallback branches without
+// hitting the real npm binary.
 interface FakeNpmSetup {
   stdout: string;
   status: number;
   sleepSeconds?: number;
 }
 
-const withFakeNpm = <T>(setup: FakeNpmSetup | "missing", fn: () => T): T => {
+const withFakeNpm = async <T>(
+  setup: FakeNpmSetup | "missing",
+  fn: () => Promise<T>,
+): Promise<T> => {
   const bin = mkdtempSync(join(tmpdir(), "tokenomy-fake-npm-"));
   const originalPath = process.env["PATH"];
   try {
@@ -30,7 +35,7 @@ const withFakeNpm = <T>(setup: FakeNpmSetup | "missing", fn: () => T): T => {
       chmodSync(npmPath, 0o755);
       process.env["PATH"] = `${bin}${delimiter}${originalPath ?? ""}`;
     }
-    return fn();
+    return await fn();
   } finally {
     if (originalPath === undefined) delete process.env["PATH"];
     else process.env["PATH"] = originalPath;
@@ -38,79 +43,298 @@ const withFakeNpm = <T>(setup: FakeNpmSetup | "missing", fn: () => T): T => {
   }
 };
 
-const sampleEntries = JSON.stringify([
-  {
-    package: {
-      name: "p-retry",
-      version: "6.2.0",
-      description: "Retry a promise-returning or async function",
-      date: "2024-11-01T00:00:00.000Z",
-      links: { npm: "https://www.npmjs.com/package/p-retry" },
-    },
-    score: { final: 0.8, detail: { quality: 0.9, popularity: 0.75, maintenance: 0.82 } },
-    searchScore: 0.9,
-  },
-  {
-    package: {
-      name: "async-retry",
-      version: "1.3.3",
-      description: "Retry with exponential backoff",
-    },
-    score: { final: 0.6, detail: { quality: 0.7, popularity: 0.55, maintenance: 0.6 } },
-    searchScore: 0.55,
-  },
-  {
-    package: {
-      name: "junk-pkg",
-      version: "0.0.1",
-      description: "barely maintained",
-    },
-    score: { final: 0.1, detail: { quality: 0.1, popularity: 0.05, maintenance: 0.1 } },
-    searchScore: 0.3,
-  },
-  {
-    package: {
-      name: "deprecated-retry",
-      version: "1.0.0",
-      description: "old retry util",
-    },
-    score: { final: 0.65, detail: { quality: 0.6, popularity: 0.6, maintenance: 0.7 } },
-    searchScore: 0.4,
-    deprecated: "Use p-retry instead",
-  },
-]);
+const withNpmRegistry = async <T>(
+  body: string | null | ((url: string) => string | null),
+  fn: (urls: string[]) => Promise<T>,
+): Promise<T> => {
+  const urls: string[] = [];
+  try {
+    _setNpmSearchFetchForTests(async (url) => {
+      urls.push(url);
+      return typeof body === "function" ? body(url) : body;
+    });
+    return await fn(urls);
+  } finally {
+    _setNpmSearchFetchForTests();
+  }
+};
 
-test("npmSearch: happy path returns ranked results, drops junk + deprecated", () => {
-  withFakeNpm(
-    { stdout: sampleEntries, status: 0 },
-    () => {
-      const r = npmSearch("retry helper", {
+const sampleEntries = JSON.stringify({
+  objects: [
+    {
+      package: {
+        name: "p-retry",
+        version: "6.2.0",
+        description: "Retry a promise-returning or async function",
+        date: "2024-11-01T00:00:00.000Z",
+        links: { npm: "https://www.npmjs.com/package/p-retry" },
+      },
+      score: { final: 0.8, detail: { quality: 0.9, popularity: 0.75, maintenance: 0.82 } },
+      searchScore: 0.9,
+    },
+    {
+      package: {
+        name: "async-retry",
+        version: "1.3.3",
+        description: "Retry with exponential backoff",
+      },
+      score: { final: 0.6, detail: { quality: 0.7, popularity: 0.55, maintenance: 0.6 } },
+      searchScore: 0.55,
+    },
+    {
+      package: {
+        name: "junk-pkg",
+        version: "0.0.1",
+        description: "barely maintained",
+      },
+      score: { final: 0.1, detail: { quality: 0.1, popularity: 0.05, maintenance: 0.1 } },
+      searchScore: 0.3,
+    },
+    {
+      package: {
+        name: "deprecated-retry",
+        version: "1.0.0",
+        description: "old retry util",
+      },
+      score: { final: 0.65, detail: { quality: 0.6, popularity: 0.6, maintenance: 0.7 } },
+      searchScore: 0.4,
+      deprecated: "Use p-retry instead",
+    },
+  ],
+});
+
+test("npmSearch: happy path returns ranked results, drops junk + deprecated", async () => {
+  await withNpmRegistry(sampleEntries, async () => {
+    const r = await npmSearch("retry helper", {
+      timeoutMs: 5000,
+      minWeeklyDownloads: 1000,
+      maxResults: 5,
+    });
+    assert.equal(r.ok, true);
+    if (!r.ok) return;
+    const names = r.results.map((x) => x.name);
+    assert.deepEqual(names, ["p-retry", "async-retry"]);
+    // Fit reason includes maintenance language.
+    assert.match(r.results[0]!.fit_reason, /maintained|adoption|quality/);
+  });
+});
+
+test("npmSearch: registry HTTPS path is used before CLI fallback", async () => {
+  await withNpmRegistry(sampleEntries, async (urls) => {
+    await withFakeNpm({ stdout: "[]", status: 99 }, async () => {
+      const r = await npmSearch("retry helper", {
         timeoutMs: 5000,
-        minWeeklyDownloads: 1000,
+        minWeeklyDownloads: 0,
         maxResults: 5,
       });
       assert.equal(r.ok, true);
       if (!r.ok) return;
-      const names = r.results.map((x) => x.name);
-      assert.deepEqual(names, ["p-retry", "async-retry"]);
-      // Fit reason includes maintenance language.
-      assert.match(r.results[0]!.fit_reason, /maintained|adoption|quality/);
-    },
-  );
+      assert.equal(r.results[0]!.name, "p-retry");
+      assert.equal(
+        urls[0],
+        "https://registry.npmjs.org/-/v1/search?text=retry%20helper&size=20",
+      );
+      assert.ok(urls.length > 1);
+    });
+  });
 });
 
-test("npmSearch: standard package-only npm JSON is accepted", () => {
-  const packageOnly = JSON.stringify([
+test("npmSearch: falls back to CLI when registry HTTP is unavailable", async () => {
+  const cliEntries = JSON.stringify([
     {
-      name: "p-retry",
-      version: "6.2.0",
-      description: "Retry a promise-returning or async function",
-      date: "2024-11-01T00:00:00.000Z",
-      links: { npm: "https://www.npmjs.com/package/p-retry" },
+      package: {
+        name: "async-retry",
+        version: "1.3.3",
+        description: "Retry with exponential backoff",
+      },
+      score: { final: 0.7, detail: { quality: 0.7, popularity: 0.7, maintenance: 0.7 } },
+      searchScore: 0.8,
     },
   ]);
-  withFakeNpm({ stdout: packageOnly, status: 0 }, () => {
-    const r = npmSearch("retry", {
+  await withNpmRegistry(null, async () => {
+    await withFakeNpm({ stdout: cliEntries, status: 0 }, async () => {
+      const r = await npmSearch("retry helper", {
+        timeoutMs: 5000,
+        minWeeklyDownloads: 0,
+        maxResults: 5,
+      });
+      assert.equal(r.ok, true);
+      if (!r.ok) return;
+      assert.deepEqual(r.results.map((entry) => entry.name), ["async-retry"]);
+    });
+  });
+});
+
+test("npmSearch: falls back to CLI when registry JSON is null", async () => {
+  const cliEntries = JSON.stringify([
+    {
+      package: {
+        name: "p-retry",
+        version: "6.2.0",
+        description: "Retry promises",
+      },
+      score: { final: 0.8, detail: { quality: 0.8, popularity: 0.8, maintenance: 0.8 } },
+      searchScore: 0.8,
+    },
+  ]);
+  await withNpmRegistry("null", async () => {
+    await withFakeNpm({ stdout: cliEntries, status: 0 }, async () => {
+      const r = await npmSearch("retry", {
+        timeoutMs: 5000,
+        minWeeklyDownloads: 0,
+        maxResults: 5,
+      });
+      assert.equal(r.ok, true);
+      if (!r.ok) return;
+      assert.deepEqual(r.results.map((entry) => entry.name), ["p-retry"]);
+    });
+  });
+});
+
+test("npmSearch: variant aggregation can lift canonical packages over literal text matches", async () => {
+  const response = (names: string[]) =>
+    JSON.stringify({
+      objects: names.map((name, index) => ({
+        package: {
+          name,
+          version: "1.0.0",
+          description: `${name} retry backoff helper`,
+        },
+        score: {
+          final: 100 - index,
+          detail: { quality: 1, popularity: 1, maintenance: 1 },
+        },
+        searchScore: 100 - index,
+      })),
+    });
+  const bodies = new Map([
+    [
+      "retry with exponential backoff",
+      response(["retry-cli", "@example/retry-cli", "retry", "p-retry"]),
+    ],
+    [
+      "retry exponential backoff",
+      response(["retry", "p-retry", "async-retry", "retry-cli"]),
+    ],
+    [
+      "async retry backoff",
+      response(["p-retry", "async-retry", "retry"]),
+    ],
+    [
+      "promise retry backoff",
+      response(["p-retry", "retry", "async-retry"]),
+    ],
+    ["keywords:backoff", response(["p-retry", "retry"])],
+    ["keywords:retry", response(["p-retry", "async-retry"])],
+  ]);
+  const downloads = new Map([
+    ["retry-cli", 100],
+    ["@example/retry-cli", 100],
+    ["retry", 1_000_000],
+    ["p-retry", 750_000],
+    ["async-retry", 500_000],
+  ]);
+
+  await withNpmRegistry((url) => {
+    if (url.startsWith("https://api.npmjs.org/downloads/point/last-week/")) {
+      const name = decodeURIComponent(url.split("/").pop() ?? "");
+      return JSON.stringify({ downloads: downloads.get(name) ?? 0 });
+    }
+    const text = new URL(url).searchParams.get("text") ?? "";
+    return bodies.get(text) ?? JSON.stringify({ objects: [] });
+  }, async () => {
+    const r = await npmSearch("retry with exponential backoff", {
+      timeoutMs: 5000,
+      minWeeklyDownloads: 0,
+      maxResults: 3,
+    });
+    assert.equal(r.ok, true);
+    if (!r.ok) return;
+    assert.deepEqual(r.results.map((entry) => entry.name), [
+      "p-retry",
+      "retry",
+      "async-retry",
+    ]);
+    assert.ok(r.results.every((entry) => entry.score.overall >= 0.7));
+  });
+});
+
+test("npmSearch: download enrichment uses remaining registry deadline", async () => {
+  const body = JSON.stringify({
+    objects: [
+      {
+        package: { name: "p-retry", version: "1.0.0", description: "retry" },
+        score: { final: 1, detail: { quality: 1, popularity: 1, maintenance: 1 } },
+        searchScore: 1,
+      },
+    ],
+  });
+  await withNpmRegistry((url) => {
+    if (url.startsWith("https://api.npmjs.org/downloads/point/last-week/")) {
+      return JSON.stringify({ downloads: 1000 });
+    }
+    return body;
+  }, async (urls) => {
+    const originalDateNow = Date.now;
+    const times = [1_000, 1_006, 1_010, 1_012, 1_014, 1_016, 1_021, 1_022, 1_023];
+    Date.now = () => times.shift() ?? 1_023;
+    try {
+      const r = await npmSearch("retry", {
+        timeoutMs: 20,
+        minWeeklyDownloads: 0,
+        maxResults: 5,
+      });
+      assert.equal(r.ok, true);
+      assert.ok(urls.some((url) => url.includes("/-/v1/search")));
+      assert.ok(!urls.some((url) => url.includes("/downloads/point/last-week/")));
+    } finally {
+      Date.now = originalDateNow;
+    }
+  });
+});
+
+test("npmSearch: normalizes raw registry relevance scores into 0-1 overall scores", async () => {
+  const entries = JSON.stringify({
+    objects: [
+      {
+        package: { name: "retry-cli", version: "1.0.0", description: "retry cli" },
+        score: { final: 100, detail: { quality: 1, popularity: 1, maintenance: 1 } },
+        searchScore: 100,
+      },
+      {
+        package: { name: "p-retry", version: "6.2.0", description: "Retry promises" },
+        score: { final: 75, detail: { quality: 1, popularity: 1, maintenance: 1 } },
+        searchScore: 75,
+      },
+    ],
+  });
+  await withNpmRegistry(entries, async () => {
+    const r = await npmSearch("retry", {
+      timeoutMs: 5000,
+      minWeeklyDownloads: 0,
+      maxResults: 5,
+    });
+    assert.equal(r.ok, true);
+    if (!r.ok) return;
+    assert.equal(r.results[0]!.score.overall, 1);
+    assert.ok(r.results.every((entry) => entry.score.overall <= 1));
+  });
+});
+
+test("npmSearch: registry package object without score is accepted", async () => {
+  const packageOnly = JSON.stringify({
+    objects: [
+      {
+        name: "p-retry",
+        version: "6.2.0",
+        description: "Retry a promise-returning or async function",
+        date: "2024-11-01T00:00:00.000Z",
+        links: { npm: "https://www.npmjs.com/package/p-retry" },
+      },
+    ],
+  });
+  await withNpmRegistry(packageOnly, async () => {
+    const r = await npmSearch("retry", {
       timeoutMs: 5000,
       minWeeklyDownloads: 1000,
       maxResults: 5,
@@ -122,38 +346,37 @@ test("npmSearch: standard package-only npm JSON is accepted", () => {
   });
 });
 
-test("npmSearch: maxResults caps the returned list", () => {
-  withFakeNpm(
-    { stdout: sampleEntries, status: 0 },
-    () => {
-      const r = npmSearch("retry", {
-        timeoutMs: 5000,
-        minWeeklyDownloads: 0,
-        maxResults: 1,
-      });
-      assert.equal(r.ok, true);
-      if (!r.ok) return;
-      assert.equal(r.results.length, 1);
-      assert.equal(r.results[0]!.name, "p-retry");
-    },
-  );
+test("npmSearch: maxResults caps the returned list", async () => {
+  await withNpmRegistry(sampleEntries, async () => {
+    const r = await npmSearch("retry", {
+      timeoutMs: 5000,
+      minWeeklyDownloads: 0,
+      maxResults: 1,
+    });
+    assert.equal(r.ok, true);
+    if (!r.ok) return;
+    assert.equal(r.results.length, 1);
+    assert.equal(r.results[0]!.name, "p-retry");
+  });
 });
 
-test("npmSearch: minWeeklyDownloads filters low-popularity candidates", () => {
-  const entries = JSON.stringify([
-    {
-      package: { name: "popular", version: "1.0.0", description: "popular retry" },
-      score: { final: 0.9, detail: { quality: 0.9, popularity: 0.72, maintenance: 0.9 } },
-      searchScore: 0.9,
-    },
-    {
-      package: { name: "niche", version: "1.0.0", description: "niche retry" },
-      score: { final: 0.9, detail: { quality: 0.9, popularity: 0.2, maintenance: 0.9 } },
-      searchScore: 0.95,
-    },
-  ]);
-  withFakeNpm({ stdout: entries, status: 0 }, () => {
-    const r = npmSearch("retry", {
+test("npmSearch: minWeeklyDownloads filters low-popularity candidates", async () => {
+  const entries = JSON.stringify({
+    objects: [
+      {
+        package: { name: "popular", version: "1.0.0", description: "popular retry" },
+        score: { final: 0.9, detail: { quality: 0.9, popularity: 0.72, maintenance: 0.9 } },
+        searchScore: 0.9,
+      },
+      {
+        package: { name: "niche", version: "1.0.0", description: "niche retry" },
+        score: { final: 0.9, detail: { quality: 0.9, popularity: 0.2, maintenance: 0.9 } },
+        searchScore: 0.95,
+      },
+    ],
+  });
+  await withNpmRegistry(entries, async () => {
+    const r = await npmSearch("retry", {
       timeoutMs: 5000,
       minWeeklyDownloads: 1000,
       maxResults: 5,
@@ -164,27 +387,23 @@ test("npmSearch: minWeeklyDownloads filters low-popularity candidates", () => {
   });
 });
 
-test("npmSearch: empty search result returns ok with zero results", () => {
-  withFakeNpm(
-    { stdout: "[]", status: 0 },
-    () => {
-      const r = npmSearch("asdf-no-such-package-xyz", {
-        timeoutMs: 5000,
-        minWeeklyDownloads: 0,
-        maxResults: 5,
-      });
-      assert.equal(r.ok, true);
-      if (!r.ok) return;
-      assert.equal(r.results.length, 0);
-    },
-  );
+test("npmSearch: empty search result returns ok with zero results", async () => {
+  await withNpmRegistry(JSON.stringify({ objects: [] }), async () => {
+    const r = await npmSearch("asdf-no-such-package-xyz", {
+      timeoutMs: 5000,
+      minWeeklyDownloads: 0,
+      maxResults: 5,
+    });
+    assert.equal(r.ok, true);
+    if (!r.ok) return;
+    assert.equal(r.results.length, 0);
+  });
 });
 
-test("npmSearch: malformed JSON fails open with bad-json reason", () => {
-  withFakeNpm(
-    { stdout: "this is not json{{{", status: 0 },
-    () => {
-      const r = npmSearch("x", {
+test("npmSearch: malformed CLI fallback JSON fails open with bad-json reason", async () => {
+  await withNpmRegistry(null, async () => {
+    await withFakeNpm({ stdout: "this is not json{{{", status: 0 }, async () => {
+      const r = await npmSearch("x", {
         timeoutMs: 5000,
         minWeeklyDownloads: 0,
         maxResults: 5,
@@ -192,15 +411,14 @@ test("npmSearch: malformed JSON fails open with bad-json reason", () => {
       assert.equal(r.ok, false);
       if (r.ok) return;
       assert.equal(r.reason, "bad-json");
-    },
-  );
+    });
+  });
 });
 
-test("npmSearch: non-zero exit fails open with npm-failed reason", () => {
-  withFakeNpm(
-    { stdout: "[]", status: 1 },
-    () => {
-      const r = npmSearch("x", {
+test("npmSearch: non-zero CLI fallback exit fails open with npm-failed reason", async () => {
+  await withNpmRegistry(null, async () => {
+    await withFakeNpm({ stdout: "[]", status: 1 }, async () => {
+      const r = await npmSearch("x", {
         timeoutMs: 5000,
         minWeeklyDownloads: 0,
         maxResults: 5,
@@ -208,27 +426,29 @@ test("npmSearch: non-zero exit fails open with npm-failed reason", () => {
       assert.equal(r.ok, false);
       if (r.ok) return;
       assert.equal(r.reason, "npm-failed");
-    },
-  );
-});
-
-test("npmSearch: npm binary not found returns npm-unavailable with install hint", () => {
-  withFakeNpm("missing", () => {
-    const r = npmSearch("x", {
-      timeoutMs: 5000,
-      minWeeklyDownloads: 0,
-      maxResults: 5,
     });
-    assert.equal(r.ok, false);
-    if (r.ok) return;
-    assert.equal(r.reason, "npm-unavailable");
-    assert.ok(r.hint && r.hint.includes("npm"));
   });
 });
 
-test("npmSearch: empty query rejected up-front as invalid-input", () => {
+test("npmSearch: npm binary not found returns npm-unavailable with install hint", async () => {
+  await withNpmRegistry(null, async () => {
+    await withFakeNpm("missing", async () => {
+      const r = await npmSearch("x", {
+        timeoutMs: 5000,
+        minWeeklyDownloads: 0,
+        maxResults: 5,
+      });
+      assert.equal(r.ok, false);
+      if (r.ok) return;
+      assert.equal(r.reason, "npm-unavailable");
+      assert.ok(r.hint && r.hint.includes("npm"));
+    });
+  });
+});
+
+test("npmSearch: empty query rejected up-front as invalid-input", async () => {
   // No need for a fake npm — short-circuits before spawn.
-  const r = npmSearch("   ", {
+  const r = await npmSearch("   ", {
     timeoutMs: 5000,
     minWeeklyDownloads: 0,
     maxResults: 5,
@@ -238,22 +458,24 @@ test("npmSearch: empty query rejected up-front as invalid-input", () => {
   assert.equal(r.reason, "invalid-input");
 });
 
-test("npmSearch: ranking prefers higher searchScore × final, not insertion order", () => {
+test("npmSearch: ranking prefers higher searchScore × final, not insertion order", async () => {
   // Flip: put the worse candidate first; ranker should re-order.
-  const flipped = JSON.stringify([
-    {
-      package: { name: "lesser", version: "1.0.0", description: "less good" },
-      score: { final: 0.4, detail: { quality: 0.4, popularity: 0.4, maintenance: 0.4 } },
-      searchScore: 0.3,
-    },
-    {
-      package: { name: "better", version: "1.0.0", description: "much better" },
-      score: { final: 0.9, detail: { quality: 0.9, popularity: 0.9, maintenance: 0.9 } },
-      searchScore: 0.9,
-    },
-  ]);
-  withFakeNpm({ stdout: flipped, status: 0 }, () => {
-    const r = npmSearch("x", {
+  const flipped = JSON.stringify({
+    objects: [
+      {
+        package: { name: "lesser", version: "1.0.0", description: "less good" },
+        score: { final: 0.4, detail: { quality: 0.4, popularity: 0.4, maintenance: 0.4 } },
+        searchScore: 0.3,
+      },
+      {
+        package: { name: "better", version: "1.0.0", description: "much better" },
+        score: { final: 0.9, detail: { quality: 0.9, popularity: 0.9, maintenance: 0.9 } },
+        searchScore: 0.9,
+      },
+    ],
+  });
+  await withNpmRegistry(flipped, async () => {
+    const r = await npmSearch("x", {
       timeoutMs: 5000,
       minWeeklyDownloads: 0,
       maxResults: 5,


### PR DESCRIPTION
## Summary

Fixes the alpha.18 OSS-alternatives ranker, which was returning `retry-cli` ahead of `p-retry`, `merge-options` ahead of `deepmerge`, and leaking `@aws-amplify/*` fragments into generic schema-validation queries. Modern `npm search --json` no longer returns `score` or `searchScore` — the ranker was falling through to a flat 0.5 default. Fix swaps the fetch layer to the npm registry search endpoint (which still returns scores) and adds three rank-sharpening heuristics on top.

## Surface

- [x] New modules — none; this is a rework of `src/nudge/npm-search.ts`
- [x] Config / types — `src/core/types.ts` (minor)
- [x] MCP tool — `src/mcp/handlers.ts` (minor)
- [x] Tests — fixtures updated + new coverage

## Why

For *"retry with exponential backoff"* the old ranker returned:
- `retry-cli` (a CLI tool, not a library)
- `@bpinternal/retry-cli`
- `@mgdn/retry-cli`

All at flat 0.5 scores. `p-retry` was in the list at position ~16 but never surfaced because we only kept `max_results` from an unranked text-match list.

## How it works

**Registry endpoint swap.** `https://registry.npmjs.org/-/v1/search?text=<q>&size=20` still returns `score.final` + `score.detail.{quality,popularity,maintenance}` + `searchScore`. Direct HTTPS GET; `npm search --json` stays as a fallback for offline/proxy environments.

**Query-variant aggregation (up to 8 variants, reciprocal-rank fusion).**
- Original query
- Compact tokens
- **Adjacent-token concatenations** — `deep merge` → `deepmerge`, `rate limit` → `ratelimit`. Many canonical npm packages are named as one word even when the concept is universally spoken as two.
- Domain augmentations for retry/backoff/http/fetch/client

**Download-count enrichment.** Top-15 candidates get a batched (Promise.all of 4) HTTP call to `api.npmjs.org/downloads/point/last-week/<pkg>`. Log-normalized into a popularity score so `p-retry` (~40M/week) beats `retry-cli` (~2k/week) even when both text-match equally.

**Intent penalty.** Kills the remaining noise:
- Names matching `-cli` without `cli` in query: × 0.65
- Scoped packages generally: × 0.8
- Big-vendor scopes (`@aws-amplify`, `@aws-cdk`, `@aws-sdk`, `@google-cloud`, `@azure`, `@cloudflare`, `@microsoft`, `@oracle`, `@alibaba-cloud`, `@sap`, `@ibm`, `@salesforce`, …): × 0.5 unless the query mentions the vendor

**Score normalization.** Registry responses where `score.final` is returned raw (not 0-1) get max-normalized. Defensive against future npm API shape drift.

**Deadline-aware fetching.** All HTTPS calls share a single deadline budget; late calls short-circuit to 0ms timeout.

## Test plan

End-to-end probed against the live npm registry:

| Query | Top picks |
|---|---|
| `retry with exponential backoff` | p-retry / exponential-backoff / promise-retry / retry-request / retry |
| `deep merge plain objects` | **deepmerge** / merge-options / copy-anything / webpack-merge / merge-anything |
| `validate schemas at runtime` | superstruct / ts-interface-checker / jsonschema (no AWS Amplify leak) |
| `http client with interceptors` | node-fetch / axios / undici |
| `rate limit requests` | express-rate-limit / ratelimit / limiter |

- [x] `pnpm test` — 350 → **356** (+6 new tests for registry-first behavior, CLI fallback, variant aggregation, raw-score normalization)
- [x] `pnpm run build` clean
- [x] `npx tsc --noEmit` clean
- [x] Live end-to-end probe via `dispatchGraphTool("find_oss_alternatives", ...)`

## Invariants preserved

- [x] Fail-open: registry failures cascade to CLI, CLI failures cascade to `{ok:false, reason}`
- [x] Budget clipping still governs output shape
- [x] MCP tool signature unchanged; only ranking behavior improves
- [x] No new config keys required; existing `nudge.oss_search.*` continues to apply
- [x] Privacy note unchanged — still only talks to public package registries

## Breaking changes

- [x] No breaking changes

## Privacy

No change from alpha.18. Queries still go to public package registries (now also `api.npmjs.org/downloads/*` for popularity scoring). Disable the proactive Write nudge with `tokenomy config set nudge.write_intercept.enabled false`.

## Checklist

- [x] Title follows `<type>(<scope>): <description>`
- [x] Rebased on `main`, no merge commits
- [x] One logical change per PR (ranker fix; all supporting heuristics serve the same fix)
- [x] CHANGELOG updated
- [x] `pnpm test` + `pnpm run build` green locally