### PR TITLE
[codex] Add Codex prompt hooks roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+### Added
+
+- Codex CLI hook foothold: `tokenomy init --graph-path` now installs
+  user-scoped `~/.codex/hooks.json` entries for `SessionStart` and
+  `UserPromptSubmit`, and enables `features.codex_hooks` in
+  `~/.codex/config.toml`. This brings Golem and prompt-classifier nudges
+  to Codex sessions while leaving unsupported MCP/Bash output mutation
+  out of the Codex path.
+- `docs/NEXT_FEATURES.md` with a prioritized roadmap for making Tokenomy
+  the agent efficiency layer for Claude Code and Codex CLI.
+
 ## [0.1.1-beta.2] — 2026-04-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Tokenomy plugs the holes the agent hook contracts let you close — with zero pr
 | `PreToolUse` on `Write` | Claude Code | `additionalContext` | Reinventing existing repo work or mature utility libraries from scratch |
 | `UserPromptSubmit` (alpha.22+) | Claude Code | `additionalContext` on every user turn | Agent planning without first checking graph for existing code, blast radius, or maintained libraries |
 | `SessionStart` (beta.1+, Golem) | Claude Code | `additionalContext` once per session + per-turn reinforcement | Verbose assistant replies — output tokens cost 5× input on Sonnet |
+| `SessionStart` + `UserPromptSubmit` hooks | Codex CLI *(experimental)* | user-scoped `~/.codex/hooks.json` + `features.codex_hooks` | Golem output rules + prompt-classifier nudges in Codex sessions |
 | `tokenomy-graph` MCP server | Claude Code · Codex CLI | 6 tools over stdio | Brute-force `Read` sweeps of the codebase — agent gets focused context from a pre-built graph + repo/branch/package alternatives |
 | `tokenomy compress` (beta.2+) | Any repo | deterministic agent-rule file cleanup + optional local Claude rewrite | Bloated `CLAUDE.md`, `AGENTS.md`, `.cursor/rules`, `.windsurf/rules` loaded every session |
 | `tokenomy status-line` (beta.2+) | Claude Code | `settings.json.statusLine` command | Invisible installs — shows active state, Golem mode, graph freshness, and today's savings |
@@ -169,13 +170,15 @@ tokenomy doctor        # all checks passing
 # restart Claude Code — then use it normally
 ```
 
-**Codex CLI** (graph MCP + transcript analysis; no live hooks yet — Codex doesn't expose the PreToolUse/PostToolUse contract). `tokenomy init --graph-path` auto-registers the graph MCP server with **both** agents when each CLI is on your PATH:
+**Codex CLI** (graph MCP + transcript analysis + experimental prompt/session hooks). `tokenomy init --graph-path` auto-registers the graph MCP server with **both** agents when each CLI is on your PATH. For Codex, Tokenomy also writes user-scoped `~/.codex/hooks.json` for `SessionStart` and `UserPromptSubmit` and enables `features.codex_hooks`:
 
 ```bash
 npm install -g tokenomy
 tokenomy init --graph-path "$PWD"    # registers tokenomy-graph in both agents AND builds the graph
 tokenomy analyze                     # benchmarks ~/.claude + ~/.codex transcripts
 ```
+
+Codex hook support is intentionally partial: current Codex hooks can inject session/prompt context, so Golem and prompt-classifier nudges work. Claude-style MCP output mutation, Read input mutation, and Bash input rewriting remain Claude Code only until Codex exposes compatible hook contracts.
 
 Since alpha.15, `init --graph-path` builds the graph for you in a single shot; pass `--no-build` to skip (CI, monorepos with pre-built graphs).
 
@@ -196,7 +199,7 @@ tokenomy uninstall --agent cursor
 | Agent | Hooks | Graph MCP | Install target |
 |---|---:|---:|---|
 | Claude Code | ✓ | ✓ | `~/.claude/settings.json` + `~/.claude.json` |
-| Codex CLI | — | ✓ | `codex mcp add tokenomy-graph ...` |
+| Codex CLI | partial | ✓ | `codex mcp add tokenomy-graph ...` + `~/.codex/hooks.json` |
 | Cursor | — | ✓ | `~/.cursor/mcp.json` |
 | Windsurf | — | ✓ | `~/.codeium/windsurf/mcp_config.json` |
 | Cline | — | ✓ | `~/.cline/mcp_settings.json` |
@@ -525,10 +528,12 @@ Removes both hook entries from `~/.claude/settings.json` (matched by absolute co
 - [x] **Phase 2.** `tokenomy analyze` — walks Claude Code + Codex CLI transcripts, replays rules with a real tokenizer, surfaces waste patterns in a fancy CLI dashboard.
 - [x] **Phase 3.** Local code-graph MCP server: `tokenomy-graph` stdio server + `graph build|status|serve|query|purge` CLI + doctor check. Works with both Claude Code and Codex CLI. TypeScript AST, 5 tools, hard budget caps, fail-open everywhere.
 - [x] **Phase 3.5.** Multi-stage PostToolUse pipeline: duplicate-response dedup, secret redaction, stacktrace collapse, schema-aware trim profiles (Atlassian/Linear/Slack/Gmail/GitHub), per-tool config overrides, `find_usages` graph tool, MCP query LRU cache, `tokenomy report` (TUI + HTML), hook perf telemetry, `doctor --fix`.
-- [x] **Phase 4.** `PreToolUse` Bash input-bounder — rewrites verbose unbounded shell commands (`git log`, `find`, `ls -R`, `ps aux`, `docker logs`, `journalctl`, …) to cap their output via `set -o pipefail; <cmd> | awk 'NR<=N'`. Exit-status preserved, no command injection (head_limit validated), no rewrites for compound / subshell / heredoc / redirected / user-piped / streaming commands. Codex live-hook support deferred until the CLI exposes a hook contract.
+- [x] **Phase 4.** `PreToolUse` Bash input-bounder — rewrites verbose unbounded shell commands (`git log`, `find`, `ls -R`, `ps aux`, `docker logs`, `journalctl`, …) to cap their output via `set -o pipefail; <cmd> | awk 'NR<=N'`. Exit-status preserved, no command injection (head_limit validated), no rewrites for compound / subshell / heredoc / redirected / user-piped / streaming commands. Claude Code only until Codex supports input mutation.
 - [x] **Phase 4.5.** OSS-alternatives-first nudge — `find_oss_alternatives` MCP tool with repo/branch/package search plus conservative `PreToolUse` Write context for new utility-like files.
 - [x] **Phase 5.** Polish — Golem output mode, statusline with live savings counter, `UserPromptSubmit` prompt-classifier, `tokenomy compress`, deterministic `tokenomy bench`, and cross-agent graph MCP installers.
+- [x] **Phase 5.5.** Codex hook foothold — user-scoped Codex `SessionStart` + `UserPromptSubmit` hook installation for Golem and prompt-classifier nudges, with MCP/PostToolUse mutation explicitly deferred until Codex supports it.
 - [ ] **Phase 6.** Language breadth — Python parser plugin for the graph, richer benchmark fixtures, and npm publish at 1.0.
+- [ ] **Phase 7.** Agent operating layer — rule-pack generator, compaction-time memory hygiene, workflow MCP tools, session ledgers, and team-ready reports. See [Tokenomy Next Features](./docs/NEXT_FEATURES.md).
 
 ---
 

--- a/docs/NEXT_FEATURES.md
+++ b/docs/NEXT_FEATURES.md
@@ -1,0 +1,145 @@
+# Tokenomy Next Features
+
+Goal: make Tokenomy the default operating layer for local coding agents,
+especially Claude Code and Codex CLI. The current core is token waste
+reduction. The next layer should make agents cheaper, better oriented, and
+less likely to repeat unsafe or low-signal work.
+
+## Current Integration Reality
+
+Claude Code is still the richest live-control target. It exposes lifecycle
+hooks for prompt submission, tool calls, compaction, subagents, session start,
+and session end; it also supports status line commands and MCP tools.
+
+Codex CLI now has experimental hooks, but the current runtime is narrower.
+`SessionStart` and `UserPromptSubmit` can inject developer context, while
+`PreToolUse` and `PostToolUse` are currently Bash-only and do not support the
+same output mutation surface Tokenomy uses for Claude MCP trimming. Codex MCP
+configuration is shared between CLI and IDE extension through Codex config.
+
+## Tier 1: Ship Next
+
+1. **Codex hook install parity**
+
+   Install `~/.codex/hooks.json`, enable `features.codex_hooks`, and wire
+   Tokenomy's existing `SessionStart` and `UserPromptSubmit` hook behavior
+   into Codex. This brings Golem and prompt-classifier nudges to Codex without
+   overclaiming unsupported live output mutation.
+
+   Status: implemented in this branch for user-scoped Codex hooks.
+
+2. **Agent rule pack generator**
+
+   Add `tokenomy agents install-rules --agent=<name>` to create compact,
+   agent-native rules:
+
+   - `AGENTS.md` for Codex
+   - `CLAUDE.md` / `.claude/rules/*.md` for Claude Code
+   - Cursor, Windsurf, Cline, and Gemini equivalents
+
+   The generated rules should be short and deterministic: prefer Tokenomy graph
+   tools before broad reads, call `find_oss_alternatives` before utility
+   rewrites, keep command output bounded, and ask for full output only when
+   needed.
+
+3. **PreCompact and PostCompact memory compactor**
+
+   Claude Code exposes compaction hooks. Add a compaction-time summary that
+   preserves decisions, files changed, failing tests, and open questions, then
+   drops repeated tool chatter. This complements `tokenomy compress`, which
+   handles static instruction files.
+
+4. **Python graph parser**
+
+   Phase 6 should start with Python because Codex and Claude sessions commonly
+   touch mixed TS/Python repos. Cover imports, definitions, call-ish references,
+   pytest target hints, and package-root detection from `pyproject.toml`,
+   `setup.cfg`, and `requirements.txt`.
+
+5. **Workflow MCP tools**
+
+   Add higher-level tools on top of the graph:
+
+   - `prepare_change_plan`
+   - `suggest_tests`
+   - `summarize_branch`
+   - `explain_failure`
+   - `get_agent_brief`
+
+   These should return task-shaped context, not raw graph dumps.
+
+## Tier 2: Make It Sticky
+
+6. **Token budget profiles**
+
+   Add named modes like `cheap`, `balanced`, `deep-review`, and `incident`.
+   Each mode should tune graph budgets, MCP trim levels, Bash caps, Golem mode,
+   and prompt-classifier behavior together.
+
+7. **Session ledger**
+
+   Record a per-session artifact under `~/.tokenomy/sessions/`: prompts,
+   graph tools used, repeated reads, largest outputs, savings, changed files,
+   and tests run. Use it for both reports and future session-start briefs.
+
+8. **Stop hook quality gate**
+
+   For Claude Code, use `Stop` to inject one final continuation prompt only
+   when there is strong evidence of unfinished work: changed files with no
+   tests, unresolved failing commands, or TODO-style model text. Keep this
+   conservative because aggressive Stop hooks can annoy users quickly.
+
+9. **Subagent budget governor**
+
+   Codex supports explicit subagent workflows, and Claude Code has subagent
+   lifecycle hooks. Track subagent count, repeated exploration, and expensive
+   duplicate work. Warn or inject context when parallel agents are about to
+   rediscover the same files.
+
+10. **Connector profile packs**
+
+    Expand schema-aware trim profiles for Asana, HubSpot, Intercom, Datadog,
+    Sentry, Stripe, Supabase, Vercel, and common GitHub issue/search shapes.
+    Pair each profile with captured fixtures and `bench` scenarios.
+
+## Tier 3: Team Product
+
+11. **Team report export**
+
+    Add `tokenomy report --share` to generate a redacted HTML/Markdown summary
+    suitable for PRs, Slack, or internal docs: savings, hot tools, repeated
+    calls, missing graph coverage, and recommended config changes.
+
+12. **Repo onboarding score**
+
+    Add `tokenomy doctor --score` for agent readiness: graph built, rules file
+    compressed, MCP connected, tests discoverable, common huge files excluded,
+    and supported language parsers enabled.
+
+13. **CI regression guard**
+
+    Add a GitHub Action example that runs `tokenomy bench compare` and fails
+    if a PR regresses fixture savings, hook latency, or graph build time beyond
+    configured thresholds.
+
+14. **Remote MCP option**
+
+    Keep stdio as the default, but add an optional remote MCP server mode for
+    teams that want shared graph summaries, centralized profiles, or managed
+    config. Treat this as an enterprise/team feature, not the default local
+    workflow.
+
+## Positioning
+
+Tokenomy should not be "another context tool." Its sharper claim is:
+
+> Tokenomy is the agent efficiency layer for Claude Code and Codex CLI:
+> install it once, then every session starts with less waste, better repo
+> orientation, safer tool use, and measurable savings.
+
+The product line should keep a strict split:
+
+- **Live control** where the agent exposes compatible hooks.
+- **MCP retrieval** where hooks are missing or narrower.
+- **Transcript analysis** for anything Tokenomy cannot intercept live yet.
+- **Rule/skill/plugin packs** to make agents voluntarily use the right tools.

--- a/src/cli/agents/index.ts
+++ b/src/cli/agents/index.ts
@@ -2,8 +2,13 @@ import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import type { AgentAdapter, AgentInstallResult, AgentName } from "./common.js";
 import { commandExists, homePath, patchMcpJson, removeMcpJson } from "./common.js";
+import { hookBinaryPath } from "../../core/paths.js";
+import {
+  removeCodexTokenomyHooks,
+  upsertCodexTokenomyHooks,
+} from "../../util/codex-config.js";
 
-const codexInstall = (graphPath: string): AgentInstallResult => {
+const codexInstall = (graphPath: string, backup: boolean): AgentInstallResult => {
   if (!commandExists("codex")) {
     return { agent: "codex", installed: false, detail: "codex not on PATH" };
   }
@@ -13,20 +18,39 @@ const codexInstall = (graphPath: string): AgentInstallResult => {
     ["mcp", "add", "tokenomy-graph", "--", "tokenomy", "graph", "serve", "--path", graphPath],
     { stdio: "ignore" },
   );
+  let hookDetail = "hooks skipped";
+  try {
+    const hooks = upsertCodexTokenomyHooks(hookBinaryPath(), backup);
+    hookDetail = `hooks ${hooks.hooksPath}`;
+  } catch {
+    hookDetail = "hooks failed";
+  }
   return {
     agent: "codex",
-    installed: add.status === 0,
-    detail: add.status === 0 ? "codex mcp add tokenomy-graph" : "codex mcp add failed",
+    installed: add.status === 0 && hookDetail !== "hooks failed",
+    detail:
+      add.status === 0
+        ? `codex mcp add tokenomy-graph; ${hookDetail}`
+        : `codex mcp add failed; ${hookDetail}`,
   };
 };
 
-const codexUninstall = (): AgentInstallResult => {
+const codexUninstall = (backup: boolean): AgentInstallResult => {
   if (!commandExists("codex")) return { agent: "codex", installed: false, detail: "codex not on PATH" };
   const rm = spawnSync("codex", ["mcp", "remove", "tokenomy-graph"], { stdio: "ignore" });
+  let hookDetail = "hooks removed";
+  try {
+    removeCodexTokenomyHooks(hookBinaryPath(), backup);
+  } catch {
+    hookDetail = "hooks remove failed";
+  }
   return {
     agent: "codex",
-    installed: rm.status === 0,
-    detail: rm.status === 0 ? "codex mcp remove tokenomy-graph" : "codex mcp remove failed",
+    installed: rm.status === 0 && hookDetail !== "hooks remove failed",
+    detail:
+      rm.status === 0
+        ? `codex mcp remove tokenomy-graph; ${hookDetail}`
+        : `codex mcp remove failed; ${hookDetail}`,
   };
 };
 
@@ -40,8 +64,8 @@ export const AGENT_ADAPTERS: AgentAdapter[] = [
   {
     name: "codex",
     detect: () => existsSync(homePath(".codex")) || commandExists("codex"),
-    install: (graphPath) => codexInstall(graphPath),
-    uninstall: () => codexUninstall(),
+    install: (graphPath, backup) => codexInstall(graphPath, backup),
+    uninstall: (backup) => codexUninstall(backup),
   },
   {
     name: "cursor",

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -113,7 +113,8 @@ export const runInit = (opts: InitOptions = {}): {
   agentResults: AgentInstallResult[];
 } => {
   const installClaude = !opts.agent || opts.agent === "claude-code";
-  const hookPath = installClaude ? stageHookBinary() : null;
+  const needsHookBinary = installClaude || opts.agent === "codex";
+  const hookPath = needsHookBinary ? stageHookBinary() : null;
   const settingsPath = claudeSettingsPath();
 
   let backupPath: string | null = null;
@@ -173,7 +174,7 @@ export const runInit = (opts: InitOptions = {}): {
     ? installDetectedAgents(graphServerPath, opts.backup !== false, opts.agent)
     : [];
 
-  if (hookPath) {
+  if (hookPath && installClaude) {
     let manifest = readManifest();
     manifest = upsertEntry(manifest, {
       command_path: hookPath,

--- a/src/util/codex-config.ts
+++ b/src/util/codex-config.ts
@@ -1,0 +1,165 @@
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { atomicWrite } from "./atomic.js";
+import { backupFile } from "./backup.js";
+import { safeParse, stableStringify } from "./json.js";
+
+export const codexConfigPath = (): string => join(homedir(), ".codex", "config.toml");
+export const codexHooksPath = (): string => join(homedir(), ".codex", "hooks.json");
+
+interface CodexHookCommand {
+  type: "command";
+  command: string;
+  timeout?: number;
+  statusMessage?: string;
+  [k: string]: unknown;
+}
+
+interface CodexHookMatcher {
+  matcher?: string;
+  hooks?: CodexHookCommand[];
+  [k: string]: unknown;
+}
+
+interface CodexHooksShape {
+  hooks?: Record<string, CodexHookMatcher[]>;
+  [k: string]: unknown;
+}
+
+export interface CodexHookPatchResult {
+  hooksPath: string;
+  configPath: string;
+  backupPath: string | null;
+}
+
+const TOKENOMY_EVENTS = new Set(["SessionStart", "UserPromptSubmit"]);
+
+const withoutCommand = (settings: CodexHooksShape, command: string): CodexHooksShape => {
+  const hooks = settings.hooks ?? {};
+  const nextHooks: Record<string, CodexHookMatcher[]> = {};
+
+  for (const [event, entries] of Object.entries(hooks)) {
+    const nextEntries: CodexHookMatcher[] = [];
+    for (const entry of entries) {
+      const kept = (entry.hooks ?? []).filter((hook) => hook.command !== command);
+      if (kept.length > 0) nextEntries.push({ ...entry, hooks: kept });
+    }
+    if (nextEntries.length > 0) nextHooks[event] = nextEntries;
+  }
+
+  return { ...settings, hooks: nextHooks };
+};
+
+const addCommandHook = (
+  settings: CodexHooksShape,
+  event: "SessionStart" | "UserPromptSubmit",
+  matcher: string | undefined,
+  command: string,
+  statusMessage: string,
+): CodexHooksShape => {
+  const hooks = settings.hooks ?? {};
+  const entry: CodexHookMatcher = {
+    ...(matcher ? { matcher } : {}),
+    hooks: [{ type: "command", command, timeout: 10, statusMessage }],
+  };
+  return {
+    ...settings,
+    hooks: {
+      ...hooks,
+      [event]: [...(hooks[event] ?? []), entry],
+    },
+  };
+};
+
+export const enableCodexHooksFeature = (path = codexConfigPath()): void => {
+  mkdirSync(dirname(path), { recursive: true });
+  const raw = existsSync(path) ? readFileSync(path, "utf8") : "";
+  const lines = raw.length > 0 ? raw.split(/\r?\n/) : [];
+  let featuresStart = -1;
+  let featuresEnd = lines.length;
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i]?.trim() ?? "";
+    if (/^\[features\]\s*$/.test(trimmed)) {
+      featuresStart = i;
+      continue;
+    }
+    if (featuresStart !== -1 && i > featuresStart && /^\[.+\]\s*$/.test(trimmed)) {
+      featuresEnd = i;
+      break;
+    }
+  }
+
+  if (featuresStart === -1) {
+    const prefix = raw.trim().length > 0 ? `${raw.replace(/\s*$/, "\n\n")}` : "";
+    atomicWrite(path, `${prefix}[features]\ncodex_hooks = true\n`, false);
+    return;
+  }
+
+  let replaced = false;
+  for (let i = featuresStart + 1; i < featuresEnd; i++) {
+    if (/^\s*codex_hooks\s*=/.test(lines[i] ?? "")) {
+      lines[i] = "codex_hooks = true";
+      replaced = true;
+      break;
+    }
+  }
+  if (!replaced) lines.splice(featuresStart + 1, 0, "codex_hooks = true");
+  atomicWrite(path, `${lines.join("\n").replace(/\s*$/, "")}\n`, false);
+};
+
+export const upsertCodexTokenomyHooks = (
+  command: string,
+  backup: boolean,
+  path = codexHooksPath(),
+  configPath = codexConfigPath(),
+): CodexHookPatchResult => {
+  mkdirSync(dirname(path), { recursive: true });
+  const before = existsSync(path) ? safeParse<CodexHooksShape>(readFileSync(path, "utf8")) : {};
+  if (!before) throw new Error(`Could not parse ${path}. Fix the JSON and try again.`);
+  const backupPath = backup && existsSync(path) ? backupFile(path) : null;
+
+  let next = withoutCommand(before, command);
+  next = addCommandHook(
+    next,
+    "SessionStart",
+    "startup|resume",
+    command,
+    "Loading Tokenomy session context",
+  );
+  next = addCommandHook(
+    next,
+    "UserPromptSubmit",
+    undefined,
+    command,
+    "Checking Tokenomy prompt nudges",
+  );
+
+  enableCodexHooksFeature(configPath);
+  atomicWrite(path, stableStringify(next) + "\n", false);
+  return { hooksPath: path, configPath, backupPath };
+};
+
+export const removeCodexTokenomyHooks = (
+  command: string,
+  backup: boolean,
+  path = codexHooksPath(),
+  configPath = codexConfigPath(),
+): CodexHookPatchResult => {
+  if (!existsSync(path)) {
+    return { hooksPath: path, configPath, backupPath: null };
+  }
+  const before = safeParse<CodexHooksShape>(readFileSync(path, "utf8"));
+  if (!before) throw new Error(`Could not parse ${path}. Manual cleanup required.`);
+  const backupPath = backup ? backupFile(path) : null;
+  const next = withoutCommand(before, command);
+  if (next.hooks) {
+    for (const event of TOKENOMY_EVENTS) {
+      if ((next.hooks[event] ?? []).length === 0) delete next.hooks[event];
+    }
+    if (Object.keys(next.hooks).length === 0) delete next.hooks;
+  }
+  atomicWrite(path, stableStringify(next) + "\n", false);
+  return { hooksPath: path, configPath, backupPath };
+};

--- a/tests/unit/agent-adapters.test.ts
+++ b/tests/unit/agent-adapters.test.ts
@@ -1,9 +1,13 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { patchMcpJson, removeMcpJson } from "../../src/cli/agents/common.js";
+import {
+  removeCodexTokenomyHooks,
+  upsertCodexTokenomyHooks,
+} from "../../src/util/codex-config.js";
 
 test("patchMcpJson and removeMcpJson are idempotent", () => {
   const dir = mkdtempSync(join(tmpdir(), "tokenomy-agent-"));
@@ -27,3 +31,54 @@ test("patchMcpJson and removeMcpJson are idempotent", () => {
   }
 });
 
+test("upsertCodexTokenomyHooks installs prompt/session hooks and enables feature flag", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tokenomy-codex-"));
+  const hooksPath = join(dir, "hooks.json");
+  const configPath = join(dir, "config.toml");
+  try {
+    const result = upsertCodexTokenomyHooks("/tmp/tokenomy-hook", false, hooksPath, configPath);
+    assert.equal(result.hooksPath, hooksPath);
+    const hooks = JSON.parse(readFileSync(hooksPath, "utf8"));
+    assert.equal(hooks.hooks.SessionStart[0].matcher, "startup|resume");
+    assert.equal(hooks.hooks.SessionStart[0].hooks[0].command, "/tmp/tokenomy-hook");
+    assert.equal(hooks.hooks.UserPromptSubmit[0].hooks[0].command, "/tmp/tokenomy-hook");
+
+    const config = readFileSync(configPath, "utf8");
+    assert.match(config, /\[features\]/);
+    assert.match(config, /codex_hooks = true/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("removeCodexTokenomyHooks removes only Tokenomy command hooks", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tokenomy-codex-"));
+  const hooksPath = join(dir, "hooks.json");
+  const configPath = join(dir, "config.toml");
+  try {
+    upsertCodexTokenomyHooks("/tmp/tokenomy-hook", false, hooksPath, configPath);
+    writeFileSync(
+      hooksPath,
+      JSON.stringify({
+        hooks: {
+          SessionStart: [
+            { matcher: "startup|resume", hooks: [{ type: "command", command: "/tmp/tokenomy-hook" }] },
+            { matcher: "startup", hooks: [{ type: "command", command: "/tmp/other-hook" }] },
+          ],
+          UserPromptSubmit: [
+            { hooks: [{ type: "command", command: "/tmp/tokenomy-hook" }] },
+          ],
+        },
+      }),
+    );
+
+    removeCodexTokenomyHooks("/tmp/tokenomy-hook", false, hooksPath, configPath);
+    const hooks = JSON.parse(readFileSync(hooksPath, "utf8"));
+    assert.equal(hooks.hooks.SessionStart.length, 1);
+    assert.equal(hooks.hooks.SessionStart[0].hooks[0].command, "/tmp/other-hook");
+    assert.equal(hooks.hooks.UserPromptSubmit, undefined);
+    assert.equal(existsSync(configPath), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Add Codex hook config helpers for user-scoped `SessionStart` and `UserPromptSubmit` hooks.
- Wire Codex agent install/uninstall to manage those hooks alongside the graph MCP registration.
- Document the partial Codex hook boundary and add the next-features roadmap.

## Notes
- No version bump and no release changes.
- Codex MCP/Bash output mutation remains deferred until Codex supports compatible hook contracts.

## Validation
- `npm run build`
- `npm run typecheck`
- `npm test` (411/411 passing)
