### PR TITLE
feat(nudge): rank repo matches by distinct token hits + 0.1.0-alpha.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,38 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.1.0-alpha.21] — 2026-04-22
+
+Relevance ranking for `find_oss_alternatives` `repo_results`. Files that match
+more distinct query tokens now rank above files that only hit the most common
+token, so the actually-relevant code surfaces first.
+
+### Changed
+
+- **Repo-search ranks candidate files by distinct token hits before Stage 2.**
+  Previously, a query like `useRuntimeConfig provider` on a large React
+  codebase returned only `Provider`-matching files because `git grep` emits
+  Stage 2 output in alphabetical/tree order and the `maxResults` cap stopped
+  before the actually-relevant `useRuntimeConfig.ts` file got a turn.
+
+  New behavior: Stage 1 runs one `git grep -l` per query token (capped at 8
+  per query in `queryTokens`; typical queries have 2-4 tokens) and scores
+  each candidate file by the number of distinct tokens it contains. The
+  top-scoring files feed Stage 2 in ranked order. Because `git grep` doesn't
+  honor pathspec argument order, Stage 2 output is re-sorted in code against
+  the ranking before slicing to `maxResults`. Applied symmetrically to
+  current-branch and other-branch paths.
+
+  Cost: 2-4 extra `git grep -l` subprocess spawns per query (~50 ms each on
+  a 5 000-file repo). Output volume is unchanged.
+
+### Tests
+
+- Added a unit test that seeds two files — one matching only the common
+  token (`provider`) and one matching both tokens (`useRuntimeConfig` +
+  `provider`) — and asserts the multi-token file ranks first. Full suite:
+  **358/358 passing**.
+
 ## [0.1.0-alpha.20] — 2026-04-22
 
 Fixes a silent truncation in `find_oss_alternatives` repo-search that collapsed
@@ -477,7 +509,8 @@ First public alpha. Phase 1 scope: transparent MCP tool-output trimming via `Pos
 - Statusline with live savings counter — Phase 2.
 - `tokenomy analyze` over transcripts — Phase 2.
 
-[Unreleased]: https://github.com/RahulDhiman93/Tokenomy/compare/v0.1.0-alpha.20...HEAD
+[Unreleased]: https://github.com/RahulDhiman93/Tokenomy/compare/v0.1.0-alpha.21...HEAD
+[0.1.0-alpha.21]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.21
 [0.1.0-alpha.20]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.20
 [0.1.0-alpha.19]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.19
 [0.1.0-alpha.18]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.18

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A surgical hook + analysis toolkit for **Claude Code and Codex CLI** that transp
 [![Node](https://img.shields.io/badge/node-%E2%89%A520-brightgreen)](#quickstart)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](#license)
 [![Phase](https://img.shields.io/badge/phase%204-alpha-blue)](#roadmap)
-[![Tests](https://img.shields.io/badge/tests-357%20passing-brightgreen)](#contribute)
+[![Tests](https://img.shields.io/badge/tests-358%20passing-brightgreen)](#contribute)
 
 </div>
 
@@ -92,7 +92,7 @@ Since alpha.15, `init --graph-path` builds the graph for you in a single shot; p
 
 Codex-only / manual registration: `codex mcp add tokenomy-graph -- tokenomy graph serve --path "$PWD"`.
 
-> **Pre-`1.0`.** Every release is `-alpha.N`; breaking changes may land on minor bumps (see [CHANGELOG](./CHANGELOG.md)). Pin for stability: `npm install -g tokenomy@0.1.0-alpha.20`. Upgrade with one command — `tokenomy update` (runs `npm install -g` + re-stages the hook + is idempotent; config + logs preserved). Check without installing: `tokenomy update --check`. Pin an exact release: `tokenomy update@0.1.0-alpha.20` or `tokenomy update --version 0.1.0-alpha.20`. Bleeding edge: see [Development](#development).
+> **Pre-`1.0`.** Every release is `-alpha.N`; breaking changes may land on minor bumps (see [CHANGELOG](./CHANGELOG.md)). Pin for stability: `npm install -g tokenomy@0.1.0-alpha.21`. Upgrade with one command — `tokenomy update` (runs `npm install -g` + re-stages the hook + is idempotent; config + logs preserved). Check without installing: `tokenomy update --check`. Pin an exact release: `tokenomy update@0.1.0-alpha.21` or `tokenomy update --version 0.1.0-alpha.21`. Bleeding edge: see [Development](#development).
 
 Watch trims live — `tail -f ~/.tokenomy/savings.jsonl`:
 
@@ -419,8 +419,8 @@ Globs are gitignore-style: `**` crosses directory boundaries, `*` stays within a
 ```bash
 tokenomy update            # install latest + re-stage hook in one shot
 tokenomy update --check    # query registry, print installed vs remote, exit 1 if out of date
-tokenomy update@0.1.0-alpha.20   # npm-style pin
-tokenomy update --version=0.1.0-alpha.20  # same, explicit flag
+tokenomy update@0.1.0-alpha.21   # npm-style pin
+tokenomy update --version=0.1.0-alpha.21  # same, explicit flag
 tokenomy update --tag=beta # opt into a non-default dist-tag
 ```
 
@@ -458,7 +458,7 @@ Removes both hook entries from `~/.claude/settings.json` (matched by absolute co
 
 ## 🤝 Contribute
 
-Contributions welcome. Dependency-light (zero runtime deps in the hot hook path; `@modelcontextprotocol/sdk` loaded dynamically for the graph server; `js-tiktoken` optional peer for accurate `analyze`), test-first (357/357 currently green, 96% stmt / 85% branch / 100% func coverage).
+Contributions welcome. Dependency-light (zero runtime deps in the hot hook path; `@modelcontextprotocol/sdk` loaded dynamically for the graph server; `js-tiktoken` optional peer for accurate `analyze`), test-first (358/358 currently green, 96% stmt / 85% branch / 100% func coverage).
 
 **Good first issues:**
 
@@ -498,7 +498,7 @@ Rules are pure: `(toolName, toolInput, toolResponse, config) → { kind: "passth
 ```bash
 git clone https://github.com/RahulDhiman93/Tokenomy && cd Tokenomy
 npm install && npm run build
-npm test             # 357 tests, ~2s
+npm test             # 358 tests, ~2s
 npm run coverage     # c8 → coverage/lcov.info + HTML
 npm run typecheck    # tsc --noEmit
 npm link             # point `tokenomy` at your local build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenomy",
-  "version": "0.1.0-alpha.20",
+  "version": "0.1.0-alpha.21",
   "description": "Surgical Claude Code hook that transparently trims bloated MCP tool responses and clamps oversized file reads — stop burning tokens on tool chatter.",
   "type": "module",
   "engines": {

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,1 +1,1 @@
-export const TOKENOMY_VERSION = "0.1.0-alpha.20";
+export const TOKENOMY_VERSION = "0.1.0-alpha.21";

--- a/src/nudge/repo-search.ts
+++ b/src/nudge/repo-search.ts
@@ -29,16 +29,16 @@ const fail = (reason: string, hint?: string): RepoSearchResult => ({
   ...(hint ? { hint } : {}),
 });
 
-const queryPattern = (query: string): string | null => {
-  const tokens = query
+const escapeRegex = (token: string): string =>
+  token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const queryTokens = (query: string): string[] =>
+  query
     .toLowerCase()
     .split(/[^a-z0-9_@/-]+/)
     .map((token) => token.trim())
     .filter((token) => token.length >= 3)
     .slice(0, 8);
-  if (tokens.length === 0) return null;
-  return tokens.map((token) => token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
-};
 
 const parseGrepLine = (
   line: string,
@@ -82,37 +82,62 @@ const STAGE_ONE_BUFFER = 4_000_000; // ~4 MB of file paths — generous headroom
 // tens of thousands of chars. 8 MB leaves enough headroom to avoid ENOBUFS.
 const STAGE_TWO_BUFFER = 8_000_000;
 
-const currentBranchFiles = (
+// Relevance ranking for Stage 1: score candidate files by how many distinct
+// query tokens they contain. A file matching both `useRuntimeConfig` AND
+// `provider` ranks above a file matching only the common word `provider`.
+// Without this, Stage 2 emits matches in git's file-tree order and `maxResults`
+// cuts off the list before the actually-relevant files get a turn.
+//
+// Cost: one `git grep -l` spawn per token. Query tokens are capped at 8 in
+// `queryTokens`; typical queries have 2-4 tokens, so 2-4 extra subprocess
+// spawns (~50 ms each on a 5 000-file repo).
+const rankFilesByTokenHits = (
   cwd: string,
-  pattern: string,
+  tokens: string[],
   opts: RepoSearchOptions,
+  branch?: string,
 ): string[] => {
-  const r = spawnSync("git", ["grep", "-l", "-i", "-E", pattern, "--", "."], {
-    cwd,
-    encoding: "utf8",
-    timeout: opts.timeoutMs,
-    stdio: ["ignore", "pipe", "ignore"],
-    maxBuffer: STAGE_ONE_BUFFER,
-  });
-  if (r.status !== 0 || !r.stdout) return [];
-  return r.stdout
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean)
+  const scores = new Map<string, number>();
+  const branchPrefix = branch ? `${branch}:` : null;
+  for (const token of tokens) {
+    const args = branch
+      ? ["grep", "-l", "-i", "-E", escapeRegex(token), branch]
+      : ["grep", "-l", "-i", "-E", escapeRegex(token), "--", "."];
+    const r = spawnSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      timeout: opts.timeoutMs,
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: STAGE_ONE_BUFFER,
+    });
+    if (r.status !== 0 || !r.stdout) continue;
+    for (const raw of r.stdout.split("\n")) {
+      const line = raw.trim();
+      if (!line) continue;
+      const file = branchPrefix && line.startsWith(branchPrefix)
+        ? line.slice(branchPrefix.length)
+        : line;
+      scores.set(file, (scores.get(file) ?? 0) + 1);
+    }
+  }
+  return [...scores.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([file]) => file)
     .slice(0, MAX_FILES_STAGE_TWO);
 };
 
 const currentBranchMatches = (
   cwd: string,
-  pattern: string,
+  tokens: string[],
   opts: RepoSearchOptions,
 ): RepoAlternative[] => {
   // Use `git grep` (not ripgrep) — it ships with every git install, runs
   // against the working tree, and keeps tooling consistent with the
   // other-branch path below. Avoids a ripgrep dependency + ENOENT on
   // machines where `rg` is a shell alias rather than a real binary.
-  const files = currentBranchFiles(cwd, pattern, opts);
+  const files = rankFilesByTokenHits(cwd, tokens, opts);
   if (files.length === 0) return [];
+  const pattern = tokens.map(escapeRegex).join("|");
   const r = spawnSync(
     "git",
     ["grep", "-n", "-i", "-E", "--max-count", "3", pattern, "--", ...files],
@@ -125,10 +150,16 @@ const currentBranchMatches = (
     },
   );
   if (r.status !== 0 || !r.stdout) return [];
+  // `git grep` emits output in its own (alphabetical / tree) order regardless
+  // of the pathspec argument order, so we re-sort the parsed matches against
+  // the ranked file list. `Array.prototype.sort` is stable, so within-file
+  // line order is preserved.
+  const rank = new Map(files.map((f, i) => [f, i]));
   return r.stdout
     .split("\n")
     .map((line) => parseGrepLine(line, "current-branch"))
     .filter((entry): entry is RepoAlternative => entry !== null)
+    .sort((a, b) => (rank.get(a.file) ?? Infinity) - (rank.get(b.file) ?? Infinity))
     .slice(0, opts.maxResults);
 };
 
@@ -165,40 +196,17 @@ const branchNames = (cwd: string, timeoutMs: number): string[] => {
     .slice(0, 20);
 };
 
-const otherBranchFiles = (
-  cwd: string,
-  pattern: string,
-  branch: string,
-  opts: RepoSearchOptions,
-): string[] => {
-  const r = spawnSync("git", ["grep", "-l", "-i", "-E", pattern, branch], {
-    cwd,
-    encoding: "utf8",
-    timeout: opts.timeoutMs,
-    stdio: ["ignore", "pipe", "ignore"],
-    maxBuffer: STAGE_ONE_BUFFER,
-  });
-  if (r.status !== 0 || !r.stdout) return [];
-  // `git grep -l <branch>` prefixes each filename with `<branch>:`; strip.
-  const prefix = `${branch}:`;
-  return r.stdout
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => (line.startsWith(prefix) ? line.slice(prefix.length) : line))
-    .slice(0, MAX_FILES_STAGE_TWO);
-};
-
 const otherBranchMatches = (
   cwd: string,
-  pattern: string,
+  tokens: string[],
   opts: RepoSearchOptions,
   already: number,
 ): RepoAlternative[] => {
   const out: RepoAlternative[] = [];
+  const pattern = tokens.map(escapeRegex).join("|");
   for (const branch of branchNames(cwd, opts.timeoutMs)) {
     if (out.length + already >= opts.maxResults) break;
-    const files = otherBranchFiles(cwd, pattern, branch, opts);
+    const files = rankFilesByTokenHits(cwd, tokens, opts, branch);
     if (files.length === 0) continue;
     const r = spawnSync(
       "git",
@@ -212,12 +220,21 @@ const otherBranchMatches = (
       },
     );
     if (r.status !== 0 || !r.stdout) continue;
+    // `git grep` doesn't honor pathspec argument order; re-sort by ranking.
+    const rank = new Map(files.map((f, i) => [f, i]));
+    const branchMatches: RepoAlternative[] = [];
     for (const line of r.stdout.split("\n")) {
       const withoutBranch = line.startsWith(`${branch}:`)
         ? line.slice(branch.length + 1)
         : line;
       const parsed = parseGrepLine(withoutBranch, "other-branch", branch);
-      if (parsed) out.push(parsed);
+      if (parsed) branchMatches.push(parsed);
+    }
+    branchMatches.sort(
+      (a, b) => (rank.get(a.file) ?? Infinity) - (rank.get(b.file) ?? Infinity),
+    );
+    for (const entry of branchMatches) {
+      out.push(entry);
       if (out.length + already >= opts.maxResults) break;
     }
   }
@@ -337,15 +354,18 @@ export const repoSearch = (
   query: string,
   opts: RepoSearchOptions,
 ): RepoSearchResult => {
-  const pattern = queryPattern(query);
-  if (!pattern) return fail("invalid-input", "repo search query has no searchable tokens");
+  const tokens = queryTokens(query);
+  if (tokens.length === 0) {
+    return fail("invalid-input", "repo search query has no searchable tokens");
+  }
   // Non-git worktrees (tmp dirs, pre-init projects) still have source files we
   // should surface — fall back to a filesystem walk so the tool isn't silently
   // empty outside a repo.
   if (!isGitWorktree(cwd, opts.timeoutMs)) {
+    const pattern = tokens.map(escapeRegex).join("|");
     return { ok: true, results: walkMatches(cwd, pattern, opts) };
   }
-  const current = currentBranchMatches(cwd, pattern, opts);
-  const other = otherBranchMatches(cwd, pattern, opts, current.length);
+  const current = currentBranchMatches(cwd, tokens, opts);
+  const other = otherBranchMatches(cwd, tokens, opts, current.length);
   return { ok: true, results: [...current, ...other].slice(0, opts.maxResults) };
 };

--- a/tests/unit/nudge-repo-search.test.ts
+++ b/tests/unit/nudge-repo-search.test.ts
@@ -118,6 +118,58 @@ test("repoSearch: returns matches from another local branch", () => {
   });
 });
 
+test("repoSearch: ranks files matching more distinct tokens ahead of common-word-only matches", () => {
+  withGitRepo((repo) => {
+    // File A: matches only the common token (`provider`). Represents the
+    // many React components that hit `provider` incidentally.
+    mkdirSync(join(repo, "src", "components"), { recursive: true });
+    writeFileSync(
+      join(repo, "src", "components", "ThemeWrapper.tsx"),
+      [
+        "import { ThemeProvider } from '@mantine/core';",
+        "export const ThemeWrapper = () => (",
+        "  <ThemeProvider><div /></ThemeProvider>",
+        ");",
+      ].join("\n"),
+    );
+    // File B: matches BOTH tokens (`useRuntimeConfig` + `provider`). This
+    // is the genuinely-relevant file.
+    mkdirSync(join(repo, "src", "hooks"), { recursive: true });
+    writeFileSync(
+      join(repo, "src", "hooks", "useRuntimeConfig.ts"),
+      [
+        "// runtime config provider for feature flags",
+        "export const useRuntimeConfig = () => {",
+        "  return { provider: 'local' };",
+        "};",
+      ].join("\n"),
+    );
+    runGit(repo, ["add", "."]);
+    runGit(repo, [
+      "-c",
+      "user.name=Tokenomy Test",
+      "-c",
+      "user.email=tokenomy@example.test",
+      "commit",
+      "-m",
+      "seed relevance test",
+    ]);
+
+    const result = repoSearch(repo, "useRuntimeConfig provider", {
+      timeoutMs: 10_000,
+      maxResults: 5,
+    });
+    assert.equal(result.ok, true, JSON.stringify(result));
+    if (!result.ok) return;
+    const firstFile = result.results[0]?.file;
+    assert.equal(
+      firstFile,
+      "src/hooks/useRuntimeConfig.ts",
+      `expected useRuntimeConfig.ts to outrank ThemeWrapper.tsx, got ${firstFile}`,
+    );
+  });
+});
+
 test("repoSearch: survives >64 KB of git-grep output (large-repo regression)", () => {
   withGitRepo((repo) => {
     // Seed 120 files that each match the search pattern on multiple lines.


### PR DESCRIPTION
## Summary

Relevance ranking for `find_oss_alternatives` `repo_results`. Files that match more distinct query tokens now rank above files that only hit the most common token, so the actually-relevant code surfaces first.

## Surface

- [x] `PreToolUse` hook — unaffected
- [x] MCP tool — `src/nudge/repo-search.ts` (ranking)
- [x] CLI / config / types — unchanged
- [x] Tests — new relevance regression test

## Why

Live dogfood on chatbox-js (~5 000 files) against the alpha.20 build:

```
> find_oss_alternatives { description: "useRuntimeConfig provider" }
repo_results: [
  { file: "cdn-src/agent-debugging-dashboard/src/App.tsx", line: 1, snippet: "import { MantineProvider ..." },
  { file: "cdn-src/agent-debugging-dashboard/src/App.tsx", line: 48 },
  { file: "cdn-src/agent-debugging-dashboard/src/App.tsx", line: 53 },
]
```

All three results came from the alphabetically-first component's `MantineProvider` hits — the actual `useRuntimeConfig.ts` and `RuntimeConfigProvider.tsx` files never surfaced. That's the entire point of the `find_oss_alternatives` tool defeated.

Root cause: Stage 2 `git grep -n -E "useruntimeconfig|provider" -- <files>` emits output in git's alphabetical/tree order regardless of pathspec argument order. With 43 matching files and `maxResults: 3`, the alphabetically-first files win.

## How it works

**Ranking, per-token:**

```ts
// One `git grep -l` spawn per token. Count distinct tokens per file.
for (const token of tokens) {
  const r = spawnSync("git", ["grep", "-l", "-i", "-E", escapeRegex(token), "--", "."], { ... });
  for (const file of r.stdout.split("\n")) {
    scores.set(file, (scores.get(file) ?? 0) + 1);
  }
}
// Sort desc by distinct-token-count, alphabetical tiebreak.
return [...scores.entries()]
  .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
  .map(([f]) => f)
  .slice(0, 50);
```

**Stage 2 re-sort:**

Because `git grep` ignores pathspec argument order, we re-sort parsed matches against the ranking before slicing:

```ts
const rank = new Map(files.map((f, i) => [f, i]));
return parsed
  .sort((a, b) => (rank.get(a.file) ?? Infinity) - (rank.get(b.file) ?? Infinity))
  .slice(0, opts.maxResults);
```

`Array.prototype.sort` is stable, so within-file line order is preserved.

Applied symmetrically to `currentBranchMatches` and `otherBranchMatches`.

## Cost

2-4 extra `git grep -l` subprocess spawns per query (tokens capped at 8 in `queryTokens`; typical 2-4). On chatbox-js (~5 000 files): ~50 ms per spawn, so ~100-200 ms added latency total. Under the 5 s `nudge.oss_search.timeout_ms` budget with room to spare. Stage 2 output volume is unchanged.

## Test plan

- [x] Unit: new `repoSearch: ranks files matching more distinct tokens ahead of common-word-only matches` seeds two files — `ThemeWrapper.tsx` (only "provider") and `useRuntimeConfig.ts` (both "useRuntimeConfig" and "provider") — asserts the multi-token file ranks first.
- [x] `pnpm test` — 357 → **358 passing**
- [x] `pnpm run build` clean
- [x] `npx tsc --noEmit` clean
- [x] End-to-end against chatbox-js via `dispatchGraphTool`:

| Query | Alpha.20 top 3 | Alpha.21 top 3 |
|---|---|---|
| `useRuntimeConfig provider` | App.tsx × 3 (MantineProvider) | useAvailableVideoWidth.ts × 2 + **RuntimeConfigProvider.tsx** |
| `runtime configuration loader` | Makefile, selfie docs | index.atom.ts × 3 (config wiring entry) |

## Invariants preserved

- [x] Fail-open: Stage 1 per-token spawn failures just skip that token; empty `scores` → `[]`
- [x] `maxResults` cap still honored after re-sort
- [x] `--max-count 3` per file still applies (no change to Stage 2)
- [x] Within-file line order preserved (stable sort)
- [x] Other-branch path handled symmetrically
- [x] Non-git worktree filesystem walk unaffected

## Breaking changes

- [x] No breaking changes

## Checklist

- [x] Title follows `<type>(<scope>): <description>`
- [x] Rebased on `main`, no merge commits
- [x] One logical change per PR
- [x] README + CHANGELOG updated
- [x] `pnpm test` + `pnpm run build` green locally