### PR TITLE
fix(nudge): unbreak repo_results on large repos + update restages graph + 0.1.0-alpha.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,48 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.1.0-alpha.20] — 2026-04-22
+
+Fixes a silent truncation in `find_oss_alternatives` repo-search that collapsed
+`repo_results` to `[]` on any real-world codebase, and teaches `tokenomy update`
+to restage the graph MCP server when one is already registered.
+
+### Fixed
+
+- **`repo_results` was silently empty on large repos.** `src/nudge/repo-search.ts`
+  spawned a one-stage `git grep -n -E "tok1|tok2"` with `maxBuffer: 64_000`. On
+  chatbox-js with a query like `runtime configuration loader`, the same command
+  produces ~2.7 MB of output — 43× over the buffer. `spawnSync` aborts with
+  `ENOBUFS`, returns `status: null`, and the caller returns `[]`. Users never
+  saw repo matches regardless of how many existed.
+
+  Fix: two-stage search. Stage 1 runs `git grep -l` (filenames only — one short
+  line per match file, bounded in practice by repo file count) with a 4 MB
+  buffer. Stage 2 runs `git grep -n --max-count 3` against only the first 50
+  returned files with an 8 MB buffer (generous enough to survive repos that
+  commit bundled / minified assets with very long lines). Output is always
+  small relative to repo size, and matches are still capped by `--max-count 3`
+  per file and `maxResults` overall. Applied to both current-branch and
+  other-branch paths.
+
+### Changed
+
+- **`tokenomy update` now restages the graph MCP server when one was already
+  registered.** Previously, `update` only re-patched the PostToolUse /
+  PreToolUse hooks; users with a `tokenomy-graph` entry in `~/.claude.json`
+  had to remember to re-run `tokenomy init --graph-path=<repo>` manually to
+  pick up schema changes. `update` now reads the existing graph path from
+  `~/.claude.json`, validates that the directory still exists, and forwards
+  `--graph-path=<existing path>` to the re-init. No new flag required; when
+  no graph is registered, behavior is unchanged.
+
+### Tests
+
+- Added a unit test that writes enough matching files to overflow the old
+  64 KB buffer (100 files, each containing the query tokens repeatedly), then
+  asserts `repo_results` is still non-empty and well-formed. Full suite:
+  **357/357 passing**.
+
 ## [0.1.0-alpha.19] — 2026-04-22
 
 Improves npm package ranking for `find_oss_alternatives` by querying the npm
@@ -435,7 +477,8 @@ First public alpha. Phase 1 scope: transparent MCP tool-output trimming via `Pos
 - Statusline with live savings counter — Phase 2.
 - `tokenomy analyze` over transcripts — Phase 2.
 
-[Unreleased]: https://github.com/RahulDhiman93/Tokenomy/compare/v0.1.0-alpha.19...HEAD
+[Unreleased]: https://github.com/RahulDhiman93/Tokenomy/compare/v0.1.0-alpha.20...HEAD
+[0.1.0-alpha.20]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.20
 [0.1.0-alpha.19]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.19
 [0.1.0-alpha.18]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.18
 [0.1.0-alpha.17]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.17

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A surgical hook + analysis toolkit for **Claude Code and Codex CLI** that transp
 [![Node](https://img.shields.io/badge/node-%E2%89%A520-brightgreen)](#quickstart)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](#license)
 [![Phase](https://img.shields.io/badge/phase%204-alpha-blue)](#roadmap)
-[![Tests](https://img.shields.io/badge/tests-356%20passing-brightgreen)](#contribute)
+[![Tests](https://img.shields.io/badge/tests-357%20passing-brightgreen)](#contribute)
 
 </div>
 
@@ -92,7 +92,7 @@ Since alpha.15, `init --graph-path` builds the graph for you in a single shot; p
 
 Codex-only / manual registration: `codex mcp add tokenomy-graph -- tokenomy graph serve --path "$PWD"`.
 
-> **Pre-`1.0`.** Every release is `-alpha.N`; breaking changes may land on minor bumps (see [CHANGELOG](./CHANGELOG.md)). Pin for stability: `npm install -g tokenomy@0.1.0-alpha.19`. Upgrade with one command — `tokenomy update` (runs `npm install -g` + re-stages the hook + is idempotent; config + logs preserved). Check without installing: `tokenomy update --check`. Pin an exact release: `tokenomy update@0.1.0-alpha.19` or `tokenomy update --version 0.1.0-alpha.19`. Bleeding edge: see [Development](#development).
+> **Pre-`1.0`.** Every release is `-alpha.N`; breaking changes may land on minor bumps (see [CHANGELOG](./CHANGELOG.md)). Pin for stability: `npm install -g tokenomy@0.1.0-alpha.20`. Upgrade with one command — `tokenomy update` (runs `npm install -g` + re-stages the hook + is idempotent; config + logs preserved). Check without installing: `tokenomy update --check`. Pin an exact release: `tokenomy update@0.1.0-alpha.20` or `tokenomy update --version 0.1.0-alpha.20`. Bleeding edge: see [Development](#development).
 
 Watch trims live — `tail -f ~/.tokenomy/savings.jsonl`:
 
@@ -419,8 +419,8 @@ Globs are gitignore-style: `**` crosses directory boundaries, `*` stays within a
 ```bash
 tokenomy update            # install latest + re-stage hook in one shot
 tokenomy update --check    # query registry, print installed vs remote, exit 1 if out of date
-tokenomy update@0.1.0-alpha.19   # npm-style pin
-tokenomy update --version=0.1.0-alpha.19  # same, explicit flag
+tokenomy update@0.1.0-alpha.20   # npm-style pin
+tokenomy update --version=0.1.0-alpha.20  # same, explicit flag
 tokenomy update --tag=beta # opt into a non-default dist-tag
 ```
 
@@ -458,7 +458,7 @@ Removes both hook entries from `~/.claude/settings.json` (matched by absolute co
 
 ## 🤝 Contribute
 
-Contributions welcome. Dependency-light (zero runtime deps in the hot hook path; `@modelcontextprotocol/sdk` loaded dynamically for the graph server; `js-tiktoken` optional peer for accurate `analyze`), test-first (356/356 currently green, 96% stmt / 85% branch / 100% func coverage).
+Contributions welcome. Dependency-light (zero runtime deps in the hot hook path; `@modelcontextprotocol/sdk` loaded dynamically for the graph server; `js-tiktoken` optional peer for accurate `analyze`), test-first (357/357 currently green, 96% stmt / 85% branch / 100% func coverage).
 
 **Good first issues:**
 
@@ -498,7 +498,7 @@ Rules are pure: `(toolName, toolInput, toolResponse, config) → { kind: "passth
 ```bash
 git clone https://github.com/RahulDhiman93/Tokenomy && cd Tokenomy
 npm install && npm run build
-npm test             # 356 tests, ~2s
+npm test             # 357 tests, ~2s
 npm run coverage     # c8 → coverage/lcov.info + HTML
 npm run typecheck    # tsc --noEmit
 npm link             # point `tokenomy` at your local build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenomy",
-  "version": "0.1.0-alpha.19",
+  "version": "0.1.0-alpha.20",
   "description": "Surgical Claude Code hook that transparently trims bloated MCP tool responses and clamps oversized file reads — stop burning tokens on tool chatter.",
   "type": "module",
   "engines": {

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -1,8 +1,31 @@
 import { spawnSync } from "node:child_process";
-import { realpathSync } from "node:fs";
+import { existsSync, realpathSync, statSync } from "node:fs";
 import { sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { TOKENOMY_VERSION } from "../core/version.js";
+import { getClaudeMcpServer } from "../util/claude-user-config.js";
+
+// Read the previously-registered graph path so `tokenomy update` can restage
+// the graph MCP server for the user without making them remember their path.
+// Returns null when no graph is registered, when the registered entry is
+// malformed, or when the directory no longer exists on disk.
+const previouslyRegisteredGraphPath = (): string | null => {
+  const entry = getClaudeMcpServer("tokenomy-graph") as
+    | { command?: unknown; args?: unknown }
+    | undefined;
+  if (!entry || entry.command !== "tokenomy" || !Array.isArray(entry.args)) return null;
+  const args = entry.args as string[];
+  const pathIdx = args.indexOf("--path");
+  if (pathIdx === -1 || pathIdx + 1 >= args.length) return null;
+  const path = args[pathIdx + 1];
+  if (typeof path !== "string" || path.length === 0) return null;
+  try {
+    if (!existsSync(path) || !statSync(path).isDirectory()) return null;
+  } catch {
+    return null;
+  }
+  return path;
+};
 
 // `tokenomy update` — self-update command.
 //
@@ -233,8 +256,21 @@ export const runUpdate = async (opts: UpdateOptions): Promise<number> => {
   // the newly-installed version. We call runInit() from the *new* install
   // via a separate node invocation so we don't stage a stale in-memory
   // dist from the old process.
-  process.stdout.write("\nRe-staging hook + config…\n");
-  const reinit = spawnSync("tokenomy", ["init"], { stdio: "inherit" });
+  //
+  // If the user previously registered `tokenomy-graph` (detectable via
+  // ~/.claude.json), forward the same --graph-path to `tokenomy init` so
+  // the MCP registration stays in sync and the graph is refreshed under
+  // the new binary's schema. Skipped silently when no graph is registered.
+  const existingGraphPath = previouslyRegisteredGraphPath();
+  const initArgs = existingGraphPath
+    ? ["init", `--graph-path=${existingGraphPath}`]
+    : ["init"];
+  process.stdout.write(
+    existingGraphPath
+      ? `\nRe-staging hook + config + graph (${existingGraphPath})…\n`
+      : "\nRe-staging hook + config…\n",
+  );
+  const reinit = spawnSync("tokenomy", initArgs, { stdio: "inherit" });
   if (reinit.status !== 0) {
     process.stderr.write(
       "tokenomy update: install succeeded but `tokenomy init` failed. " +

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,1 +1,1 @@
-export const TOKENOMY_VERSION = "0.1.0-alpha.19";
+export const TOKENOMY_VERSION = "0.1.0-alpha.20";

--- a/src/nudge/repo-search.ts
+++ b/src/nudge/repo-search.ts
@@ -65,6 +65,43 @@ const parseGrepLine = (
   };
 };
 
+// Two-stage `git grep` keeps subprocess output bounded regardless of repo
+// size. A single-stage `git grep -n -E "token1|token2"` on a large codebase
+// (chatbox-js: 2.7 MB of output for `provider|loader|runtime`) blows right
+// through `spawnSync`'s `maxBuffer`, which returns `status: null` and an
+// empty stdout, silently collapsing `repo_results` to `[]`.
+//
+// Stage 1: `git grep -l` → newline-delimited file list. One short line per
+// matching file, bounded in practice by repo file count.
+// Stage 2: `git grep -n -E` against only the first ~50 files. Per-file match
+// count capped at 3 by `--max-count 3`, so output is always small.
+const MAX_FILES_STAGE_TWO = 50;
+const STAGE_ONE_BUFFER = 4_000_000; // ~4 MB of file paths — generous headroom.
+// 50 files × 3 matches is fine for typical source lines, but repos that keep
+// bundled or minified assets in-tree (cdn-src/, dist/) can have lines running
+// tens of thousands of chars. 8 MB leaves enough headroom to avoid ENOBUFS.
+const STAGE_TWO_BUFFER = 8_000_000;
+
+const currentBranchFiles = (
+  cwd: string,
+  pattern: string,
+  opts: RepoSearchOptions,
+): string[] => {
+  const r = spawnSync("git", ["grep", "-l", "-i", "-E", pattern, "--", "."], {
+    cwd,
+    encoding: "utf8",
+    timeout: opts.timeoutMs,
+    stdio: ["ignore", "pipe", "ignore"],
+    maxBuffer: STAGE_ONE_BUFFER,
+  });
+  if (r.status !== 0 || !r.stdout) return [];
+  return r.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, MAX_FILES_STAGE_TWO);
+};
+
 const currentBranchMatches = (
   cwd: string,
   pattern: string,
@@ -74,15 +111,17 @@ const currentBranchMatches = (
   // against the working tree, and keeps tooling consistent with the
   // other-branch path below. Avoids a ripgrep dependency + ENOENT on
   // machines where `rg` is a shell alias rather than a real binary.
+  const files = currentBranchFiles(cwd, pattern, opts);
+  if (files.length === 0) return [];
   const r = spawnSync(
     "git",
-    ["grep", "-n", "-i", "-E", "--max-count", "3", pattern, "--", "."],
+    ["grep", "-n", "-i", "-E", "--max-count", "3", pattern, "--", ...files],
     {
       cwd,
       encoding: "utf8",
       timeout: opts.timeoutMs,
       stdio: ["ignore", "pipe", "ignore"],
-      maxBuffer: 64_000,
+      maxBuffer: STAGE_TWO_BUFFER,
     },
   );
   if (r.status !== 0 || !r.stdout) return [];
@@ -126,6 +165,30 @@ const branchNames = (cwd: string, timeoutMs: number): string[] => {
     .slice(0, 20);
 };
 
+const otherBranchFiles = (
+  cwd: string,
+  pattern: string,
+  branch: string,
+  opts: RepoSearchOptions,
+): string[] => {
+  const r = spawnSync("git", ["grep", "-l", "-i", "-E", pattern, branch], {
+    cwd,
+    encoding: "utf8",
+    timeout: opts.timeoutMs,
+    stdio: ["ignore", "pipe", "ignore"],
+    maxBuffer: STAGE_ONE_BUFFER,
+  });
+  if (r.status !== 0 || !r.stdout) return [];
+  // `git grep -l <branch>` prefixes each filename with `<branch>:`; strip.
+  const prefix = `${branch}:`;
+  return r.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => (line.startsWith(prefix) ? line.slice(prefix.length) : line))
+    .slice(0, MAX_FILES_STAGE_TWO);
+};
+
 const otherBranchMatches = (
   cwd: string,
   pattern: string,
@@ -135,13 +198,19 @@ const otherBranchMatches = (
   const out: RepoAlternative[] = [];
   for (const branch of branchNames(cwd, opts.timeoutMs)) {
     if (out.length + already >= opts.maxResults) break;
-    const r = spawnSync("git", ["grep", "-n", "-i", "-E", pattern, branch, "--", "."], {
-      cwd,
-      encoding: "utf8",
-      timeout: opts.timeoutMs,
-      stdio: ["ignore", "pipe", "ignore"],
-      maxBuffer: 64_000,
-    });
+    const files = otherBranchFiles(cwd, pattern, branch, opts);
+    if (files.length === 0) continue;
+    const r = spawnSync(
+      "git",
+      ["grep", "-n", "-i", "-E", "--max-count", "3", pattern, branch, "--", ...files],
+      {
+        cwd,
+        encoding: "utf8",
+        timeout: opts.timeoutMs,
+        stdio: ["ignore", "pipe", "ignore"],
+        maxBuffer: STAGE_TWO_BUFFER,
+      },
+    );
     if (r.status !== 0 || !r.stdout) continue;
     for (const line of r.stdout.split("\n")) {
       const withoutBranch = line.startsWith(`${branch}:`)

--- a/tests/unit/nudge-repo-search.test.ts
+++ b/tests/unit/nudge-repo-search.test.ts
@@ -117,3 +117,43 @@ test("repoSearch: returns matches from another local branch", () => {
     );
   });
 });
+
+test("repoSearch: survives >64 KB of git-grep output (large-repo regression)", () => {
+  withGitRepo((repo) => {
+    // Seed 120 files that each match the search pattern on multiple lines.
+    // With the legacy single-stage `git grep -n` + 64 KB maxBuffer, the
+    // subprocess overflows with ENOBUFS, status becomes null, and repoSearch
+    // silently returns []. The two-stage implementation caps Stage 1 output
+    // at filenames only, then runs Stage 2 against the first 50 files.
+    mkdirSync(join(repo, "src", "providers"), { recursive: true });
+    const noise = "provider runtime configuration ".repeat(40);
+    for (let i = 0; i < 120; i++) {
+      writeFileSync(
+        join(repo, "src", "providers", `Provider${i}.ts`),
+        `// ${noise}\nexport const Provider${i} = () => null;\n// ${noise}\n`,
+      );
+    }
+    runGit(repo, ["add", "."]);
+    runGit(repo, [
+      "-c",
+      "user.name=Tokenomy Test",
+      "-c",
+      "user.email=tokenomy@example.test",
+      "commit",
+      "-m",
+      "seed large repo",
+    ]);
+
+    const result = repoSearch(repo, "provider runtime configuration", {
+      timeoutMs: 10_000,
+      maxResults: 5,
+    });
+    assert.equal(result.ok, true, JSON.stringify(result));
+    if (!result.ok) return;
+    assert.ok(
+      result.results.length > 0,
+      "repo search must return matches even when raw git grep output exceeds 64 KB",
+    );
+    assert.equal(result.results[0]?.source, "current-branch");
+  });
+});


### PR DESCRIPTION
## Summary

Two fixes for `find_oss_alternatives` that together make it actually work on real-world repos:

1. **`repo_results` was silently empty on any repo with >64 KB of git-grep output** — i.e., almost every real codebase. Two-stage search with a 4 MB Stage 1 buffer (filenames) and 8 MB Stage 2 buffer (matched lines).
2. **`tokenomy update` now restages the graph MCP server when one is already registered** — reads the existing `--path` from `~/.claude.json` and forwards it to the re-init.

## Surface

- [x] `PreToolUse` hook — unaffected
- [x] CLI — `src/cli/update.ts` (restage graph)
- [x] Config / types — unchanged
- [x] MCP tool — `src/nudge/repo-search.ts` rewrite (two-stage)
- [x] Tests — new large-repo regression test

## Why

Live end-to-end test against chatbox-js (~5 000 files) while verifying alpha.19:

```
Call mcp__tokenomy-graph__find_oss_alternatives with description "runtime configuration loader"
→ "repo_results": []
```

Despite `useRuntimeConfig` having ~40 usages in the repo. Traced to `spawnSync`:

```
$ cd chatbox-js && git grep -n -i -E --max-count 3 "runtime|configuration|loader" -- . | wc -c
2,756,149
```

2.76 MB of output — **43× the 64 KB `maxBuffer`** in `src/nudge/repo-search.ts:85`. `spawnSync` kills the child with `ENOBUFS`, returns `status: null`, and the guard `if (r.status !== 0 || !r.stdout) return []` silently collapses everything. This has been broken since alpha.18; tokenomy itself is tiny (~150 files) so it never surfaced during local dogfooding.

Separately, users with a registered graph MCP have to remember to manually re-run `tokenomy init --graph-path=<repo>` after every `tokenomy update` to pick up schema/binary changes. `update` now does this automatically when a graph is already registered.

## How it works

### Repo-search two-stage

```ts
// Stage 1: filenames only, 4 MB buffer, bounded by repo file count.
const filesR = spawnSync("git", ["grep", "-l", "-i", "-E", pattern, "--", "."], {
  cwd, encoding: "utf8", timeout, stdio: ["ignore","pipe","ignore"],
  maxBuffer: 4_000_000,
});
const files = filesR.stdout.split("\n").filter(Boolean).slice(0, 50);

// Stage 2: against only those files, 8 MB buffer (bundled assets can have
// 10k+ char lines, so 1 MB is too tight for cdn-src/, dist/ in-tree).
const r = spawnSync("git", ["grep", "-n", "-i", "-E", "--max-count", "3",
  pattern, "--", ...files], { maxBuffer: 8_000_000, ... });
```

Applied symmetrically to the other-branch path.

### Update restages graph

```ts
const existingGraphPath = previouslyRegisteredGraphPath();
const initArgs = existingGraphPath
  ? ["init", `--graph-path=${existingGraphPath}`]
  : ["init"];
spawnSync("tokenomy", initArgs, { stdio: "inherit" });
```

`previouslyRegisteredGraphPath()` reads `~/.claude.json` → `mcpServers['tokenomy-graph'].args`, extracts the value after `--path`, and validates the directory still exists on disk. Returns `null` (→ skip) when anything is missing or malformed.

## Test plan

- [x] Unit: new `repoSearch: survives >64 KB of git-grep output` test seeds 120 files each matching on multiple lines with ~40 chars of noise per line, asserts non-empty results.
- [x] `pnpm test` — 356 → **357 passing** (+1)
- [x] `pnpm run build` clean
- [x] `npx tsc --noEmit` clean
- [x] End-to-end probe against chatbox-js through `dispatchGraphTool("find_oss_alternatives", ...)`:

| Query | Before | After |
|---|---|---|
| `runtime configuration loader` | 0 repo matches | 3 repo matches |
| `useRuntimeConfig provider` | 0 repo matches | 3 repo matches |
| `video window component` | 3 | 3 |
| `deep merge objects` | 0 | 3 |

## Invariants preserved

- [x] Fail-open: Stage 1 failure → `[]` (same as before); Stage 2 failure → `[]`
- [x] `--max-count 3` per file still caps matches; `maxResults` still caps total
- [x] `graph-path` extraction validates the directory exists; missing dir = skip
- [x] `tokenomy update` with no graph registered behaves exactly as before

## Breaking changes

- [x] No breaking changes

## Checklist

- [x] Title follows `<type>(<scope>): <description>`
- [x] Rebased on `main`, no merge commits
- [x] CHANGELOG + README + version bump
- [x] `pnpm test` + `pnpm run build` green locally