### PR TITLE
feat(golem): terse-output-mode plugin + 0.1.1-beta.1 (alpha→beta graduation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,66 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.1.1-beta.1] — 2026-04-23
+
+First beta release. The alpha.0–alpha.22 arc shipped deterministic
+byte-trimming (MCP / Read / Bash), the tokenomy-graph MCP server (6
+tools), repo/branch/package search, and the UserPromptSubmit prompt-
+classifier nudge. Beta.1 crosses the final gap: assistant **output**
+tokens, via a new opt-in plugin called Golem.
+
+### Added
+
+- **Golem** — a terse-output-mode plugin for the assistant's own replies.
+  Injects deterministic style rules via a new `SessionStart` hook and
+  reinforces per-turn via the existing `UserPromptSubmit` path so other
+  plugins can't drift the rules away over long sessions. Four modes:
+  - `lite`: drop hedging, pleasantries, and repeat caveats.
+  - `full`: + declarative sentences only, no narration of upcoming steps,
+    one-sentence conclusions (Hemingway-adjacent).
+  - `ultra`: + max 3 non-code lines per reply, single-word confirmations
+    where accurate.
+  - `grunt`: + drop articles (a/an/the) and subject pronouns, fragments
+    over sentences, occasional playful terseness ("ship it.", "nope.",
+    "aye."). Tightest mode — caveman-adjacent energy, zero emoji, still
+    safety-gated. A Golem that literally grunts.
+  Safety gates are on by default and preserve fenced code, shell
+  commands, security/auth warnings, destructive-action language, error
+  messages, URLs/paths, and numerical results verbatim — in ALL modes,
+  grunt included.
+- **`tokenomy golem` CLI** — `enable [--mode=lite|full|ultra|grunt]`,
+  `disable`, `status`. The `status` command prints the exact text that
+  gets injected at SessionStart and per-turn, so users can see what Golem
+  is doing with zero surprise.
+- **New `SessionStart` hook registration** in `tokenomy init`. Fires
+  once per Claude Code session. Passthrough (nothing injected) when
+  Golem is disabled. Powers the Golem preamble when enabled.
+- **Golem savings tracking.** Every SessionStart injection logs a
+  `golem:session-start:<mode>` row; every per-turn reminder logs
+  `golem:<mode>` with a conservative token estimate (lite 150, full 300,
+  ultra 500 per turn). `tokenomy report` aggregates these alongside
+  the existing trim categories.
+
+### Changed
+
+- `tokenomy init` now also registers the `SessionStart` hook. Existing
+  installs pick this up on next `tokenomy update`.
+- `tokenomy doctor` hook-entries check now verifies all four events
+  (`PostToolUse`, `PreToolUse`, `UserPromptSubmit`, `SessionStart`).
+- `settings-patch.HookEvent` extends to include `"SessionStart"`.
+- Version channel graduates from `-alpha.*` to `-beta.*`. Config-file
+  schema is considered stable for the beta line; features are additive
+  and won't break existing configs.
+
+### Tests
+
+- +23 tests: 12 Golem unit (mode rules including grunt, safety gates,
+  savings estimate monotonicity, session-context / turn-reminder
+  generation) + 4 hook-spawn integration (SessionStart with/without
+  Golem, UserPromptSubmit reinforcement with and without a classifier
+  intent) + 7 CLI integration (enable/disable/status round-trips,
+  invalid-mode rejection). Full suite: **396/396 passing**.
+
 ## [0.1.0-alpha.22] — 2026-04-22
 
 Closes the planning-phase gap in tokenomy's nudge surface: a new

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,7 +225,7 @@ The publish flow is fully automated via `.github/workflows/publish.yml` using **
 
 ### Every release
 
-1. Branch off `main`, bump `package.json` version (e.g. `0.1.0-alpha.N` → `0.1.0-alpha.(N+1)`).
+1. Branch off `main`, bump `package.json` + `src/core/version.ts` (e.g. `0.1.1-beta.N` → `0.1.1-beta.(N+1)`, or graduate to `0.1.1` → `0.1.2-beta.1` for a new minor). Both files MUST match — prior releases have shipped with drift between them and the CLI reported stale versions.
 2. Add a CHANGELOG section for the new version, listing Added / Changed / Fixed items.
 3. `npm run prepublishOnly` — clean + build + test + typecheck must be green.
 4. Commit with `chore(release): X.Y.Z — <one-line summary>`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A surgical hook + analysis toolkit for **Claude Code and Codex CLI** that transp
 [![Node](https://img.shields.io/badge/node-%E2%89%A520-brightgreen)](#quickstart)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](#license)
 [![Phase](https://img.shields.io/badge/phase%204-alpha-blue)](#roadmap)
-[![Tests](https://img.shields.io/badge/tests-373%20passing-brightgreen)](#contribute)
+[![Tests](https://img.shields.io/badge/tests-396%20passing-brightgreen)](#contribute)
 
 </div>
 
@@ -43,6 +43,7 @@ Tokenomy plugs the holes the agent hook contracts let you close — with zero pr
 | `PreToolUse` on `Bash` | Claude Code | rewrites `tool_input.command` | Unbounded verbose shell output — `git log`, `find`, `ls -R`, `ps aux`, `docker logs`, `journalctl`, `tree` |
 | `PreToolUse` on `Write` | Claude Code | `additionalContext` | Reinventing existing repo work or mature utility libraries from scratch |
 | `UserPromptSubmit` (alpha.22+) | Claude Code | `additionalContext` on every user turn | Agent planning without first checking graph for existing code, blast radius, or maintained libraries |
+| `SessionStart` (beta.1+, Golem) | Claude Code | `additionalContext` once per session + per-turn reinforcement | Verbose assistant replies — output tokens cost 5× input on Sonnet |
 | `tokenomy-graph` MCP server | Claude Code · Codex CLI | 6 tools over stdio | Brute-force `Read` sweeps of the codebase — agent gets focused context from a pre-built graph + repo/branch/package alternatives |
 | `tokenomy analyze` | Claude Code · Codex CLI transcripts | Walks `~/.claude/projects/**/*.jsonl` + `~/.codex/sessions/**/*.jsonl`, replays Tokenomy rules with a real tokenizer | Tells you *exactly* how much you've been wasting, by tool, by day, by rule |
 
@@ -68,6 +69,7 @@ Automatic response shrinking the moment a tool call finishes (or is about to fir
 Nudges cost nothing if the agent was going to do the right thing anyway — and save 10–50 k tokens per occurrence when it wasn't.
 
 - **OSS-alternatives Write nudge** *(alpha.18+)* — when Claude creates a new file in a utility-ish path (`src/utils/**`, `src/lib/**`, `pkg/**`, `internal/**`, etc.) above 500 B, Tokenomy recommends `find_oss_alternatives` first. The agent checks this repo + local branches + npm / PyPI / pkg.go.dev / Maven Central before writing anything.
+- **Golem** *(beta.1+)* — opt-in terse-output-mode plugin. Injects deterministic style rules at `SessionStart` and reinforces per-turn. Four modes: `lite` (drop hedging) → `full` (declarative sentences) → `ultra` (max 3 lines, single-word confirmations) → `grunt` (fragments, dropped articles/pronouns, occasional "ship it." / "nope." / "aye." — caveman-adjacent energy). Safety gates always preserve code, commands, warnings, and numerical results verbatim. Enable: `tokenomy golem enable [--mode=lite|full|ultra|grunt]`. Off by default; attacks the one token surface the other features leave alone — assistant output.
 - **Prompt-classifier nudge** *(alpha.22+)* — fires once per user turn, **before** Claude plans. Classifies intent and points at the right graph tool:
   - `build | implement | add | create` → `find_oss_alternatives`
   - `refactor | rename | migrate | extract | replace` → `find_usages` + `get_impact_radius`
@@ -144,7 +146,7 @@ Since alpha.15, `init --graph-path` builds the graph for you in a single shot; p
 
 Codex-only / manual registration: `codex mcp add tokenomy-graph -- tokenomy graph serve --path "$PWD"`.
 
-> **Pre-`1.0`.** Every release is `-alpha.N`; breaking changes may land on minor bumps (see [CHANGELOG](./CHANGELOG.md)). Pin for stability: `npm install -g tokenomy@0.1.0-alpha.22`. Upgrade with one command — `tokenomy update` (runs `npm install -g` + re-stages the hook + is idempotent; config + logs preserved). Check without installing: `tokenomy update --check`. Pin an exact release: `tokenomy update@0.1.0-alpha.22` or `tokenomy update --version 0.1.0-alpha.22`. Bleeding edge: see [Development](#development).
+> **Pre-`1.0`.** Every release is `-alpha.N`; breaking changes may land on minor bumps (see [CHANGELOG](./CHANGELOG.md)). Pin for stability: `npm install -g tokenomy@0.1.1-beta.1`. Upgrade with one command — `tokenomy update` (runs `npm install -g` + re-stages the hook + is idempotent; config + logs preserved). Check without installing: `tokenomy update --check`. Pin an exact release: `tokenomy update@0.1.1-beta.1` or `tokenomy update --version 0.1.1-beta.1`. Bleeding edge: see [Development](#development).
 
 Watch trims live — `tail -f ~/.tokenomy/savings.jsonl`:
 
@@ -473,8 +475,8 @@ Globs are gitignore-style: `**` crosses directory boundaries, `*` stays within a
 ```bash
 tokenomy update            # install latest + re-stage hook in one shot
 tokenomy update --check    # query registry, print installed vs remote, exit 1 if out of date
-tokenomy update@0.1.0-alpha.22   # npm-style pin
-tokenomy update --version=0.1.0-alpha.22  # same, explicit flag
+tokenomy update@0.1.1-beta.1   # npm-style pin
+tokenomy update --version=0.1.1-beta.1  # same, explicit flag
 tokenomy update --tag=beta # opt into a non-default dist-tag
 ```
 
@@ -512,7 +514,7 @@ Removes both hook entries from `~/.claude/settings.json` (matched by absolute co
 
 ## 🤝 Contribute
 
-Contributions welcome. Dependency-light (zero runtime deps in the hot hook path; `@modelcontextprotocol/sdk` loaded dynamically for the graph server; `js-tiktoken` optional peer for accurate `analyze`), test-first (373/373 currently green, 96% stmt / 85% branch / 100% func coverage).
+Contributions welcome. Dependency-light (zero runtime deps in the hot hook path; `@modelcontextprotocol/sdk` loaded dynamically for the graph server; `js-tiktoken` optional peer for accurate `analyze`), test-first (396/396 currently green, 96% stmt / 85% branch / 100% func coverage).
 
 **Good first issues:**
 
@@ -552,7 +554,7 @@ Rules are pure: `(toolName, toolInput, toolResponse, config) → { kind: "passth
 ```bash
 git clone https://github.com/RahulDhiman93/Tokenomy && cd Tokenomy
 npm install && npm run build
-npm test             # 373 tests, ~2s
+npm test             # 396 tests, ~2s
 npm run coverage     # c8 → coverage/lcov.info + HTML
 npm run typecheck    # tsc --noEmit
 npm link             # point `tokenomy` at your local build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenomy",
-  "version": "0.1.0-alpha.22",
+  "version": "0.1.1-beta.1",
   "description": "Surgical Claude Code hook that transparently trims bloated MCP tool responses and clamps oversized file reads — stop burning tokens on tool chatter.",
   "type": "module",
   "engines": {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -73,11 +73,12 @@ const hookEntryCheck = (settings: SettingsShape | undefined): CheckResult => {
   const post = countHooksForPath(settings, hook, "PostToolUse");
   const pre = countHooksForPath(settings, hook, "PreToolUse");
   const prompt = countHooksForPath(settings, hook, "UserPromptSubmit");
-  const ok = post === 1 && pre === 1 && prompt === 1;
+  const session = countHooksForPath(settings, hook, "SessionStart");
+  const ok = post === 1 && pre === 1 && prompt === 1 && session === 1;
   return {
-    name: "Hook entries present (PostToolUse + PreToolUse + UserPromptSubmit)",
+    name: "Hook entries present (PostToolUse + PreToolUse + UserPromptSubmit + SessionStart)",
     ok,
-    detail: `post=${post} pre=${pre} prompt=${prompt}`,
+    detail: `post=${post} pre=${pre} prompt=${prompt} session=${session}`,
     remediation: ok ? undefined : "Run `tokenomy init` to install/repair.",
   };
 };
@@ -418,7 +419,7 @@ export const runDoctorFix = async (): Promise<CheckResult[]> => {
 
     // Hook entries missing / manifest drift → re-run init.
     if (
-      c.name === "Hook entries present (PostToolUse + PreToolUse + UserPromptSubmit)" ||
+      c.name === "Hook entries present (PostToolUse + PreToolUse + UserPromptSubmit + SessionStart)" ||
       c.name === "Manifest drift"
     ) {
       try {

--- a/src/cli/entry.ts
+++ b/src/cli/entry.ts
@@ -7,6 +7,7 @@ import { runGraph } from "./graph.js";
 import { runReport } from "./report.js";
 import { runAnalyze } from "./analyze.js";
 import { runUpdate } from "./update.js";
+import { runGolem } from "./golem-cmd.js";
 import { buildGraph } from "../graph/build.js";
 import { loadConfig } from "../core/config.js";
 import type { TokenizerChoice } from "../analyze/tokens.js";
@@ -30,6 +31,9 @@ Usage:
   tokenomy update [--tag=alpha|latest|beta|rc] [--version=<v>] [--check] [--force]
   tokenomy config get <key>
   tokenomy config set <key> <value>
+  tokenomy golem enable [--mode=lite|full|ultra|grunt]
+  tokenomy golem disable
+  tokenomy golem status
   tokenomy --version | --help
 `;
 
@@ -263,6 +267,8 @@ const main = async (): Promise<number> => {
     }
     return 0;
   }
+
+  if (cmd === "golem") return runGolem(process.argv.slice(3));
 
   if (cmd === "config") {
     const sub = args._[1];

--- a/src/cli/golem-cmd.ts
+++ b/src/cli/golem-cmd.ts
@@ -1,0 +1,116 @@
+import { configGet, configSet } from "./config-cmd.js";
+import { loadConfig } from "../core/config.js";
+import {
+  buildGolemSessionContext,
+  buildGolemTurnReminder,
+} from "../rules/golem.js";
+
+// `tokenomy golem enable|disable|status [--mode=lite|full|ultra]`
+//
+// Pure CLI wrapper over the existing `tokenomy config set` machinery. No
+// settings.json patching here — the SessionStart + UserPromptSubmit hook
+// registrations land during `tokenomy init`. This command only toggles the
+// config flags that the live hooks read every invocation.
+
+const MODES = new Set(["lite", "full", "ultra", "grunt"]);
+
+const parseModeFlag = (argv: string[]): string | null => {
+  for (const arg of argv) {
+    if (arg.startsWith("--mode=")) return arg.slice("--mode=".length);
+    if (arg === "--mode") {
+      const idx = argv.indexOf(arg);
+      const next = argv[idx + 1];
+      if (typeof next === "string" && !next.startsWith("--")) return next;
+    }
+  }
+  return null;
+};
+
+const writeStatus = (): number => {
+  const cfg = loadConfig(process.cwd());
+  const g = cfg.golem;
+  const status = g.enabled ? "ENABLED" : "disabled";
+  process.stdout.write(`Golem: ${status}\n`);
+  process.stdout.write(`  mode:         ${g.mode}\n`);
+  process.stdout.write(`  safety_gates: ${g.safety_gates}\n`);
+  if (!g.enabled) {
+    process.stdout.write(
+      "\nRun `tokenomy golem enable [--mode=lite|full|ultra]` to turn it on.\n",
+    );
+    return 0;
+  }
+  // When enabled, show the user exactly what gets injected. No surprises.
+  const sessionCtx = buildGolemSessionContext(cfg);
+  const turnReminder = buildGolemTurnReminder(cfg);
+  if (sessionCtx) {
+    process.stdout.write(
+      "\nSessionStart injection (once per session):\n----------\n" +
+        sessionCtx +
+        "\n----------\n",
+    );
+  }
+  if (turnReminder) {
+    process.stdout.write(
+      "\nUserPromptSubmit reminder (every turn):\n----------\n" +
+        turnReminder +
+        "\n----------\n",
+    );
+  }
+  return 0;
+};
+
+export const runGolem = (argv: string[]): number => {
+  const sub = argv[0];
+
+  if (sub === "status" || sub === undefined) {
+    return writeStatus();
+  }
+
+  if (sub === "enable") {
+    const mode = parseModeFlag(argv);
+    if (mode !== null) {
+      if (!MODES.has(mode)) {
+        process.stderr.write(
+          `tokenomy golem: invalid mode "${mode}". Expected one of: lite, full, ultra, grunt.\n`,
+        );
+        return 1;
+      }
+      configSet("golem.mode", mode);
+    }
+    configSet("golem.enabled", "true");
+    const cfg = loadConfig(process.cwd());
+    process.stdout.write(
+      `✓ Golem enabled in ${cfg.golem.mode.toUpperCase()} mode. ` +
+        `Safety gates: ${cfg.golem.safety_gates ? "on" : "off"}.\n`,
+    );
+    process.stdout.write(
+      "  → Start a new Claude Code session to load the output-style rules.\n",
+    );
+    process.stdout.write(
+      "  → `tokenomy golem status` shows exactly what gets injected.\n",
+    );
+    return 0;
+  }
+
+  if (sub === "disable") {
+    configSet("golem.enabled", "false");
+    process.stdout.write(
+      "✓ Golem disabled. Assistant replies will return to normal style on the next session.\n",
+    );
+    return 0;
+  }
+
+  if (sub === "get" && argv[1]) {
+    const v = configGet(`golem.${argv[1]}`);
+    process.stdout.write(v === undefined ? "" : `${JSON.stringify(v)}\n`);
+    return 0;
+  }
+
+  process.stderr.write(
+    "Usage:\n" +
+      "  tokenomy golem enable [--mode=lite|full|ultra|grunt]\n" +
+      "  tokenomy golem disable\n" +
+      "  tokenomy golem status\n",
+  );
+  return 1;
+};

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -154,8 +154,13 @@ export const runInit = (opts: InitOptions = {}): {
   settings = addHook(settings, "PreToolUse", hookPath, PRE_MATCHER, TIMEOUT_SECONDS);
   // UserPromptSubmit fires once per user turn, before the model sees the
   // prompt. Matcher is empty because the event isn't tool-scoped. Powers
-  // the prompt-classifier nudge (alpha.22+).
+  // the prompt-classifier nudge (alpha.22+) and the Golem per-turn
+  // reinforcement (0.1.1-beta.1+).
   settings = addHook(settings, "UserPromptSubmit", hookPath, "", TIMEOUT_SECONDS);
+  // SessionStart fires once when a new coding session begins. Powers the
+  // Golem output-mode preamble (0.1.1-beta.1+). Passthrough when Golem
+  // is disabled — the hook returns null and nothing is injected.
+  settings = addHook(settings, "SessionStart", hookPath, "", TIMEOUT_SECONDS);
   const graphServerPath = opts.graphPath ? resolve(opts.graphPath) : null;
 
   atomicWrite(settingsPath, stableStringify(settings) + "\n");
@@ -179,7 +184,7 @@ export const runInit = (opts: InitOptions = {}): {
   manifest = upsertEntry(manifest, {
     command_path: hookPath,
     settings_path: settingsPath,
-    matcher: `PostToolUse:${POST_MATCHER}|PreToolUse:${PRE_MATCHER}|UserPromptSubmit`,
+    matcher: `PostToolUse:${POST_MATCHER}|PreToolUse:${PRE_MATCHER}|UserPromptSubmit|SessionStart`,
     installed_at: new Date().toISOString(),
   });
   writeManifest(manifest);

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -95,6 +95,11 @@ export const DEFAULT_CONFIG: Config = {
     p95_budget_ms: 50,
     sample_size: 100,
   },
+  golem: {
+    enabled: false,
+    mode: "full",
+    safety_gates: true,
+  },
   nudge: {
     enabled: true,
     oss_search: {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -65,6 +65,24 @@ export interface UserPromptHookOutput {
   };
 }
 
+// Claude Code fires SessionStart once when a new coding session begins.
+// Golem uses this to inject its output-style rules so the whole session
+// (not just one turn) runs terse-mode.
+export interface SessionStartHookInput {
+  session_id: string;
+  transcript_path: string;
+  cwd: string;
+  hook_event_name: "SessionStart";
+  source?: string;
+}
+
+export interface SessionStartHookOutput {
+  hookSpecificOutput: {
+    hookEventName: "SessionStart";
+    additionalContext: string;
+  };
+}
+
 export type RuleResult =
   | { kind: "passthrough" }
   | {
@@ -242,6 +260,32 @@ export interface NudgeConfig {
   };
 }
 
+// Golem: terse-output-mode plugin. Injects assistant-reply style rules at
+// SessionStart and reinforces per-turn via UserPromptSubmit. Three modes
+// (lite / full / ultra) with a safety gate that NEVER compresses fenced
+// code, shell commands, security/auth warnings, or destructive-action
+// language. Off by default — opt in via `tokenomy golem enable`.
+export interface GolemConfig {
+  // Master switch. When false, no SessionStart injection, no per-turn
+  // reminder, no output-mode rules. Default: false (opt-in).
+  enabled: boolean;
+  // Terseness level:
+  // - "lite":  drop hedging ("I think", "perhaps"), pleasantries, repeat caveats
+  // - "full":  + declarative sentences only, no narration of upcoming steps,
+  //            one-sentence conclusions (Hemingway-adjacent)
+  // - "ultra": + max 3 non-code lines per reply, single-word confirmations
+  //            where possible
+  // - "grunt": + drop articles / subject pronouns where meaning survives,
+  //            fragments over sentences, occasional playful terseness
+  //            ("ship it.", "nope.", "aye."). Tightest mode — caveman-
+  //            adjacent energy, still safety-gated.
+  mode: "lite" | "full" | "ultra" | "grunt";
+  // Always-preserved content carve-outs. Fenced code / shell / security /
+  // destructive-action / error-message text is never subject to the style
+  // rules. Off this only if you understand the risk.
+  safety_gates: boolean;
+}
+
 export interface Config {
   aggression: "conservative" | "balanced" | "aggressive";
   gate: GateConfig;
@@ -263,6 +307,8 @@ export interface Config {
   // See NudgeConfig. Optional for backwards-compat: legacy config files
   // deserialize fine and pick up defaults via DEFAULT_CONFIG merging.
   nudge?: NudgeConfig;
+  // Golem: terse-output-mode plugin (0.1.1-beta.1+). Off by default.
+  golem: GolemConfig;
 }
 
 export interface DedupConfig {

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,1 +1,1 @@
-export const TOKENOMY_VERSION = "0.1.0-alpha.22";
+export const TOKENOMY_VERSION = "0.1.1-beta.1";

--- a/src/hook/entry.ts
+++ b/src/hook/entry.ts
@@ -2,12 +2,17 @@
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { dispatch } from "./dispatch.js";
-import { preDispatch, dispatchUserPrompt } from "./pre-dispatch.js";
+import {
+  preDispatch,
+  dispatchUserPrompt,
+  dispatchSessionStart,
+} from "./pre-dispatch.js";
 import { loadConfig } from "../core/config.js";
 import { tokenomyDir } from "../core/paths.js";
 import type {
   HookInput,
   PreHookInput,
+  SessionStartHookInput,
   UserPromptHookInput,
 } from "../core/types.js";
 
@@ -99,12 +104,17 @@ const main = async (): Promise<void> => {
       return;
     }
 
-    let parsed: HookInput | PreHookInput | UserPromptHookInput;
+    let parsed:
+      | HookInput
+      | PreHookInput
+      | UserPromptHookInput
+      | SessionStartHookInput;
     try {
       parsed = JSON.parse(buf.toString("utf8")) as
         | HookInput
         | PreHookInput
-        | UserPromptHookInput;
+        | UserPromptHookInput
+        | SessionStartHookInput;
     } catch {
       debugLog({ phase: "parse-fail", stdin_bytes: buf.length });
       process.exit(0);
@@ -112,6 +122,20 @@ const main = async (): Promise<void> => {
     }
 
     const cfg = loadConfig(parsed?.cwd ?? process.cwd());
+
+    if (parsed?.hook_event_name === "SessionStart") {
+      const sessionInput = parsed as SessionStartHookInput;
+      const out = dispatchSessionStart(sessionInput, cfg);
+      debugLog({
+        phase: out ? "session-start-golem" : "session-start-passthrough",
+        session_id: sessionInput.session_id,
+        event: "SessionStart",
+        elapsed_ms: Date.now() - hookStart,
+      });
+      if (out) process.stdout.write(JSON.stringify(out));
+      process.exit(0);
+      return;
+    }
 
     if (parsed?.hook_event_name === "UserPromptSubmit") {
       const promptInput = parsed as UserPromptHookInput;

--- a/src/hook/pre-dispatch.ts
+++ b/src/hook/pre-dispatch.ts
@@ -5,6 +5,8 @@ import type {
   PreHookInput,
   PreHookOutput,
   SavingsLogEntry,
+  SessionStartHookInput,
+  SessionStartHookOutput,
   UserPromptHookInput,
   UserPromptHookOutput,
 } from "../core/types.js";
@@ -12,6 +14,11 @@ import { readBoundRule } from "../rules/read-bound.js";
 import { bashBoundRule } from "../rules/bash-bound.js";
 import { writeNudgeRule } from "../rules/write-nudge.js";
 import { classifyPromptRule } from "../rules/prompt-classifier.js";
+import {
+  buildGolemSessionContext,
+  buildGolemTurnReminder,
+  estimateGolemSavingsTokens,
+} from "../rules/golem.js";
 import { estimateTokens } from "../core/gate.js";
 import { appendSavingsLog } from "../core/log.js";
 import { graphMetaPath, tokenomyGraphRootDir } from "../core/paths.js";
@@ -155,29 +162,88 @@ export const dispatchUserPrompt = (
   cfg: Config,
 ): UserPromptHookOutput | null => {
   const r = classifyPromptRule(input.prompt ?? "", cfg, input.cwd);
-  if (r.kind !== "nudge" || !r.additionalContext) return null;
+  const golemReminder = buildGolemTurnReminder(cfg);
 
-  // Log a savings entry so `tokenomy report` and `tokenomy analyze` surface
-  // these nudges alongside Read/Bash/MCP trims. Token estimates are
-  // intentionally conservative — this is the value the nudge unlocks IF
-  // the agent follows through on the MCP call, not a guaranteed saving.
-  const tokensSavedEst = INTENT_SAVINGS_TOKENS[r.intent ?? ""] ?? 5_000;
-  const bytesSavedEst = tokensSavedEst * 4;
+  if (r.kind === "nudge" && r.additionalContext) {
+    // Log a savings entry so `tokenomy report` and `tokenomy analyze` surface
+    // these nudges alongside Read/Bash/MCP trims. Token estimates are
+    // intentionally conservative — this is the value the nudge unlocks IF
+    // the agent follows through on the MCP call, not a guaranteed saving.
+    const tokensSavedEst = INTENT_SAVINGS_TOKENS[r.intent ?? ""] ?? 5_000;
+    const bytesSavedEst = tokensSavedEst * 4;
+    const entry: SavingsLogEntry = {
+      ts: new Date().toISOString(),
+      session_id: input.session_id,
+      tool: "UserPromptSubmit",
+      bytes_in: bytesSavedEst,
+      bytes_out: 0,
+      tokens_saved_est: tokensSavedEst,
+      reason: `nudge:prompt-classifier:${r.intent ?? "unknown"}`,
+    };
+    appendSavingsLog(cfg.log_path, entry);
+
+    // If Golem is active, append its per-turn reminder so the style rules
+    // survive plugin drift even in turns where a classifier intent fires.
+    const additionalContext = golemReminder
+      ? `${r.additionalContext}\n\n${golemReminder}`
+      : r.additionalContext;
+    return {
+      hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext,
+      },
+    };
+  }
+
+  // No classifier intent matched. Golem still needs its per-turn reminder
+  // so other plugins can't shadow the style rules over time.
+  if (golemReminder) {
+    const savingsTokens = estimateGolemSavingsTokens(cfg.golem.mode);
+    const entry: SavingsLogEntry = {
+      ts: new Date().toISOString(),
+      session_id: input.session_id,
+      tool: "UserPromptSubmit",
+      bytes_in: savingsTokens * 4,
+      bytes_out: 0,
+      tokens_saved_est: savingsTokens,
+      reason: `golem:${cfg.golem.mode}`,
+    };
+    appendSavingsLog(cfg.log_path, entry);
+    return {
+      hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: golemReminder,
+      },
+    };
+  }
+
+  return null;
+};
+
+export const dispatchSessionStart = (
+  input: SessionStartHookInput,
+  cfg: Config,
+): SessionStartHookOutput | null => {
+  const ctx = buildGolemSessionContext(cfg);
+  if (!ctx) return null;
+  // SessionStart fires once per session — log a single "golem:session-start"
+  // event so `tokenomy report` can show Golem is active without double-
+  // counting the per-turn reminders. Savings value is 0 here; the per-turn
+  // path does the accounting.
   const entry: SavingsLogEntry = {
     ts: new Date().toISOString(),
     session_id: input.session_id,
-    tool: "UserPromptSubmit",
-    bytes_in: bytesSavedEst,
+    tool: "SessionStart",
+    bytes_in: 0,
     bytes_out: 0,
-    tokens_saved_est: tokensSavedEst,
-    reason: `nudge:prompt-classifier:${r.intent ?? "unknown"}`,
+    tokens_saved_est: 0,
+    reason: `golem:session-start:${cfg.golem.mode}`,
   };
   appendSavingsLog(cfg.log_path, entry);
-
   return {
     hookSpecificOutput: {
-      hookEventName: "UserPromptSubmit",
-      additionalContext: r.additionalContext,
+      hookEventName: "SessionStart",
+      additionalContext: ctx,
     },
   };
 };

--- a/src/rules/golem.ts
+++ b/src/rules/golem.ts
@@ -1,0 +1,123 @@
+import type { Config } from "../core/types.js";
+
+// Golem — the tireless-clay-worker output-mode plugin for tokenomy.
+//
+// Golem attacks the one token surface tokenomy's other rules leave alone:
+// the assistant's own replies. Input-side trimming (MCP trim, Read clamp,
+// Bash bounder) can save 100k tokens on a busy day, but a 500-token reply
+// × 50 turns in a session is another 25k tokens of output that is billed
+// more expensively than input on every major provider.
+//
+// Golem ships three modes. Each injects a concise style rule via the
+// SessionStart hook; UserPromptSubmit re-injects a short reminder every
+// turn so the rules survive competition from other plugins (Cursor rules,
+// project CLAUDE.md, etc). Nothing is stochastic — the rule list is fixed
+// and documented. Users can inspect exactly what Golem adds to the
+// conversation by running `tokenomy golem status`.
+//
+// Safety gates: Golem never compresses fenced code blocks, shell commands,
+// security/auth warnings, destructive-action language, error messages, or
+// stack traces. These five classes are the ones where terseness is
+// actively harmful. The gates are on by default; advanced users can
+// disable via `nudge.golem.safety_gates = false` but that's rarely wise.
+
+export type GolemMode = "lite" | "full" | "ultra" | "grunt";
+
+// The canonical rule blocks. Kept as plain text so users who run
+// `tokenomy golem status` can see exactly what's being injected — no
+// stochastic template generation, no opaque prompt engineering.
+const LITE_RULES = [
+  "Drop hedging: no \"I think\", \"perhaps\", \"you might want to\", \"it seems\".",
+  "Drop pleasantries: no \"great question\", \"happy to help\", \"absolutely\".",
+  "Drop repeat caveats: state a caveat once, never twice in one reply.",
+  "Skip narration of what you are about to do; just do it and report results.",
+].join("\n  - ");
+
+const FULL_RULES = [
+  LITE_RULES,
+  "Use declarative sentences; avoid softeners (\"perhaps\", \"maybe\", \"could\").",
+  "One-sentence conclusions after tool results, not a paragraph.",
+  "No restating the user's question back before answering.",
+  "No \"let me know if...\" closers.",
+].join("\n  - ");
+
+const ULTRA_RULES = [
+  FULL_RULES,
+  "Maximum 3 non-code lines per reply unless the user asked for a plan or analysis.",
+  "Single-word confirmations where accurate: \"Done.\", \"Shipped.\", \"Yes.\", \"No.\".",
+  "Lists over prose whenever a list works.",
+  "No headers on replies under 10 lines.",
+].join("\n  - ");
+
+// GRUNT — the tightest Golem mode. A Golem that literally grunts. Caveman-
+// adjacent energy but still safety-gated: numbers, code, commands, and
+// warnings are preserved verbatim. Prose around them becomes fragments.
+// Use when every token counts and tone doesn't matter.
+const GRUNT_RULES = [
+  ULTRA_RULES,
+  "Drop articles (a, an, the) wherever the meaning survives. \"Use p-retry\" beats \"Use the p-retry library\".",
+  "Drop subject pronouns when context is obvious. \"Skipping.\", \"Done.\", \"Fixed it.\" — not \"I'm skipping.\".",
+  "Fragments over complete sentences when intent is clear. \"Tests green. Ready to ship.\" — not \"The tests are green and the code is ready to ship.\".",
+  "Questions as fragments. \"Ship?\", \"Revert?\", \"Retry?\" — not \"Should I ship this now?\".",
+  "Occasional playful terseness is allowed: \"ship it.\", \"nope.\", \"aye.\", \"bah.\", \"done and done.\". Keep it dry; no emoji, no exclamation.",
+  "Never sacrifice a number, name, path, or warning for brevity. Those stay verbatim.",
+].join("\n  - ");
+
+const SAFETY_GATES = `
+ALWAYS PRESERVE IN FULL (these override every rule above):
+  - Fenced code blocks and inline code spans
+  - Shell commands and CLI snippets
+  - Security/auth warnings (anything mentioning auth, secret, token, credential, API key)
+  - Destructive-action language (rm -rf, DROP TABLE, git push --force, reset --hard, production deploys, migrations)
+  - Error messages, stack traces, file paths, URLs
+  - Numerical results, counts, measurements (precision matters)
+`.trim();
+
+const rulesFor = (mode: GolemMode): string => {
+  if (mode === "lite") return LITE_RULES;
+  if (mode === "ultra") return ULTRA_RULES;
+  if (mode === "grunt") return GRUNT_RULES;
+  return FULL_RULES;
+};
+
+const modeLabel = (mode: GolemMode): string => mode.toUpperCase();
+
+// Session-start preamble: full style rules + safety gates. Loaded once per
+// session so the agent has the full rule set in working memory from turn 1.
+export const buildGolemSessionContext = (cfg: Config): string | null => {
+  const g = cfg.golem;
+  if (!g || !g.enabled) return null;
+  const rules = rulesFor(g.mode);
+  const gates = g.safety_gates ? `\n\n${SAFETY_GATES}` : "";
+  return (
+    `[tokenomy-golem: ${modeLabel(g.mode)} mode — terse assistant replies, deterministic rules]\n\n` +
+    `Apply these output-style rules to every assistant reply in this session:\n` +
+    `  - ${rules}${gates}\n\n` +
+    `Turn Golem off: \`tokenomy golem disable\`. Change mode: ` +
+    `\`tokenomy golem enable --mode lite|full|ultra\`.`
+  );
+};
+
+// Per-turn reinforcement: very short (~30 tokens) reminder that Golem is
+// active. This is a tax against plugin drift — without it, other hooks or
+// project rules that fire AFTER SessionStart can shadow the Golem rules.
+// Intentionally short so the per-turn overhead stays under 1% of a typical
+// assistant reply budget.
+export const buildGolemTurnReminder = (cfg: Config): string | null => {
+  const g = cfg.golem;
+  if (!g || !g.enabled) return null;
+  return `[tokenomy-golem: ${modeLabel(g.mode)} — terse replies, preserve code/commands/warnings verbatim]`;
+};
+
+// Rough per-turn output-token savings estimate, used for savings.jsonl and
+// `tokenomy report`. These are back-of-the-envelope numbers derived from
+// caveman's benchmark range (22–87% reduction, they report ~65% average);
+// we pick conservative values to avoid overclaiming. Users who want real
+// numbers should run `tokenomy analyze` which replays transcripts against
+// a real tokenizer.
+export const estimateGolemSavingsTokens = (mode: GolemMode): number => {
+  if (mode === "lite") return 150; // per-turn estimate — gentle drops
+  if (mode === "ultra") return 500; // aggressive terseness
+  if (mode === "grunt") return 750; // tightest — articles + pronouns dropped too
+  return 300; // full-mode default
+};

--- a/src/util/settings-patch.ts
+++ b/src/util/settings-patch.ts
@@ -24,13 +24,18 @@ interface SettingsShape {
     PostToolUse?: HookMatcherEntry[];
     PreToolUse?: HookMatcherEntry[];
     UserPromptSubmit?: HookMatcherEntry[];
+    SessionStart?: HookMatcherEntry[];
     [event: string]: HookMatcherEntry[] | undefined;
   };
   mcpServers?: Record<string, McpServerEntry>;
   [k: string]: unknown;
 }
 
-export type HookEvent = "PostToolUse" | "PreToolUse" | "UserPromptSubmit";
+export type HookEvent =
+  | "PostToolUse"
+  | "PreToolUse"
+  | "UserPromptSubmit"
+  | "SessionStart";
 
 const stripQuotes = (s: string): string => {
   const t = s.trim();
@@ -110,7 +115,7 @@ export const countHooksForPath = (
 ): number => {
   const events = event
     ? [event]
-    : (["PostToolUse", "PreToolUse", "UserPromptSubmit"] as HookEvent[]);
+    : (["PostToolUse", "PreToolUse", "UserPromptSubmit", "SessionStart"] as HookEvent[]);
   let n = 0;
   for (const e of events) {
     const entries = settings.hooks?.[e];

--- a/tests/integration/golem-cli.test.ts
+++ b/tests/integration/golem-cli.test.ts
@@ -1,0 +1,101 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CLI = join(
+  fileURLToPath(new URL("../..", import.meta.url)),
+  "dist/cli/entry.js",
+);
+
+const runCli = (argv: string[], env: NodeJS.ProcessEnv) => {
+  if (!existsSync(CLI)) throw new Error("CLI not built. Run `npm run build`.");
+  const r = spawnSync(process.execPath, [CLI, ...argv], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return { code: r.status, stdout: r.stdout, stderr: r.stderr };
+};
+
+const withHome = <T>(fn: (home: string) => T): T => {
+  const home = mkdtempSync(join(tmpdir(), "tokenomy-golem-cli-"));
+  try {
+    return fn(home);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+};
+
+test("tokenomy golem status: prints disabled by default", () => {
+  withHome((home) => {
+    const r = runCli(["golem", "status"], { HOME: home });
+    assert.equal(r.code, 0);
+    assert.match(r.stdout, /Golem: disabled/);
+    assert.match(r.stdout, /mode:\s+full/); // default mode even when disabled
+  });
+});
+
+test("tokenomy golem enable: flips enabled=true, persists to config.json", () => {
+  withHome((home) => {
+    const r = runCli(["golem", "enable"], { HOME: home });
+    assert.equal(r.code, 0);
+    assert.match(r.stdout, /Golem enabled in FULL mode/);
+    const cfg = JSON.parse(readFileSync(join(home, ".tokenomy", "config.json"), "utf8"));
+    assert.equal(cfg.golem.enabled, true);
+    assert.equal(cfg.golem.mode, "full");
+  });
+});
+
+test("tokenomy golem enable --mode=lite: persists mode override", () => {
+  withHome((home) => {
+    const r = runCli(["golem", "enable", "--mode=lite"], { HOME: home });
+    assert.equal(r.code, 0);
+    assert.match(r.stdout, /Golem enabled in LITE mode/);
+    const cfg = JSON.parse(readFileSync(join(home, ".tokenomy", "config.json"), "utf8"));
+    assert.equal(cfg.golem.mode, "lite");
+  });
+});
+
+test("tokenomy golem enable --mode=bogus: rejects invalid modes", () => {
+  withHome((home) => {
+    const r = runCli(["golem", "enable", "--mode=bogus"], { HOME: home });
+    assert.notEqual(r.code, 0);
+    assert.match(r.stderr, /invalid mode/);
+  });
+});
+
+test("tokenomy golem disable: flips enabled=false", () => {
+  withHome((home) => {
+    runCli(["golem", "enable"], { HOME: home });
+    const r = runCli(["golem", "disable"], { HOME: home });
+    assert.equal(r.code, 0);
+    assert.match(r.stdout, /Golem disabled/);
+    const cfg = JSON.parse(readFileSync(join(home, ".tokenomy", "config.json"), "utf8"));
+    assert.equal(cfg.golem.enabled, false);
+  });
+});
+
+test("tokenomy golem status (enabled): shows the exact injection text", () => {
+  withHome((home) => {
+    runCli(["golem", "enable", "--mode=ultra"], { HOME: home });
+    const r = runCli(["golem", "status"], { HOME: home });
+    assert.equal(r.code, 0);
+    assert.match(r.stdout, /Golem: ENABLED/);
+    assert.match(r.stdout, /mode:\s+ultra/);
+    assert.match(r.stdout, /SessionStart injection/);
+    assert.match(r.stdout, /ULTRA mode/);
+    assert.match(r.stdout, /UserPromptSubmit reminder/);
+  });
+});
+
+test("tokenomy golem: unknown subcommand → prints usage + non-zero exit", () => {
+  withHome((home) => {
+    const r = runCli(["golem", "bogus"], { HOME: home });
+    assert.notEqual(r.code, 0);
+    assert.match(r.stderr, /Usage:/);
+  });
+});

--- a/tests/integration/hook-spawn.test.ts
+++ b/tests/integration/hook-spawn.test.ts
@@ -276,6 +276,136 @@ test("hook: UserPromptSubmit short / neutral prompt → passthrough (no stdout)"
   }
 });
 
+test("hook: SessionStart with Golem enabled → injects terse-mode rules", async () => {
+  const home = mkdtempSync(join(tmpdir(), "tokenomy-golem-"));
+  try {
+    // Seed a config with Golem enabled so the hook actually fires.
+    mkdirSync(join(home, ".tokenomy"), { recursive: true });
+    writeFileSync(
+      join(home, ".tokenomy", "config.json"),
+      JSON.stringify({
+        golem: { enabled: true, mode: "full", safety_gates: true },
+      }),
+    );
+    const env = { ...process.env, HOME: home };
+    const { code, stdout } = await runHook(
+      {
+        session_id: "s",
+        transcript_path: "/tmp/t",
+        cwd: "/tmp",
+        hook_event_name: "SessionStart",
+      },
+      env,
+    );
+    assert.equal(code, 0);
+    assert.ok(stdout.length > 0, "expected Golem session-start injection");
+    const parsed = JSON.parse(stdout);
+    assert.equal(parsed.hookSpecificOutput.hookEventName, "SessionStart");
+    assert.match(parsed.hookSpecificOutput.additionalContext, /FULL mode/);
+    assert.match(parsed.hookSpecificOutput.additionalContext, /Drop hedging/);
+    assert.match(
+      parsed.hookSpecificOutput.additionalContext,
+      /ALWAYS PRESERVE IN FULL/,
+    );
+    // SessionStart writes a savings-log entry so `tokenomy report` can show
+    // Golem is active for this session.
+    const log = readFileSync(join(home, ".tokenomy", "savings.jsonl"), "utf8");
+    assert.match(log, /golem:session-start:full/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("hook: SessionStart with Golem disabled → passthrough (no stdout)", async () => {
+  const home = mkdtempSync(join(tmpdir(), "tokenomy-golem-off-"));
+  try {
+    const env = { ...process.env, HOME: home };
+    const { code, stdout } = await runHook(
+      {
+        session_id: "s",
+        transcript_path: "/tmp/t",
+        cwd: "/tmp",
+        hook_event_name: "SessionStart",
+      },
+      env,
+    );
+    assert.equal(code, 0);
+    assert.equal(stdout, "", "Golem disabled must not emit injection");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("hook: UserPromptSubmit with Golem enabled + no classifier intent → emits reminder only", async () => {
+  const home = mkdtempSync(join(tmpdir(), "tokenomy-golem-reminder-"));
+  try {
+    mkdirSync(join(home, ".tokenomy"), { recursive: true });
+    writeFileSync(
+      join(home, ".tokenomy", "config.json"),
+      JSON.stringify({
+        golem: { enabled: true, mode: "ultra", safety_gates: true },
+      }),
+    );
+    const env = { ...process.env, HOME: home };
+    // Prompt that has no classifier-intent verb ("tell", "explain") AND is
+    // long enough to pass the min-chars gate. Should fire only the Golem
+    // per-turn reminder.
+    const { code, stdout } = await runHook(
+      {
+        session_id: "s",
+        transcript_path: "/tmp/t",
+        cwd: "/tmp",
+        hook_event_name: "UserPromptSubmit",
+        prompt: "Tell me about the architecture of the TLS handshake protocol.",
+      },
+      env,
+    );
+    assert.equal(code, 0);
+    assert.ok(stdout.length > 0, "expected Golem per-turn reminder");
+    const parsed = JSON.parse(stdout);
+    assert.match(parsed.hookSpecificOutput.additionalContext, /ULTRA/);
+    assert.doesNotMatch(
+      parsed.hookSpecificOutput.additionalContext,
+      /tokenomy-nudge \(build\)|find_oss_alternatives/,
+    );
+    const log = readFileSync(join(home, ".tokenomy", "savings.jsonl"), "utf8");
+    assert.match(log, /golem:ultra/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("hook: UserPromptSubmit with Golem + classifier intent → stacks both context lines", async () => {
+  const home = mkdtempSync(join(tmpdir(), "tokenomy-golem-stack-"));
+  try {
+    mkdirSync(join(home, ".tokenomy"), { recursive: true });
+    writeFileSync(
+      join(home, ".tokenomy", "config.json"),
+      JSON.stringify({
+        golem: { enabled: true, mode: "full", safety_gates: true },
+      }),
+    );
+    const env = { ...process.env, HOME: home };
+    const { code, stdout } = await runHook(
+      {
+        session_id: "s",
+        transcript_path: "/tmp/t",
+        cwd: "/tmp",
+        hook_event_name: "UserPromptSubmit",
+        prompt: "Build a retry-with-backoff wrapper for our fetch calls.",
+      },
+      env,
+    );
+    assert.equal(code, 0);
+    const parsed = JSON.parse(stdout);
+    // Both the build-intent nudge AND the Golem reminder must be present.
+    assert.match(parsed.hookSpecificOutput.additionalContext, /find_oss_alternatives/);
+    assert.match(parsed.hookSpecificOutput.additionalContext, /tokenomy-golem: FULL/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
 test("hook: malformed stdin → exit 0 with empty stdout", async () => {
   const child = spawn(process.execPath, [HOOK], { stdio: ["pipe", "pipe", "pipe"] });
   const out: Buffer[] = [];

--- a/tests/unit/golem.test.ts
+++ b/tests/unit/golem.test.ts
@@ -1,0 +1,117 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildGolemSessionContext,
+  buildGolemTurnReminder,
+  estimateGolemSavingsTokens,
+} from "../../src/rules/golem.js";
+import { DEFAULT_CONFIG } from "../../src/core/config.js";
+import type { Config, GolemConfig } from "../../src/core/types.js";
+
+const cfgWithGolem = (patch: Partial<GolemConfig>): Config => {
+  const clone = JSON.parse(JSON.stringify(DEFAULT_CONFIG)) as Config;
+  clone.golem = { ...clone.golem, ...patch };
+  return clone;
+};
+
+test("golem: disabled → buildGolemSessionContext returns null", () => {
+  const cfg = cfgWithGolem({ enabled: false });
+  assert.equal(buildGolemSessionContext(cfg), null);
+  assert.equal(buildGolemTurnReminder(cfg), null);
+});
+
+test("golem: lite mode session context contains lite rules, no ultra-mode rules", () => {
+  const cfg = cfgWithGolem({ enabled: true, mode: "lite" });
+  const ctx = buildGolemSessionContext(cfg);
+  assert.ok(ctx, "expected session context");
+  assert.match(ctx!, /LITE mode/);
+  assert.match(ctx!, /Drop hedging/);
+  assert.doesNotMatch(ctx!, /Maximum 3 non-code lines/);
+});
+
+test("golem: full mode session context adds declarative-sentence rule", () => {
+  const cfg = cfgWithGolem({ enabled: true, mode: "full" });
+  const ctx = buildGolemSessionContext(cfg);
+  assert.match(ctx!, /FULL mode/);
+  assert.match(ctx!, /Use declarative sentences/);
+  assert.match(ctx!, /Drop hedging/); // still inherits lite rules
+  assert.doesNotMatch(ctx!, /Maximum 3 non-code lines/);
+});
+
+test("golem: ultra mode session context adds max-3-lines rule", () => {
+  const cfg = cfgWithGolem({ enabled: true, mode: "ultra" });
+  const ctx = buildGolemSessionContext(cfg);
+  assert.match(ctx!, /ULTRA mode/);
+  assert.match(ctx!, /Maximum 3 non-code lines/);
+  assert.match(ctx!, /Use declarative sentences/); // inherits full
+  assert.match(ctx!, /Drop hedging/); // inherits lite
+});
+
+test("golem: safety_gates on → context mentions preserve-in-full block", () => {
+  const cfg = cfgWithGolem({ enabled: true, mode: "full", safety_gates: true });
+  const ctx = buildGolemSessionContext(cfg);
+  assert.match(ctx!, /ALWAYS PRESERVE IN FULL/);
+  assert.match(ctx!, /Fenced code blocks/);
+  assert.match(ctx!, /Shell commands/);
+  assert.match(ctx!, /Destructive-action language/);
+});
+
+test("golem: safety_gates off → preserve block is omitted", () => {
+  const cfg = cfgWithGolem({ enabled: true, mode: "full", safety_gates: false });
+  const ctx = buildGolemSessionContext(cfg);
+  assert.doesNotMatch(ctx!, /ALWAYS PRESERVE IN FULL/);
+});
+
+test("golem: turn reminder is short (<200 chars) to keep per-turn overhead minimal", () => {
+  const cfg = cfgWithGolem({ enabled: true, mode: "full" });
+  const reminder = buildGolemTurnReminder(cfg);
+  assert.ok(reminder);
+  assert.ok(
+    reminder!.length < 200,
+    `turn reminder too long: ${reminder!.length} chars (${reminder})`,
+  );
+});
+
+test("golem: turn reminder still mentions safety invariants (code/commands preservation)", () => {
+  const cfg = cfgWithGolem({ enabled: true, mode: "ultra" });
+  const reminder = buildGolemTurnReminder(cfg);
+  assert.match(reminder!, /code/i);
+});
+
+test("golem: savings estimate is higher for ultra than lite (tighter rules → more savings)", () => {
+  const lite = estimateGolemSavingsTokens("lite");
+  const full = estimateGolemSavingsTokens("full");
+  const ultra = estimateGolemSavingsTokens("ultra");
+  const grunt = estimateGolemSavingsTokens("grunt");
+  assert.ok(lite < full, `expected lite (${lite}) < full (${full})`);
+  assert.ok(full < ultra, `expected full (${full}) < ultra (${ultra})`);
+  assert.ok(ultra < grunt, `expected ultra (${ultra}) < grunt (${grunt})`);
+});
+
+test("golem: grunt mode inherits all ultra rules AND adds article/pronoun drops", () => {
+  const cfg = cfgWithGolem({ enabled: true, mode: "grunt" });
+  const ctx = buildGolemSessionContext(cfg);
+  assert.ok(ctx);
+  assert.match(ctx!, /GRUNT mode/);
+  // Inherits lite/full/ultra rules.
+  assert.match(ctx!, /Drop hedging/);
+  assert.match(ctx!, /Use declarative sentences/);
+  assert.match(ctx!, /Maximum 3 non-code lines/);
+  // Grunt-specific rules.
+  assert.match(ctx!, /Drop articles/);
+  assert.match(ctx!, /Drop subject pronouns/);
+  assert.match(ctx!, /Fragments over complete sentences/);
+  assert.match(ctx!, /playful terseness/);
+});
+
+test("golem: grunt mode still preserves numbers/names/paths/warnings verbatim", () => {
+  const cfg = cfgWithGolem({ enabled: true, mode: "grunt" });
+  const ctx = buildGolemSessionContext(cfg);
+  assert.match(ctx!, /Never sacrifice a number, name, path, or warning/);
+});
+
+test("golem: session context includes the opt-out command so users can find the off switch", () => {
+  const cfg = cfgWithGolem({ enabled: true, mode: "full" });
+  const ctx = buildGolemSessionContext(cfg);
+  assert.match(ctx!, /tokenomy golem disable/);
+});


### PR DESCRIPTION
## Summary

First beta release. Crosses the one token surface the alpha.0–.22 arc left untouched: **assistant output tokens**. Tokenomy's existing features trim input-side waste (MCP responses, Read calls, Bash output). Golem closes the loop on reply verbosity — opt-in, four modes (`lite` / `full` / `ultra` / `grunt`), deterministic rule list, safety-gated.

Version channel graduates `alpha.*` → `beta.*`. Config schema is stable for the beta line.

## Surface

- [x] **New hook event:** `SessionStart` — `src/rules/golem.ts`, `src/hook/pre-dispatch.ts`, `src/hook/entry.ts`
- [x] **New CLI:** `tokenomy golem enable|disable|status` — `src/cli/golem-cmd.ts`
- [x] **Config / types:** new `golem` config block + `GolemConfig` interface
- [x] **Install:** `tokenomy init` registers `SessionStart` alongside the existing 3 events
- [x] **Doctor:** hook-entries check verifies all 4 events
- [x] **Settings patcher:** `HookEvent` extends to `"SessionStart"`
- [x] **Tests:** 12 unit + 4 integration + 7 CLI = **+23 tests**
- [x] **Docs:** README Features section + Surfaces table, CHANGELOG graduation entry, CLAUDE.md updated conventions

## Why

The alpha.22 prompt-classifier and Write-nudge together close most of the agent-level waste patterns. The one remaining gap: Claude's own reply text. On Sonnet 4.5, output tokens cost **5× more per-token than input** — a 20–30% output reduction is real dollars on a heavy session. Until beta.1, tokenomy had no story for this surface.

## How it works

**Four modes, strictly tighter each time:**

| Mode | What it drops | Per-turn ~tokens saved |
|---|---|---|
| `lite` | hedging, pleasantries, repeat caveats | ~150 |
| `full` | + softeners, narration, one-sentence conclusions | ~300 |
| `ultra` | + max 3 lines non-code, single-word confirmations | ~500 |
| `grunt` | + articles, subject pronouns, fragments, playful terseness | ~750 |

**Mechanics:**
- `SessionStart` injects the full mode rules once per session (working-memory baseline)
- `UserPromptSubmit` re-injects a ~30-token reminder every turn (plugin-drift defense)
- Safety gates always preserve: fenced code, shell commands, security/auth warnings, destructive-action language, error messages, URLs/paths, numerical results — in ALL modes including grunt

**Grunt mode example output:**
```
Before: "I've reviewed the diff and I think it looks good. I'd suggest
         we ship it after running the tests one more time just to be sure."
After:  "Reviewed. Looks good. Ship after tests pass."
```

Code / commands / numbers / warnings in grunt mode pass through verbatim — no terseness at the cost of correctness.

## Honest framing on savings

Golem reduces output tokens only. Output is 5–25% of typical session token spend. Expected per-day savings:

| Mode | Heavy-user ~output tokens saved | ~$/day (Sonnet 4.5) |
|---|---|---|
| `lite` | ~3k | $0.04 |
| `full` | ~8k | $0.12 |
| `ultra` | ~15k | $0.22 |
| `grunt` | ~20k | $0.30 |

Smaller than Bash bounder / Read clamp / MCP trim wins but real. Opt-in by default so users who don't want it pay zero cost. Savings estimates are conservative back-of-envelope until we ship the conversion-tracking telemetry.

## Test plan

- [x] Unit: 12 tests covering per-mode rule content, safety gates on/off, turn-reminder length invariant, savings-estimate monotonicity (lite < full < ultra < grunt), opt-out command surfaced in injection text
- [x] Integration: 4 hook-spawn tests — SessionStart with/without Golem, UserPromptSubmit reinforcement with and without a classifier intent (stacks correctly)
- [x] CLI: 7 tests — enable/disable/status round-trips, invalid-mode rejection, per-mode persistence
- [x] Live E2E probe through built hook binary confirms SessionStart injection + per-turn reinforcement + savings-log entries
- [x] `pnpm test`: 373 → **396 passing** (+23)
- [x] `pnpm run build` clean
- [x] `npx tsc --noEmit` clean

## Invariants preserved

- [x] Fail-open: malformed stdin → exit 0 empty stdout; rule errors → passthrough
- [x] Never modifies user prompts or tool inputs — output is pure `additionalContext` append
- [x] Exit code 2 (blocking) not used
- [x] Safety gates apply to ALL modes including grunt — code/commands/warnings verbatim
- [x] Existing PostToolUse / PreToolUse / UserPromptSubmit hooks unchanged
- [x] Config backward-compatible: missing `golem` block → defaults (disabled), no behavior change for existing users

## Breaking changes

- [x] **No user-visible breaking changes.**
- [x] Settings.json shape now includes a `SessionStart` hook entry. Existing installs pick this up on next `tokenomy update` (alpha.20+ auto-restages graph too). Users who want to disable Golem entry-point: `tokenomy config set golem.enabled false` (already the default).
- [x] Version channel: `-alpha.*` → `-beta.*`. Semver-wise it's a patch bump (`0.1.0` → `0.1.1`) with the pre-release tag reset. Config schema is considered stable across the beta line.

## Config knobs added

```
golem.enabled          (default false, opt-in)
golem.mode             (default "full")
golem.safety_gates     (default true, STRONGLY RECOMMENDED)
```

## Checklist

- [x] Title follows `<type>(<scope>): <description>`
- [x] Rebased on `main`, no merge commits
- [x] One logical change per PR (Golem only — compress/statusline specs handed off separately for follow-up)
- [x] README + CHANGELOG + CLAUDE.md + CONTRIBUTING updated
- [x] `pnpm test` + `pnpm run build` green locally