### PR TITLE
feat(nudge): UserPromptSubmit prompt-classifier + 0.1.0-alpha.22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 .claude/
 .codex/
 *.cursorrules
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,60 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.1.0-alpha.22] — 2026-04-22
+
+Closes the planning-phase gap in tokenomy's nudge surface: a new
+`UserPromptSubmit` hook classifies every user turn and injects
+`additionalContext` pointing at the right `tokenomy-graph` MCP tool BEFORE
+Claude plans — not just before a Write. So "plan X, no code" prompts and
+refactor/removal questions that never reach a Write finally get nudged.
+
+### Added
+
+- **`UserPromptSubmit` prompt-classifier nudge** (`src/rules/prompt-classifier.ts`).
+  Four intents, each toggleable:
+  - `build` — `build|implement|add|create|make|write` (minus git-workflow
+    nouns like "branch", "commit", "PR", "tag") → nudge toward
+    `find_oss_alternatives`. Works without a graph snapshot.
+  - `change` — `refactor|rename|move|migrate|consolidate|extract|split|replace|
+    rewrite` → nudge toward `find_usages` + `get_impact_radius`.
+  - `remove` — `remove|delete|drop|deprecate|prune|rip out` → nudge toward
+    `get_impact_radius` (so "unreachable code" claims get checked).
+  - `review` — `review|audit|analyze|summarize|blast radius|what changed` →
+    nudge toward `get_review_context`.
+
+  Conservative gates: skips prompts under `min_prompt_chars` (default 20),
+  skips when the prompt already mentions a tokenomy-graph tool, and
+  graph-dependent intents (change / remove / review) skip entirely when no
+  graph snapshot exists for the repo.
+- **`nudge.prompt_classifier` config surface**:
+  - `nudge.prompt_classifier.enabled` (master switch, default true)
+  - `nudge.prompt_classifier.intents.{build,change,remove,review}` (per-intent
+    toggles, all default true)
+  - `nudge.prompt_classifier.min_prompt_chars` (default 20)
+- **Savings-log integration.** Every prompt-classifier nudge appends a
+  `SavingsLogEntry` under `tool: "UserPromptSubmit"` with
+  `reason: "nudge:prompt-classifier:{intent}"`. Conservative per-intent
+  token estimates (build 15 000, change 8 000, remove 5 000, review 6 000)
+  surface in `tokenomy report` alongside Read / Bash / MCP trims.
+
+### Changed
+
+- `tokenomy init` now also registers the `UserPromptSubmit` hook (empty
+  matcher — event isn't tool-scoped). Existing installs pick this up the
+  next time `tokenomy update` runs.
+- `tokenomy doctor` now verifies `UserPromptSubmit` is present alongside
+  `PostToolUse` / `PreToolUse`. Doctor-check count: 13 → **14**.
+- `settings-patch.HookEvent` extends to `"PostToolUse" | "PreToolUse" |
+  "UserPromptSubmit"`.
+
+### Tests
+
+- +15 tests: 13 classifier unit (per-intent triggers, passthroughs, graph-gate,
+  already-mentions short-circuit, git-noun false-positive guards, min-chars
+  gate, per-intent toggle) + 2 hook-spawn integration (live nudge + savings-log
+  entry + short-prompt passthrough). Full suite: **373/373 passing**.
+
 ## [0.1.0-alpha.21] — 2026-04-22
 
 Relevance ranking for `find_oss_alternatives` `repo_results`. Files that match
@@ -509,7 +563,8 @@ First public alpha. Phase 1 scope: transparent MCP tool-output trimming via `Pos
 - Statusline with live savings counter — Phase 2.
 - `tokenomy analyze` over transcripts — Phase 2.
 
-[Unreleased]: https://github.com/RahulDhiman93/Tokenomy/compare/v0.1.0-alpha.21...HEAD
+[Unreleased]: https://github.com/RahulDhiman93/Tokenomy/compare/v0.1.0-alpha.22...HEAD
+[0.1.0-alpha.22]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.22
 [0.1.0-alpha.21]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.21
 [0.1.0-alpha.20]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.20
 [0.1.0-alpha.19]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.0-alpha.19

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A surgical hook + analysis toolkit for **Claude Code and Codex CLI** that transp
 [![Node](https://img.shields.io/badge/node-%E2%89%A520-brightgreen)](#quickstart)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](#license)
 [![Phase](https://img.shields.io/badge/phase%204-alpha-blue)](#roadmap)
-[![Tests](https://img.shields.io/badge/tests-358%20passing-brightgreen)](#contribute)
+[![Tests](https://img.shields.io/badge/tests-373%20passing-brightgreen)](#contribute)
 
 </div>
 
@@ -76,7 +76,7 @@ Top tools by tokens saved
 ```bash
 npm install -g tokenomy
 tokenomy init          # patches ~/.claude/settings.json (backed up first)
-tokenomy doctor        # 13/13 ✓
+tokenomy doctor        # 14/14 ✓
 # restart Claude Code — then use it normally
 ```
 
@@ -92,7 +92,7 @@ Since alpha.15, `init --graph-path` builds the graph for you in a single shot; p
 
 Codex-only / manual registration: `codex mcp add tokenomy-graph -- tokenomy graph serve --path "$PWD"`.
 
-> **Pre-`1.0`.** Every release is `-alpha.N`; breaking changes may land on minor bumps (see [CHANGELOG](./CHANGELOG.md)). Pin for stability: `npm install -g tokenomy@0.1.0-alpha.21`. Upgrade with one command — `tokenomy update` (runs `npm install -g` + re-stages the hook + is idempotent; config + logs preserved). Check without installing: `tokenomy update --check`. Pin an exact release: `tokenomy update@0.1.0-alpha.21` or `tokenomy update --version 0.1.0-alpha.21`. Bleeding edge: see [Development](#development).
+> **Pre-`1.0`.** Every release is `-alpha.N`; breaking changes may land on minor bumps (see [CHANGELOG](./CHANGELOG.md)). Pin for stability: `npm install -g tokenomy@0.1.0-alpha.22`. Upgrade with one command — `tokenomy update` (runs `npm install -g` + re-stages the hook + is idempotent; config + logs preserved). Check without installing: `tokenomy update --check`. Pin an exact release: `tokenomy update@0.1.0-alpha.22` or `tokenomy update --version 0.1.0-alpha.22`. Bleeding edge: see [Development](#development).
 
 Watch trims live — `tail -f ~/.tokenomy/savings.jsonl`:
 
@@ -146,6 +146,8 @@ Invariants: `content.length` never shrinks, `is_error` flows through, non-text b
 **Bash input-bounder (`PreToolUse`).** Detects unbounded verbose shell invocations (`git log`, `find`, `ls -R`, `ps aux`, `docker logs`, `journalctl`, `kubectl logs`, `tree`) and rewrites to `set -o pipefail; <cmd> | awk 'NR<=200'`. Awk consumes producer output (no SIGPIPE); `pipefail` preserves exit codes. Excludes exit-status-sensitive commands (`git diff --exit-code`, `npm ls`, `git status --porcelain`), streaming forms (`-f`/`--follow`/`watch`/`top`), and destructive `find` actions (`-exec`, `-delete`). User pipelines, redirections, compound commands (`;`/`&&`/`||`), subshells, heredocs all passthrough. `head_limit` validated as integer in `[20, 10_000]` before interpolation (no command injection).
 
 **OSS-alternatives nudge (`PreToolUse` Write + MCP).** When Claude Code is about to create a new utility-like file (`src/utils/**`, `src/lib/**`, `pkg/**`, `internal/**`, Java `src/main/java/**`, etc.) above `nudge.write_intercept.min_size_bytes`, Tokenomy appends `additionalContext` recommending `mcp__tokenomy-graph__find_oss_alternatives` before bespoke implementation. The Write input is unchanged; Tokenomy never blocks the file write. The MCP tool searches the current repo, other local branches, npm, PyPI, pkg.go.dev, and Maven Central based on project files or explicit `ecosystems`, then returns `{query, ecosystems, repo_results, results, summary, hint}`. It is fail-open and budget-clipped like the graph tools. Privacy note: the search description/keywords go to public package registries when registry search runs; local repo/branch search stays on the machine. Disable the proactive Write nudge with `tokenomy config set nudge.write_intercept.enabled false` and avoid the MCP call for sensitive proprietary descriptions.
+
+**Prompt-classifier nudge (`UserPromptSubmit`, alpha.22+).** Fires once per user turn, BEFORE Claude plans. Classifies the prompt's intent and injects `additionalContext` pointing at the right `tokenomy-graph` MCP tool: `build|implement|add|create` → `find_oss_alternatives`; `refactor|rename|migrate|extract|replace` → `find_usages` + `get_impact_radius`; `remove|delete|drop|deprecate` → `get_impact_radius`; `review|audit|blast radius|what changed` → `get_review_context`. Conservative gates: skips prompts under 20 chars, skips when the prompt already mentions a tokenomy-graph tool, graph-dependent intents only fire when a graph snapshot exists for the repo. Per-intent toggles via `nudge.prompt_classifier.intents.{build,change,remove,review}`. Disable entirely: `tokenomy config set nudge.prompt_classifier.enabled false`.
 
 **Fail-open is non-negotiable.** Malformed stdin / parse errors / unknown shapes → exit 0 with empty stdout. 10 MB stdin cap. 2.5 s internal timeout. Exit code 2 (blocking) never used. Breaking the agent is worse than wasting tokens.
 
@@ -270,7 +272,7 @@ tokenomy config set nudge.oss_search.max_results 8    # return more OSS candidat
 ✓ Graph MCP SDK available
 ✓ Hook perf budget — p50=5ms p95=12ms max=14ms (n=30, budget 50ms)
 
-13/13 checks passed
+14/14 checks passed
 ```
 
 Every check has an actionable remediation hint on failure. For routine repair, run `tokenomy doctor --fix` — it creates the log directory, `chmod +x`'s the hook binary, and re-patches `~/.claude/settings.json` on manifest drift.
@@ -359,7 +361,7 @@ npm install -g typescript              # peer-optional; required for the graph
 tokenomy init --graph-path "$PWD"      # registers with Claude Code AND Codex — and builds the graph
                                        #   (writes ~/.claude.json, shells `codex mcp add` if on PATH,
                                        #    parses TS/JS → ~/.tokenomy/graphs/<id>/; pass --no-build to skip)
-tokenomy doctor                        # 13/13 ✓
+tokenomy doctor                        # 14/14 ✓
 # fully quit + relaunch Claude Code (Cmd+Q) so it reloads MCP servers
 
 # verify
@@ -419,8 +421,8 @@ Globs are gitignore-style: `**` crosses directory boundaries, `*` stays within a
 ```bash
 tokenomy update            # install latest + re-stage hook in one shot
 tokenomy update --check    # query registry, print installed vs remote, exit 1 if out of date
-tokenomy update@0.1.0-alpha.21   # npm-style pin
-tokenomy update --version=0.1.0-alpha.21  # same, explicit flag
+tokenomy update@0.1.0-alpha.22   # npm-style pin
+tokenomy update --version=0.1.0-alpha.22  # same, explicit flag
 tokenomy update --tag=beta # opt into a non-default dist-tag
 ```
 
@@ -458,7 +460,7 @@ Removes both hook entries from `~/.claude/settings.json` (matched by absolute co
 
 ## 🤝 Contribute
 
-Contributions welcome. Dependency-light (zero runtime deps in the hot hook path; `@modelcontextprotocol/sdk` loaded dynamically for the graph server; `js-tiktoken` optional peer for accurate `analyze`), test-first (358/358 currently green, 96% stmt / 85% branch / 100% func coverage).
+Contributions welcome. Dependency-light (zero runtime deps in the hot hook path; `@modelcontextprotocol/sdk` loaded dynamically for the graph server; `js-tiktoken` optional peer for accurate `analyze`), test-first (373/373 currently green, 96% stmt / 85% branch / 100% func coverage).
 
 **Good first issues:**
 
@@ -498,11 +500,11 @@ Rules are pure: `(toolName, toolInput, toolResponse, config) → { kind: "passth
 ```bash
 git clone https://github.com/RahulDhiman93/Tokenomy && cd Tokenomy
 npm install && npm run build
-npm test             # 358 tests, ~2s
+npm test             # 373 tests, ~2s
 npm run coverage     # c8 → coverage/lcov.info + HTML
 npm run typecheck    # tsc --noEmit
 npm link             # point `tokenomy` at your local build
-tokenomy doctor      # 13/13 ✓
+tokenomy doctor      # 14/14 ✓
 # revert to published version: npm unlink -g tokenomy && npm install -g tokenomy
 # or just:                      tokenomy update --force   (from a fresh npm-installed shell)
 ```

--- a/README.md
+++ b/README.md
@@ -42,10 +42,62 @@ Tokenomy plugs the holes the agent hook contracts let you close — with zero pr
 | `PreToolUse` on `Read` | Claude Code | `updatedInput` | Unbounded reads on huge source files |
 | `PreToolUse` on `Bash` | Claude Code | rewrites `tool_input.command` | Unbounded verbose shell output — `git log`, `find`, `ls -R`, `ps aux`, `docker logs`, `journalctl`, `tree` |
 | `PreToolUse` on `Write` | Claude Code | `additionalContext` | Reinventing existing repo work or mature utility libraries from scratch |
+| `UserPromptSubmit` (alpha.22+) | Claude Code | `additionalContext` on every user turn | Agent planning without first checking graph for existing code, blast radius, or maintained libraries |
 | `tokenomy-graph` MCP server | Claude Code · Codex CLI | 6 tools over stdio | Brute-force `Read` sweeps of the codebase — agent gets focused context from a pre-built graph + repo/branch/package alternatives |
 | `tokenomy analyze` | Claude Code · Codex CLI transcripts | Walks `~/.claude/projects/**/*.jsonl` + `~/.codex/sessions/**/*.jsonl`, replays Tokenomy rules with a real tokenizer | Tells you *exactly* how much you've been wasting, by tool, by day, by rule |
 
 Each live trim appends a row to `~/.tokenomy/savings.jsonl` with measured bytes-in / bytes-out, so you can prove the savings. Run `tokenomy report` for a TUI + HTML digest, or `tokenomy analyze` to benchmark real historical waste from session transcripts.
+
+---
+
+## ✨ Features
+
+Tokenomy is organized around four layers. Install once, and every layer starts working across all your Claude Code sessions — no per-project setup.
+
+### 🔻 Live token trimming
+
+Automatic response shrinking the moment a tool call finishes (or is about to fire). Zero config to get started.
+
+- **MCP response trimming** — schema-aware profiles for Atlassian, Linear, Slack, Gmail, GitHub, Notion; generic redact + stacktrace collapse + byte-trim fallback for the long tail. Unknown top-level keys flow through untouched.
+- **MCP dedup** — identical MCP responses within a 30-minute session window return a pointer stub instead of a full refetch.
+- **Read clamp** — unbounded `Read` on a large source file gets rewritten to an explicit `limit: N` with an `additionalContext` note so the agent can offset-Read further regions on demand. Self-contained docs (`.md`, `.rst`, `.txt`, `.adoc`) below the doc-passthrough threshold skip clamping entirely.
+- **Bash input-bounder** — verbose shell invocations (`git log`, `find`, `ls -R`, `ps aux`, `docker logs`, `journalctl`, `kubectl logs`, `tree`) get rewritten to `set -o pipefail; <cmd> | awk 'NR<=N'`. Exit codes preserved; exit-status-sensitive commands, streaming forms, destructive `find` actions, and user-piped compound commands all pass through.
+
+### 🎯 Agent nudges *(redirect waste before it happens)*
+
+Nudges cost nothing if the agent was going to do the right thing anyway — and save 10–50 k tokens per occurrence when it wasn't.
+
+- **OSS-alternatives Write nudge** *(alpha.18+)* — when Claude creates a new file in a utility-ish path (`src/utils/**`, `src/lib/**`, `pkg/**`, `internal/**`, etc.) above 500 B, Tokenomy recommends `find_oss_alternatives` first. The agent checks this repo + local branches + npm / PyPI / pkg.go.dev / Maven Central before writing anything.
+- **Prompt-classifier nudge** *(alpha.22+)* — fires once per user turn, **before** Claude plans. Classifies intent and points at the right graph tool:
+  - `build | implement | add | create` → `find_oss_alternatives`
+  - `refactor | rename | migrate | extract | replace` → `find_usages` + `get_impact_radius`
+  - `remove | delete | drop | deprecate` → `get_impact_radius`
+  - `review | audit | blast radius | what changed` → `get_review_context`
+
+  Conservative by design: skips confirmations under 20 chars, short-circuits if the prompt already names a graph tool, and graph-dependent intents only fire when a graph snapshot exists for the repo.
+
+### 🧠 Code-graph MCP *(surgical context retrieval)*
+
+`tokenomy-graph` — a stdio MCP server exposing six tools that replace brute-force `Read` sweeps of the codebase. Works with both Claude Code and Codex CLI.
+
+| Tool | What it does | Budget |
+|---|---|---|
+| `build_or_update_graph` | Build or refresh the local code graph for the current repo | 4 KB |
+| `get_minimal_context` | Smallest useful neighborhood around a file or symbol | 8 KB |
+| `get_impact_radius` | Reverse deps + suggested tests for changed files or symbols | 16 KB |
+| `get_review_context` | Ranked hotspots + fanout across changed files | 4 KB |
+| `find_usages` | Direct callers, references, importers of a file or symbol | 16 KB |
+| `find_oss_alternatives` | Repo + branch + package-registry search with distinct-token ranking | 8 KB |
+
+TypeScript / JavaScript AST via the TS compiler (no type checker); `tsconfig.paths` / `jsconfig.paths` resolved *(alpha.17+)* so `@/hooks/foo` and friends link to real source files on Next.js, Vite, Nuxt, monorepos. Read-side auto-refresh *(alpha.15+)* rebuilds on demand when files change between queries. Fail-open everywhere.
+
+### 📊 Observability + retrospection
+
+- **`~/.tokenomy/savings.jsonl`** — every trim and nudge appends a row with measured bytes-in / bytes-out and estimated tokens saved. Tail it: `tail -f ~/.tokenomy/savings.jsonl`.
+- **`tokenomy report`** — TUI + HTML digest of recent trims grouped by tool, by reason, by day. Answers "am I actually saving tokens?"
+- **`tokenomy analyze`** — walks `~/.claude/projects/**/*.jsonl` and `~/.codex/sessions/**/*.jsonl`, replays Tokenomy rules against real historical transcripts with a real tokenizer, surfaces patterns like *Wasted-probe incidents*. Answers "where have I been wasting tokens all along?"
+- **`tokenomy doctor`** — 14 health checks covering hook install, settings.json integrity, manifest drift, MCP registration, hook perf budget. Run anytime; run automatically on every `tokenomy update`.
+- **`tokenomy update`** — single-command self-update: runs `npm install -g tokenomy@latest`, re-stages the hook, re-registers the graph MCP *(alpha.20+)* if one was previously configured. Config and logs preserved.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenomy",
-  "version": "0.1.0-alpha.21",
+  "version": "0.1.0-alpha.22",
   "description": "Surgical Claude Code hook that transparently trims bloated MCP tool responses and clamps oversized file reads — stop burning tokens on tool chatter.",
   "type": "module",
   "engines": {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -72,11 +72,12 @@ const hookEntryCheck = (settings: SettingsShape | undefined): CheckResult => {
   const hook = hookBinaryPath();
   const post = countHooksForPath(settings, hook, "PostToolUse");
   const pre = countHooksForPath(settings, hook, "PreToolUse");
-  const ok = post === 1 && pre === 1;
+  const prompt = countHooksForPath(settings, hook, "UserPromptSubmit");
+  const ok = post === 1 && pre === 1 && prompt === 1;
   return {
-    name: "Hook entries present (PostToolUse + PreToolUse)",
+    name: "Hook entries present (PostToolUse + PreToolUse + UserPromptSubmit)",
     ok,
-    detail: `post=${post} pre=${pre}`,
+    detail: `post=${post} pre=${pre} prompt=${prompt}`,
     remediation: ok ? undefined : "Run `tokenomy init` to install/repair.",
   };
 };
@@ -417,7 +418,7 @@ export const runDoctorFix = async (): Promise<CheckResult[]> => {
 
     // Hook entries missing / manifest drift → re-run init.
     if (
-      c.name === "Hook entries present (PostToolUse + PreToolUse)" ||
+      c.name === "Hook entries present (PostToolUse + PreToolUse + UserPromptSubmit)" ||
       c.name === "Manifest drift"
     ) {
       try {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -152,6 +152,10 @@ export const runInit = (opts: InitOptions = {}): {
   settings = removeHookByCommandPath(settings, hookPath);
   settings = addHook(settings, "PostToolUse", hookPath, POST_MATCHER, TIMEOUT_SECONDS);
   settings = addHook(settings, "PreToolUse", hookPath, PRE_MATCHER, TIMEOUT_SECONDS);
+  // UserPromptSubmit fires once per user turn, before the model sees the
+  // prompt. Matcher is empty because the event isn't tool-scoped. Powers
+  // the prompt-classifier nudge (alpha.22+).
+  settings = addHook(settings, "UserPromptSubmit", hookPath, "", TIMEOUT_SECONDS);
   const graphServerPath = opts.graphPath ? resolve(opts.graphPath) : null;
 
   atomicWrite(settingsPath, stableStringify(settings) + "\n");
@@ -175,7 +179,7 @@ export const runInit = (opts: InitOptions = {}): {
   manifest = upsertEntry(manifest, {
     command_path: hookPath,
     settings_path: settingsPath,
-    matcher: `PostToolUse:${POST_MATCHER}|PreToolUse:${PRE_MATCHER}`,
+    matcher: `PostToolUse:${POST_MATCHER}|PreToolUse:${PRE_MATCHER}|UserPromptSubmit`,
     installed_at: new Date().toISOString(),
   });
   writeManifest(manifest);

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -139,6 +139,16 @@ export const DEFAULT_CONFIG: Config = {
       ],
       min_size_bytes: 500,
     },
+    prompt_classifier: {
+      enabled: true,
+      intents: {
+        build: true,
+        change: true,
+        remove: true,
+        review: true,
+      },
+      min_prompt_chars: 20,
+    },
   },
 };
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -47,6 +47,24 @@ export interface PreHookOutput {
   };
 }
 
+// Claude Code fires UserPromptSubmit once per user turn, before the model
+// sees the prompt. The hook can inject `additionalContext` that's appended
+// to the user's message so the model sees it inline.
+export interface UserPromptHookInput {
+  session_id: string;
+  transcript_path: string;
+  cwd: string;
+  hook_event_name: "UserPromptSubmit";
+  prompt: string;
+}
+
+export interface UserPromptHookOutput {
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit";
+    additionalContext: string;
+  };
+}
+
 export type RuleResult =
   | { kind: "passthrough" }
   | {
@@ -200,6 +218,27 @@ export interface NudgeConfig {
     // Filters out tiny stubs / types-only files that aren't real reinvention.
     // Default: 500 bytes.
     min_size_bytes: number;
+  };
+  // UserPromptSubmit prompt-classifier nudge. Fires once per user turn,
+  // BEFORE Claude plans. Classifies the prompt's intent (build / change /
+  // remove / review) and injects `additionalContext` pointing at the right
+  // `tokenomy-graph` MCP tool. This closes the gap where Write-only nudges
+  // miss planning-phase turns ("plan X", "no code") and questions about
+  // refactors / removals that never reach a Write.
+  prompt_classifier: {
+    // Master switch for all prompt-classifier intents. Default: true.
+    enabled: boolean;
+    // Per-intent toggles — tune down if an intent produces false positives
+    // on a particular user's working style.
+    intents: {
+      build: boolean;      // "build X", "implement Y" → find_oss_alternatives
+      change: boolean;     // "refactor", "rename", "migrate" → find_usages + get_impact_radius
+      remove: boolean;     // "remove", "delete", "drop" → get_impact_radius
+      review: boolean;     // "review", "audit", "what changed" → get_review_context
+    };
+    // Skip classification on prompts shorter than this — avoids firing on
+    // "yes", "go ahead", single-word confirmations. Default: 20 chars.
+    min_prompt_chars: number;
   };
 }
 

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,1 +1,1 @@
-export const TOKENOMY_VERSION = "0.1.0-alpha.21";
+export const TOKENOMY_VERSION = "0.1.0-alpha.22";

--- a/src/hook/entry.ts
+++ b/src/hook/entry.ts
@@ -2,10 +2,14 @@
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { dispatch } from "./dispatch.js";
-import { preDispatch } from "./pre-dispatch.js";
+import { preDispatch, dispatchUserPrompt } from "./pre-dispatch.js";
 import { loadConfig } from "../core/config.js";
 import { tokenomyDir } from "../core/paths.js";
-import type { HookInput, PreHookInput } from "../core/types.js";
+import type {
+  HookInput,
+  PreHookInput,
+  UserPromptHookInput,
+} from "../core/types.js";
 
 // Returns a shallow, size-capped snapshot of the tool_input for diagnostics.
 // Strings longer than 200 chars are truncated; unknown types are stringified.
@@ -95,9 +99,12 @@ const main = async (): Promise<void> => {
       return;
     }
 
-    let parsed: HookInput | PreHookInput;
+    let parsed: HookInput | PreHookInput | UserPromptHookInput;
     try {
-      parsed = JSON.parse(buf.toString("utf8")) as HookInput | PreHookInput;
+      parsed = JSON.parse(buf.toString("utf8")) as
+        | HookInput
+        | PreHookInput
+        | UserPromptHookInput;
     } catch {
       debugLog({ phase: "parse-fail", stdin_bytes: buf.length });
       process.exit(0);
@@ -105,6 +112,21 @@ const main = async (): Promise<void> => {
     }
 
     const cfg = loadConfig(parsed?.cwd ?? process.cwd());
+
+    if (parsed?.hook_event_name === "UserPromptSubmit") {
+      const promptInput = parsed as UserPromptHookInput;
+      const out = dispatchUserPrompt(promptInput, cfg);
+      debugLog({
+        phase: out ? "prompt-nudged" : "prompt-passthrough",
+        session_id: promptInput.session_id,
+        event: "UserPromptSubmit",
+        elapsed_ms: Date.now() - hookStart,
+        prompt_len: promptInput.prompt?.length ?? 0,
+      });
+      if (out) process.stdout.write(JSON.stringify(out));
+      process.exit(0);
+      return;
+    }
 
     if (parsed?.hook_event_name === "PreToolUse") {
       const preInput = parsed as PreHookInput;

--- a/src/hook/pre-dispatch.ts
+++ b/src/hook/pre-dispatch.ts
@@ -1,9 +1,17 @@
 import { existsSync } from "node:fs";
 import { isAbsolute, resolve } from "node:path";
-import type { Config, PreHookInput, PreHookOutput, SavingsLogEntry } from "../core/types.js";
+import type {
+  Config,
+  PreHookInput,
+  PreHookOutput,
+  SavingsLogEntry,
+  UserPromptHookInput,
+  UserPromptHookOutput,
+} from "../core/types.js";
 import { readBoundRule } from "../rules/read-bound.js";
 import { bashBoundRule } from "../rules/bash-bound.js";
 import { writeNudgeRule } from "../rules/write-nudge.js";
+import { classifyPromptRule } from "../rules/prompt-classifier.js";
 import { estimateTokens } from "../core/gate.js";
 import { appendSavingsLog } from "../core/log.js";
 import { graphMetaPath, tokenomyGraphRootDir } from "../core/paths.js";
@@ -127,4 +135,49 @@ export const preDispatch = (
   if (input.tool_name === "Bash") return preDispatchBash(input, cfg);
   if (input.tool_name === "Write") return preDispatchWrite(input, cfg);
   return null;
+};
+
+// Conservative token-savings estimates per intent. These are the typical
+// downstream cost when an agent skips the MCP tool and brute-forces the
+// alternative path (Read sweep, from-scratch implementation, etc.). Values
+// tuned to the low end of the observed range so reports don't overstate.
+// Bytes are back-calculated from tokens via the same ~4 bytes/token factor
+// `estimateTokens` uses internally so `tokenomy report` aggregates sanely.
+const INTENT_SAVINGS_TOKENS: Record<string, number> = {
+  build: 15_000, // from-scratch rewrite of a utility that has a library
+  change: 8_000, // brute-force Read sweep to enumerate callers
+  remove: 5_000, // verification reads before a "safe" deletion
+  review: 6_000, // reading every changed file vs hotspot-ranked list
+};
+
+export const dispatchUserPrompt = (
+  input: UserPromptHookInput,
+  cfg: Config,
+): UserPromptHookOutput | null => {
+  const r = classifyPromptRule(input.prompt ?? "", cfg, input.cwd);
+  if (r.kind !== "nudge" || !r.additionalContext) return null;
+
+  // Log a savings entry so `tokenomy report` and `tokenomy analyze` surface
+  // these nudges alongside Read/Bash/MCP trims. Token estimates are
+  // intentionally conservative — this is the value the nudge unlocks IF
+  // the agent follows through on the MCP call, not a guaranteed saving.
+  const tokensSavedEst = INTENT_SAVINGS_TOKENS[r.intent ?? ""] ?? 5_000;
+  const bytesSavedEst = tokensSavedEst * 4;
+  const entry: SavingsLogEntry = {
+    ts: new Date().toISOString(),
+    session_id: input.session_id,
+    tool: "UserPromptSubmit",
+    bytes_in: bytesSavedEst,
+    bytes_out: 0,
+    tokens_saved_est: tokensSavedEst,
+    reason: `nudge:prompt-classifier:${r.intent ?? "unknown"}`,
+  };
+  appendSavingsLog(cfg.log_path, entry);
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      additionalContext: r.additionalContext,
+    },
+  };
 };

--- a/src/rules/prompt-classifier.ts
+++ b/src/rules/prompt-classifier.ts
@@ -1,0 +1,156 @@
+import { existsSync } from "node:fs";
+import type { Config } from "../core/types.js";
+import { graphMetaPath, tokenomyGraphRootDir } from "../core/paths.js";
+import { resolveRepoId } from "../graph/repo-id.js";
+
+// UserPromptSubmit prompt-classifier nudge.
+//
+// Fires once per user turn, before Claude plans. Inspects the user's prompt
+// for action verbs ("build X", "refactor Y", "remove Z", "review the PR")
+// and injects `additionalContext` recommending the right `tokenomy-graph`
+// MCP tool for that intent.
+//
+// This closes the gap where the Write-only nudge misses planning-phase
+// turns: users asking "plan X, no code" never trigger a Write, so the
+// existing find_oss_alternatives nudge stays silent. The prompt classifier
+// catches them upstream.
+//
+// Design:
+// - Pure classifier. Regex-only, no LLM call, no registry call.
+// - Four intents, toggleable independently via config.
+// - Short-circuits on very short prompts ("yes", "go ahead") to avoid noise.
+// - Skips when the prompt already mentions a tokenomy-graph tool — the user
+//   is clearly already aware.
+// - Only suggests graph-dependent tools (find_usages / get_impact_radius /
+//   get_review_context) when a graph snapshot exists for this repo. The
+//   find_oss_alternatives tool works without a graph, so it always nudges.
+// - Never blocks. Never modifies the prompt. Output is pure append.
+
+export type PromptIntent = "build" | "change" | "remove" | "review";
+
+export interface PromptClassifierResult {
+  kind: "nudge" | "passthrough";
+  intent?: PromptIntent;
+  additionalContext?: string;
+}
+
+interface IntentPattern {
+  intent: PromptIntent;
+  // Matches when any of these words appears as a standalone token in the
+  // prompt. Boundaries matter — `readme` shouldn't match `read`.
+  pattern: RegExp;
+  // Whether this intent's suggestion requires the repo to already have a
+  // graph snapshot. find_oss_alternatives works standalone; the others all
+  // need the code graph.
+  needsGraph: boolean;
+  hint: (promptPreview: string) => string;
+}
+
+const previewPrompt = (prompt: string): string => {
+  const cleaned = prompt.replace(/\s+/g, " ").trim();
+  return cleaned.length > 80 ? cleaned.slice(0, 80) + "…" : cleaned;
+};
+
+const INTENTS: IntentPattern[] = [
+  {
+    intent: "build",
+    // Match "build|implement|add|create|make|write" — but NOT when followed
+    // within 30 chars by git/workflow nouns like "branch", "commit", "PR
+    // description", etc. The .{0,30} window covers "make a new branch",
+    // "write a short PR description", "create another release tag", etc.
+    pattern:
+      /\b(build|implement|add|create|make|write)\b(?!.{0,30}\b(?:branch|commit|tag|release|pr|pull\s+request|comment|message|note|test\s+case|docstring|log\s+entry|changelog)\b)/i,
+    needsGraph: false,
+    hint: (preview) =>
+      `[tokenomy-nudge (build): "${preview}" — before planning or writing code, ` +
+      `call \`mcp__tokenomy-graph__find_oss_alternatives\` with a one-line description. ` +
+      `It checks this repo, local branches, and maintained package registries (~1–2s). ` +
+      `Report any repo matches and the top package pick in the plan before proposing ` +
+      `a bespoke implementation. Skip only if you've already evaluated alternatives ` +
+      `or this is clearly project-specific glue. Disable: ` +
+      `\`tokenomy config set nudge.prompt_classifier.intents.build false\`.]`,
+  },
+  {
+    intent: "change",
+    pattern:
+      /\b(refactor|rename|move|migrate|consolidate|restructure|extract|split|inline|replace|swap|rewrite)\b/i,
+    needsGraph: true,
+    hint: (preview) =>
+      `[tokenomy-nudge (change): "${preview}" — before proposing any rename/refactor/move, ` +
+      `call \`mcp__tokenomy-graph__find_usages\` on the target symbol, then ` +
+      `\`mcp__tokenomy-graph__get_impact_radius\` on the file. Report the reverse-dep ` +
+      `count + suggested_tests list in the plan. Anything > 10 callers is a high-` +
+      `blast-radius change and should propose a staged migration. Disable: ` +
+      `\`tokenomy config set nudge.prompt_classifier.intents.change false\`.]`,
+  },
+  {
+    intent: "remove",
+    pattern: /\b(remove|delete|drop|deprecate|prune|rip\s+out|tear\s+out|kill)\b/i,
+    needsGraph: true,
+    hint: (preview) =>
+      `[tokenomy-nudge (remove): "${preview}" — before proposing the removal, call ` +
+      `\`mcp__tokenomy-graph__get_impact_radius\` on the target file or symbol. Report ` +
+      `the reverse-dep count. An "unused" claim is wrong if there's even one caller. ` +
+      `If the graph shows callers, propose a deprecation path before deletion. Disable: ` +
+      `\`tokenomy config set nudge.prompt_classifier.intents.remove false\`.]`,
+  },
+  {
+    intent: "review",
+    pattern:
+      /\b(review|audit|analyze|summari[sz]e|blast[\s-]radius|regression[\s-]check|what\s+(?:changed|broke))\b/i,
+    needsGraph: true,
+    hint: (preview) =>
+      `[tokenomy-nudge (review): "${preview}" — for change-set review, call ` +
+      `\`mcp__tokenomy-graph__get_review_context\` with the list of changed files. ` +
+      `It ranks hotspots + fanout so the review focuses on the blast-radius files ` +
+      `instead of bikeshedding low-impact ones. Disable: ` +
+      `\`tokenomy config set nudge.prompt_classifier.intents.review false\`.]`,
+  },
+];
+
+const graphSnapshotExists = (cwd: string): boolean => {
+  try {
+    if (!existsSync(tokenomyGraphRootDir())) return false;
+    const { repoId } = resolveRepoId(cwd);
+    return existsSync(graphMetaPath(repoId));
+  } catch {
+    return false;
+  }
+};
+
+// Already-aware short-circuit: if the user's prompt is itself directing
+// Claude to a graph tool, don't double-nudge. Same for the OSS tool.
+const alreadyMentionsTokenomy = (prompt: string): boolean =>
+  /mcp__tokenomy-graph__|tokenomy[-_]graph|find_oss_alternatives|find_usages|get_impact_radius|get_review_context|get_minimal_context/i.test(
+    prompt,
+  );
+
+export const classifyPromptRule = (
+  prompt: string,
+  cfg: Config,
+  cwd: string,
+): PromptClassifierResult => {
+  const nudge = cfg.nudge;
+  if (!nudge || !nudge.enabled) return { kind: "passthrough" };
+  if (!nudge.prompt_classifier.enabled) return { kind: "passthrough" };
+  if (typeof prompt !== "string") return { kind: "passthrough" };
+  if (prompt.length < nudge.prompt_classifier.min_prompt_chars) {
+    return { kind: "passthrough" };
+  }
+  if (alreadyMentionsTokenomy(prompt)) return { kind: "passthrough" };
+
+  const intents = nudge.prompt_classifier.intents;
+  const hasGraph = graphSnapshotExists(cwd);
+
+  for (const entry of INTENTS) {
+    if (!intents[entry.intent]) continue;
+    if (entry.needsGraph && !hasGraph) continue;
+    if (!entry.pattern.test(prompt)) continue;
+    return {
+      kind: "nudge",
+      intent: entry.intent,
+      additionalContext: entry.hint(previewPrompt(prompt)),
+    };
+  }
+  return { kind: "passthrough" };
+};

--- a/src/util/settings-patch.ts
+++ b/src/util/settings-patch.ts
@@ -23,13 +23,14 @@ interface SettingsShape {
   hooks?: {
     PostToolUse?: HookMatcherEntry[];
     PreToolUse?: HookMatcherEntry[];
+    UserPromptSubmit?: HookMatcherEntry[];
     [event: string]: HookMatcherEntry[] | undefined;
   };
   mcpServers?: Record<string, McpServerEntry>;
   [k: string]: unknown;
 }
 
-export type HookEvent = "PostToolUse" | "PreToolUse";
+export type HookEvent = "PostToolUse" | "PreToolUse" | "UserPromptSubmit";
 
 const stripQuotes = (s: string): string => {
   const t = s.trim();
@@ -107,7 +108,9 @@ export const countHooksForPath = (
   commandPath: string,
   event?: HookEvent,
 ): number => {
-  const events = event ? [event] : (["PostToolUse", "PreToolUse"] as HookEvent[]);
+  const events = event
+    ? [event]
+    : (["PostToolUse", "PreToolUse", "UserPromptSubmit"] as HookEvent[]);
   let n = 0;
   for (const e of events) {
     const entries = settings.hooks?.[e];

--- a/tests/integration/hook-spawn.test.ts
+++ b/tests/integration/hook-spawn.test.ts
@@ -227,6 +227,55 @@ test("hook: PreToolUse Write redacts content in debug preview", async () => {
   }
 });
 
+test("hook: UserPromptSubmit build-intent prompt → nudge with find_oss_alternatives", async () => {
+  const home = mkdtempSync(join(tmpdir(), "tokenomy-prompt-"));
+  try {
+    const env = { ...process.env, HOME: home };
+    const { code, stdout } = await runHook(
+      {
+        session_id: "s",
+        transcript_path: "/tmp/t",
+        cwd: "/tmp",
+        hook_event_name: "UserPromptSubmit",
+        prompt: "Build a retry-with-backoff wrapper for our fetch calls.",
+      },
+      env,
+    );
+    assert.equal(code, 0);
+    assert.ok(stdout.length > 0, "expected nudge output for build-intent prompt");
+    const parsed = JSON.parse(stdout);
+    assert.equal(parsed.hookSpecificOutput.hookEventName, "UserPromptSubmit");
+    assert.match(parsed.hookSpecificOutput.additionalContext, /find_oss_alternatives/);
+    // Savings log entry must be appended so `tokenomy report` picks it up.
+    const log = readFileSync(join(home, ".tokenomy", "savings.jsonl"), "utf8");
+    assert.match(log, /nudge:prompt-classifier:build/);
+    assert.match(log, /"tool":"UserPromptSubmit"/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("hook: UserPromptSubmit short / neutral prompt → passthrough (no stdout)", async () => {
+  const home = mkdtempSync(join(tmpdir(), "tokenomy-prompt-neutral-"));
+  try {
+    const env = { ...process.env, HOME: home };
+    const { code, stdout } = await runHook(
+      {
+        session_id: "s",
+        transcript_path: "/tmp/t",
+        cwd: "/tmp",
+        hook_event_name: "UserPromptSubmit",
+        prompt: "Thanks, looks good",
+      },
+      env,
+    );
+    assert.equal(code, 0);
+    assert.equal(stdout, "", "short/neutral prompts must not emit nudge output");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
 test("hook: malformed stdin → exit 0 with empty stdout", async () => {
   const child = spawn(process.execPath, [HOOK], { stdio: ["pipe", "pipe", "pipe"] });
   const out: Buffer[] = [];

--- a/tests/unit/nudge-prompt-classifier.test.ts
+++ b/tests/unit/nudge-prompt-classifier.test.ts
@@ -1,0 +1,211 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { classifyPromptRule } from "../../src/rules/prompt-classifier.js";
+import { DEFAULT_CONFIG } from "../../src/core/config.js";
+import { resolveRepoId } from "../../src/graph/repo-id.js";
+import type { Config } from "../../src/core/types.js";
+
+const cfgWith = (patch: (c: Config) => Config): Config =>
+  patch(JSON.parse(JSON.stringify(DEFAULT_CONFIG)));
+
+// Seeds a tmp graph root + meta.json pair so the repo-aware intents
+// (change / remove / review) don't short-circuit on missing graph. The
+// classifier resolves the repo id from cwd, so we mirror its expectation.
+const withFakeGraph = <T>(fn: (cwd: string) => T): T => {
+  const cwd = mkdtempSync(join(tmpdir(), "tok-classifier-"));
+  const home = mkdtempSync(join(tmpdir(), "tok-classifier-home-"));
+  const prevHome = process.env["HOME"];
+  process.env["HOME"] = home;
+  try {
+    spawnSync("git", ["init", "-q"], { cwd });
+    spawnSync("git", ["config", "user.email", "t@t"], { cwd });
+    spawnSync("git", ["config", "user.name", "T"], { cwd });
+    writeFileSync(join(cwd, "seed.txt"), "hi");
+    spawnSync("git", ["add", "."], { cwd });
+    spawnSync("git", ["commit", "-q", "-m", "seed"], { cwd });
+
+    const { repoId } = resolveRepoId(cwd);
+    const graphDir = join(home, ".tokenomy", "graphs", repoId);
+    mkdirSync(graphDir, { recursive: true });
+    writeFileSync(join(graphDir, "meta.json"), "{}");
+
+    return fn(cwd);
+  } finally {
+    if (prevHome === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = prevHome;
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }
+};
+
+test("classifyPromptRule: build intent nudges toward find_oss_alternatives", () => {
+  const cfg = DEFAULT_CONFIG;
+  const r = classifyPromptRule(
+    "Build a retry-with-backoff wrapper for our fetch calls.",
+    cfg,
+    process.cwd(),
+  );
+  assert.equal(r.kind, "nudge");
+  assert.equal(r.intent, "build");
+  assert.match(r.additionalContext ?? "", /find_oss_alternatives/);
+  assert.match(r.additionalContext ?? "", /tokenomy-nudge \(build\)/);
+});
+
+test("classifyPromptRule: change intent nudges toward find_usages + get_impact_radius", () => {
+  withFakeGraph((cwd) => {
+    const r = classifyPromptRule(
+      "Let's refactor the useRuntimeConfig hook to support async loading.",
+      DEFAULT_CONFIG,
+      cwd,
+    );
+    assert.equal(r.kind, "nudge");
+    assert.equal(r.intent, "change");
+    assert.match(r.additionalContext ?? "", /find_usages/);
+    assert.match(r.additionalContext ?? "", /get_impact_radius/);
+  });
+});
+
+test("classifyPromptRule: remove intent nudges toward get_impact_radius", () => {
+  withFakeGraph((cwd) => {
+    const r = classifyPromptRule(
+      "I want to remove the legacy auth middleware — what's the blast radius?",
+      DEFAULT_CONFIG,
+      cwd,
+    );
+    assert.equal(r.kind, "nudge");
+    assert.equal(r.intent, "remove");
+    assert.match(r.additionalContext ?? "", /get_impact_radius/);
+  });
+});
+
+test("classifyPromptRule: review intent nudges toward get_review_context", () => {
+  withFakeGraph((cwd) => {
+    const r = classifyPromptRule(
+      "Please review the changes on this branch and highlight what might regress.",
+      DEFAULT_CONFIG,
+      cwd,
+    );
+    assert.equal(r.kind, "nudge");
+    assert.equal(r.intent, "review");
+    assert.match(r.additionalContext ?? "", /get_review_context/);
+  });
+});
+
+test("classifyPromptRule: passthrough when nudge disabled", () => {
+  const cfg = cfgWith((c) => {
+    if (c.nudge) c.nudge.enabled = false;
+    return c;
+  });
+  const r = classifyPromptRule("Build a retry helper at src/utils/retry.ts", cfg, process.cwd());
+  assert.equal(r.kind, "passthrough");
+});
+
+test("classifyPromptRule: passthrough when classifier disabled", () => {
+  const cfg = cfgWith((c) => {
+    if (c.nudge) c.nudge.prompt_classifier.enabled = false;
+    return c;
+  });
+  const r = classifyPromptRule("Build a retry helper at src/utils/retry.ts", cfg, process.cwd());
+  assert.equal(r.kind, "passthrough");
+});
+
+test("classifyPromptRule: passthrough on prompts shorter than min_prompt_chars", () => {
+  const r = classifyPromptRule("build X", DEFAULT_CONFIG, process.cwd());
+  assert.equal(r.kind, "passthrough");
+});
+
+test("classifyPromptRule: passthrough when prompt already mentions the tool", () => {
+  const r = classifyPromptRule(
+    "Call mcp__tokenomy-graph__find_oss_alternatives before building retry.",
+    DEFAULT_CONFIG,
+    process.cwd(),
+  );
+  assert.equal(r.kind, "passthrough");
+});
+
+test("classifyPromptRule: passthrough on neutral conversational prompts", () => {
+  const r = classifyPromptRule(
+    "Thanks, that looks good to me — any gotchas I should know about?",
+    DEFAULT_CONFIG,
+    process.cwd(),
+  );
+  assert.equal(r.kind, "passthrough");
+});
+
+test("classifyPromptRule: skips git-noun false positives (create a commit/branch/PR)", () => {
+  for (const phrase of [
+    "create a commit with the changes so far",
+    "make a new branch for the refactor work",
+    "write a PR description summarizing the change",
+  ]) {
+    const r = classifyPromptRule(phrase, DEFAULT_CONFIG, process.cwd());
+    // These should NOT trigger the build intent because the noun following
+    // the verb is git-shaped, not code-shaped.
+    if (r.kind === "nudge") {
+      // A "change"/"refactor"/"review" intent may still trigger legitimately
+      // (phrase 2 mentions "refactor"; phrase 3 mentions "summarizing"), but
+      // the build intent specifically must not fire here.
+      assert.notEqual(r.intent, "build", `false-positive build on: ${phrase}`);
+    }
+  }
+});
+
+test("classifyPromptRule: graph-dependent intents skip when no graph snapshot exists", () => {
+  // Use a tmp cwd that has no graph seeded — change/remove/review should
+  // passthrough even though the verbs match.
+  const cwd = mkdtempSync(join(tmpdir(), "tok-no-graph-"));
+  const home = mkdtempSync(join(tmpdir(), "tok-no-graph-home-"));
+  const prevHome = process.env["HOME"];
+  process.env["HOME"] = home;
+  try {
+    const r = classifyPromptRule(
+      "Let's refactor the whole auth layer to use the new session API.",
+      DEFAULT_CONFIG,
+      cwd,
+    );
+    assert.equal(r.kind, "passthrough");
+  } finally {
+    if (prevHome === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = prevHome;
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("classifyPromptRule: build intent fires without a graph snapshot (OSS tool is graph-independent)", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "tok-build-no-graph-"));
+  const home = mkdtempSync(join(tmpdir(), "tok-build-no-graph-home-"));
+  const prevHome = process.env["HOME"];
+  process.env["HOME"] = home;
+  try {
+    const r = classifyPromptRule(
+      "Let's build a schema validator for our API inputs.",
+      DEFAULT_CONFIG,
+      cwd,
+    );
+    assert.equal(r.kind, "nudge");
+    assert.equal(r.intent, "build");
+  } finally {
+    if (prevHome === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = prevHome;
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("classifyPromptRule: per-intent toggle silences just that intent", () => {
+  const cfg = cfgWith((c) => {
+    if (c.nudge) c.nudge.prompt_classifier.intents.build = false;
+    return c;
+  });
+  const r = classifyPromptRule(
+    "Let's build a rate limiter for the API gateway.",
+    cfg,
+    process.cwd(),
+  );
+  assert.equal(r.kind, "passthrough");
+});


### PR DESCRIPTION
## Summary

Closes the planning-phase gap in tokenomy's nudge surface. Until alpha.22 the Write-only nudge missed "plan X, no code" prompts and refactor/removal asks that never reach a Write — users had to manually say *"did you use tokenomy?"* to get the agent to check. New `UserPromptSubmit` hook classifies every user turn BEFORE Claude plans and injects `additionalContext` pointing at the right `tokenomy-graph` MCP tool.

Plus a README Features section grouping the full tokenomy surface into four layers (trim / nudge / graph / observability) so users can see what they get at a glance.

## Surface

- [x] **New hook event:** `UserPromptSubmit` handler — `src/rules/prompt-classifier.ts`, `src/hook/pre-dispatch.ts`, `src/hook/entry.ts`
- [x] **CLI:** `src/cli/init.ts` registers the new hook matcher; `src/cli/doctor.ts` verifies it (check count 13 → 14)
- [x] **Settings patcher:** `src/util/settings-patch.ts` — `HookEvent` extends to `"UserPromptSubmit"`
- [x] **Config / types:** `src/core/types.ts` + `src/core/config.ts` — new `nudge.prompt_classifier.*` shape with defaults
- [x] **Savings log integration:** every nudge appends `SavingsLogEntry` under `tool: "UserPromptSubmit"` with per-intent token estimates
- [x] **Docs:** README gets a Features section + alpha.22 pin; CHANGELOG full entry
- [x] **CLAUDE.md** (gitignored) with the pre-PR checklist for future releases

## Why

Concrete failure case: user asks *"Plan a runtime config loader for feature flags at src/hooks/useFeatureFlags.ts. NO CODE."* — planning is pure text, no Write fires, existing OSS-Write-nudge stays silent. Claude drafts a 200-LOC plan against an outdated mental model of the codebase. After prompting *"did you use tokenomy?"* + running the tool, the revised plan correctly identifies that `RuntimeConfigProvider` has 41 consumers, the repo uses Jotai atoms (not hooks) for flags, and the original plan's "extend the provider" approach would have been a cross-codebase regression.

The whole point of a nudge is removing the human in the loop. Alpha.22 closes this.

## How it works

**Four intents, each toggleable independently:**

| Intent | Verbs | Nudges toward | Needs graph? |
|---|---|---|---|
| `build` | `build\|implement\|add\|create\|make\|write` (minus git-workflow nouns) | `find_oss_alternatives` | No |
| `change` | `refactor\|rename\|move\|migrate\|extract\|split\|replace\|rewrite` | `find_usages` + `get_impact_radius` | Yes |
| `remove` | `remove\|delete\|drop\|deprecate\|prune\|rip out` | `get_impact_radius` | Yes |
| `review` | `review\|audit\|analyze\|summarize\|blast radius\|what changed` | `get_review_context` | Yes |

**Conservative gates:**
- Min prompt length (default 20 chars) skips "yes" / "go ahead" / confirmations
- Prompts already mentioning a tokenomy-graph tool short-circuit (user is already aware)
- Git-workflow noun guard: `"make a new branch"` / `"write a PR description"` does NOT fire the build intent
- Graph-dependent intents (change / remove / review) skip entirely when no graph snapshot exists for the repo — avoids nudging toward a tool that can't run yet

**Savings integration:**

Every nudge appends a row to `~/.tokenomy/savings.jsonl`:
```json
{"tool":"UserPromptSubmit","reason":"nudge:prompt-classifier:build","tokens_saved_est":15000}
```

Conservative per-intent token estimates (build 15 000, change 8 000, remove 5 000, review 6 000). `tokenomy report`'s `reason.split(":")[0]` aggregation groups these under the "nudge" category automatically.

**End-to-end probe through the built hook binary:**

```
=== "Build a retry-with-backoff helper for our fetch layer." ===
  hint: [tokenomy-nudge (build): ...]

=== "Thanks, looks good" ===
  (no nudge — under min_prompt_chars)

=== "Can you rename the getUser() method..."  ===
  (no nudge — change intent needs graph, /tmp has none)

=== savings.jsonl ===
  tool=UserPromptSubmit reason=nudge:prompt-classifier:build tokens_saved=15000
```

## Test plan

- [x] Unit: 13 tests — per-intent triggers, passthrough cases, graph-gate, already-mentions short-circuit, git-noun false-positive guards, min-chars gate, per-intent toggle, master switch
- [x] Integration: 2 hook-spawn tests — live nudge + savings log entry + short-prompt passthrough (real hook binary, real spawn, real jsonl read)
- [x] `pnpm test` — 358 → **373 passing** (+15)
- [x] `pnpm run build` clean
- [x] `npx tsc --noEmit` clean
- [x] Live probe against built hook binary with 4 prompt shapes confirms expected nudge / passthrough behavior

## Invariants preserved

- [x] Fail-open: malformed JSON → exit 0 empty stdout; classifier errors → passthrough
- [x] Never modifies the user's prompt — output is pure `additionalContext` append
- [x] Never uses exit code 2 (blocking)
- [x] Existing PreToolUse / PostToolUse hooks untouched
- [x] Config is backward-compatible: missing `nudge.prompt_classifier` block → all defaults, nudge enabled

## Breaking changes

- [x] **No user-visible breaking changes**, but the matcher shape in `~/.claude/settings.json` now includes a `UserPromptSubmit` entry. Existing installs pick this up the next time `tokenomy update` runs (alpha.20+ update also restages the graph automatically). Users can drop the hook manually if they don't want it (`tokenomy doctor` will flag it as missing, but the tool works otherwise).

## Config knobs added

```
nudge.prompt_classifier.enabled                 (master switch, default true)
nudge.prompt_classifier.intents.build           (default true)
nudge.prompt_classifier.intents.change          (default true)
nudge.prompt_classifier.intents.remove          (default true)
nudge.prompt_classifier.intents.review          (default true)
nudge.prompt_classifier.min_prompt_chars        (default 20)
```

## Checklist

- [x] Title follows `<type>(<scope>): <description>`
- [x] Rebased on `main`, no merge commits
- [x] One logical change per PR
- [x] README + CHANGELOG + version bump
- [x] `pnpm test` + `pnpm run build` green locally