### PR TITLE
feat: 0.1.1-beta.5 — statusline update marker + Raven in report/analyze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.1.1-beta.5] — 2026-04-23
+
+### Added
+
+- **Statusline update marker.** `tokenomy update --check` now caches the
+  registry reply at `~/.tokenomy/update-cache.json` (dist-tag lookups only,
+  not pinned versions). The statusline reads that cache and renders a
+  `↑` after the version tag when a newer build exists on npm (e.g.
+  `[Tokenomy v0.1.1-beta.5↑ · …]`). Cache is ignored past 14 days.
+- **Raven in report + analyze.** `tokenomy report` (TUI + HTML) and
+  `tokenomy analyze` now surface Raven bridge stats — packets, reviews,
+  comparisons, decisions, repo count, last activity. The analyze block
+  is suppressed when Raven has zero data and is disabled, so empty
+  installs aren't spammed.
+
+### Changed
+
+- `ReportSummary` and `AggregateReport` gain a `raven` field. Callers
+  reading either interface will see the new key; JSON shape is additive.
+
 ## [0.1.1-beta.4] — 2026-04-23
 
 ### Added
@@ -763,7 +783,8 @@ First public alpha. Phase 1 scope: transparent MCP tool-output trimming via `Pos
 - Statusline with live savings counter — Phase 2.
 - `tokenomy analyze` over transcripts — Phase 2.
 
-[Unreleased]: https://github.com/RahulDhiman93/Tokenomy/compare/v0.1.1-beta.4...HEAD
+[Unreleased]: https://github.com/RahulDhiman93/Tokenomy/compare/v0.1.1-beta.5...HEAD
+[0.1.1-beta.5]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.1-beta.5
 [0.1.1-beta.4]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.1-beta.4
 [0.1.1-beta.3]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.1-beta.3
 [0.1.1-beta.2]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.1-beta.2

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ TypeScript / JavaScript AST via the TS compiler (no type checker); `tsconfig.pat
 - **Incremental graph updates** *(beta.3+)* — `cfg.graph.incremental: true` enables delta rebuilds that re-parse only stale files + direct importers. Falls back to full rebuild if tsconfig/exclude fingerprints shift or >40% of files changed. Opt-in.
 - **`tokenomy budget` pre-flight gate** *(beta.3+)* — advisory `PreToolUse` rule that estimates incoming-call response size from analyze cache and warns via `additionalContext` when the call would push the session past `cfg.budget.session_cap_tokens`. Never rejects. Default off.
 - **`tokenomy ci` + GitHub Action** *(beta.3+)* — `action.yml` at repo root plus a `tokenomy ci format --input=<analyze.json>` CLI that converts analyze JSON into a PR-ready markdown comment. Inputs validated + HTML-escaped.
-- **Statusline version** *(beta.3+)* — `tokenomy status-line` now shows the version tag inline, e.g. `[Tokenomy v0.1.1-beta.4 · GOLEM-GRUNT · 15.0k saved]`.
+- **Statusline version + update marker** *(beta.3+, marker beta.5+)* — `tokenomy status-line` shows the version tag inline, e.g. `[Tokenomy v0.1.1-beta.5 · GOLEM-GRUNT · 15.0k saved]`. After a `tokenomy update --check`, a `↑` is appended when a newer release exists on npm (e.g. `v0.1.1-beta.5↑`). The cache at `~/.tokenomy/update-cache.json` is ignored past 14 days.
 - **Per-tool p95 latency** *(beta.3+)* — `analyze` + `report` show p50/p95 wall-clock latency per tool (from paired `tool_use`/`tool_result` timestamps).
 
 ### 🪶 Raven — cross-agent handoff + review *(beta.4+)*
@@ -148,6 +148,8 @@ Raven turns Claude Code and Codex CLI into a primary/reviewer pair. Claude works
 - **`tokenomy raven pr-check`** — verdict rules: `no` on any unresolved `critical` finding / stale HEAD / zero reviews. `risky` on graph stale / dirty tree / high-severity disagreement. Exit code 2 when blocking.
 - **`tokenomy raven install-commands`** — writes `.claude/commands/raven-brief.md` + `raven-pr-check.md`. Never clobbers.
 - **Agent-facing MCP tools** (all budget-clipped, all refuse stale packets): `create_handoff_packet`, `read_handoff_packet`, `record_agent_review`, `list_agent_reviews`, `compare_agent_reviews`, `get_pr_readiness`, `record_decision`.
+
+- **Raven in report + analyze** *(beta.5+)* — Raven activity (packets, reviews, comparisons, decisions, last activity, repo count) now surfaces in both `tokenomy report` (TUI + HTML) and `tokenomy analyze`, so the bridge is visible alongside token savings.
 
 Out-of-scope for beta.4: `review --agent` auto-subprocessing (human-in-the-loop flow instead — print the packet path, run Codex in a second terminal, it calls `record_agent_review`) and `dispatch --worktree` (follow-up PR).
 
@@ -267,7 +269,7 @@ tokenomy compress /path/to/CLAUDE.md --in-place --force  # explicit outside-cwd 
 tokenomy compress restore CLAUDE.md
 ```
 
-> **Pre-`1.0`.** Every release is `-beta.N`; breaking changes may land before `1.0.0` (see [CHANGELOG](./CHANGELOG.md)). Pin for stability: `npm install -g tokenomy@0.1.1-beta.4`. Upgrade with one command — `tokenomy update` (runs `npm install -g` + re-stages the hook + is idempotent; config + logs preserved). Check without installing: `tokenomy update --check`. Pin an exact release: `tokenomy update@0.1.1-beta.4` or `tokenomy update --version 0.1.1-beta.4`. Bleeding edge: see [Development](#development).
+> **Pre-`1.0`.** Every release is `-beta.N`; breaking changes may land before `1.0.0` (see [CHANGELOG](./CHANGELOG.md)). Pin for stability: `npm install -g tokenomy@0.1.1-beta.5`. Upgrade with one command — `tokenomy update` (runs `npm install -g` + re-stages the hook + is idempotent; config + logs preserved). Check without installing: `tokenomy update --check`. Pin an exact release: `tokenomy update@0.1.1-beta.5` or `tokenomy update --version 0.1.1-beta.5`. Bleeding edge: see [Development](#development).
 
 Watch trims live — `tail -f ~/.tokenomy/savings.jsonl`:
 
@@ -549,8 +551,8 @@ Duplicate hotspots (same args)
 ```bash
 tokenomy update            # install latest + re-stage hook in one shot
 tokenomy update --check    # query registry, print installed vs remote, exit 1 if out of date
-tokenomy update@0.1.1-beta.4   # npm-style pin
-tokenomy update --version=0.1.1-beta.4  # same, explicit flag
+tokenomy update@0.1.1-beta.5   # npm-style pin
+tokenomy update --version=0.1.1-beta.5  # same, explicit flag
 tokenomy update --tag=beta # opt into a non-default dist-tag
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tokenomy",
-  "version": "0.1.1-beta.2",
+  "version": "0.1.1-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tokenomy",
-      "version": "0.1.1-beta.2",
+      "version": "0.1.1-beta.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenomy",
-  "version": "0.1.1-beta.4",
+  "version": "0.1.1-beta.5",
   "description": "Surgical Claude Code hook that transparently trims bloated MCP tool responses and clamps oversized file reads — stop burning tokens on tool chatter.",
   "type": "module",
   "engines": {

--- a/src/analyze/render.ts
+++ b/src/analyze/render.ts
@@ -246,6 +246,30 @@ export const render = (report: AggregateReport, opts: RenderOptions): string => 
     out.push("");
   }
 
+  // Raven bridge summary. Shown even when disabled so users see the feature
+  // exists; suppressed entirely when there's literally no data to avoid noise.
+  // Tolerate older JSON payloads / test fixtures that predate the `raven`
+  // field on AggregateReport — render nothing instead of crashing.
+  const rv = report.raven;
+  if (rv && (rv.enabled || rv.packets > 0 || rv.reviews > 0 || rv.decisions > 0)) {
+    out.push(`${c.bold}Raven bridge${c.reset}  ${c.dim}(cross-agent handoff / review)${c.reset}`);
+    const status = rv.enabled ? `${c.green}enabled${c.reset}` : `${c.dim}disabled${c.reset}`;
+    out.push(`  ${pad("Status", 26)} ${status}`);
+    out.push(
+      `  ${pad("Packets", 26)} ${c.bold}${n(rv.packets)}${c.reset}` +
+        `     ${pad("Repos", 14)} ${c.bold}${n(rv.repos)}${c.reset}`,
+    );
+    out.push(
+      `  ${pad("Reviews", 26)} ${c.bold}${n(rv.reviews)}${c.reset}` +
+        `     ${pad("Comparisons", 14)} ${c.bold}${n(rv.comparisons)}${c.reset}`,
+    );
+    out.push(
+      `  ${pad("Decisions", 26)} ${c.bold}${n(rv.decisions)}${c.reset}` +
+        `     ${pad("Last activity", 14)} ${c.dim}${rv.last_activity ? rv.last_activity.slice(0, 19) + "Z" : "—"}${c.reset}`,
+    );
+    out.push("");
+  }
+
   // By-day sparkline.
   if (report.by_day.length > 1) {
     out.push(`${c.bold}By day${c.reset}  ${c.dim}(observed tokens)${c.reset}`);

--- a/src/analyze/report.ts
+++ b/src/analyze/report.ts
@@ -1,4 +1,5 @@
 import type { SimEvent } from "./simulate.js";
+import { collectRavenStats, type RavenStats } from "../raven/stats.js";
 
 export interface AggregateReport {
   window: { first_ts: string | null; last_ts: string | null };
@@ -55,6 +56,7 @@ export interface AggregateReport {
     session_id: string;
   }>;
   tokenizer: { name: string; approximate: boolean };
+  raven: RavenStats;
 }
 
 export interface AggregatorOptions {
@@ -62,6 +64,10 @@ export interface AggregatorOptions {
   price_per_million: number;
   tokenizer_name: string;
   tokenizer_approximate: boolean;
+  // Config-driven hint so the `raven` block in the rendered report knows
+  // whether the bridge is currently turned on. Stats are collected
+  // unconditionally; this only colours the "status" line.
+  raven_enabled?: boolean;
 }
 
 interface ToolBucket {
@@ -385,6 +391,7 @@ export class Aggregator {
         name: this.opts.tokenizer_name,
         approximate: this.opts.tokenizer_approximate,
       },
+      raven: collectRavenStats(undefined, this.opts.raven_enabled === true),
     };
   }
 }

--- a/src/cli/analyze.ts
+++ b/src/cli/analyze.ts
@@ -118,6 +118,7 @@ export const runAnalyze = async (opts: AnalyzeOptions): Promise<number> => {
       opts.pricePerMillion ?? priceFromConfig(cfg as Config & { report?: { price_per_million?: number } }),
     tokenizer_name: tokenizer.name,
     tokenizer_approximate: tokenizer.approximate,
+    raven_enabled: cfg.raven?.enabled === true,
   });
 
   // Live progress: write \r-updated status line to stderr so stdout stays

--- a/src/cli/report.ts
+++ b/src/cli/report.ts
@@ -6,6 +6,8 @@ import { defaultLogPath, tokenomyDir } from "../core/paths.js";
 import { safeParse } from "../util/json.js";
 import type { Config, SavingsLogEntry } from "../core/types.js";
 import { globalConfigPath } from "../core/paths.js";
+import { collectRavenStats, type RavenStats } from "../raven/stats.js";
+import { loadConfig } from "../core/config.js";
 
 // Per-1M-token pricing (USD). Used purely to estimate $ saved for the
 // "tokens saved" column. Users can override via `tokenomy config set
@@ -29,6 +31,7 @@ export interface ReportSummary {
   by_reason: { reason: string; calls: number; tokens_saved: number }[];
   by_day: { day: string; calls: number; tokens_saved: number }[];
   window: { first_ts: string | null; last_ts: string | null };
+  raven: RavenStats;
 }
 
 const readEntries = (logPath: string, since?: Date): SavingsLogEntry[] => {
@@ -47,7 +50,7 @@ const readEntries = (logPath: string, since?: Date): SavingsLogEntry[] => {
 
 export const summarize = (
   entries: SavingsLogEntry[],
-  opts: { top: number; pricePerMillion: number },
+  opts: { top: number; pricePerMillion: number; raven?: RavenStats },
 ): ReportSummary => {
   const byTool = new Map<string, { calls: number; tokens: number }>();
   const byReason = new Map<string, { calls: number; tokens: number }>();
@@ -108,6 +111,7 @@ export const summarize = (
     by_reason: reasonRanking,
     by_day: dayRanking,
     window: { first_ts: first, last_ts: last },
+    raven: opts.raven ?? collectRavenStats(undefined, false),
   };
 };
 
@@ -124,6 +128,12 @@ const renderTui = (s: ReportSummary): string => {
     `(−${fmtNum(s.total_bytes_in - s.total_bytes_out)})`);
   lines.push(`Tokens saved (est): ${fmtNum(s.total_tokens_saved)}`);
   lines.push(`~USD saved:        $${s.estimated_usd_saved.toFixed(4)}`);
+  lines.push("");
+  lines.push("Raven bridge");
+  lines.push(`  status:            ${s.raven.enabled ? "enabled" : "disabled"}`);
+  lines.push(`  packets:           ${fmtNum(s.raven.packets)}   repos: ${fmtNum(s.raven.repos)}`);
+  lines.push(`  reviews:           ${fmtNum(s.raven.reviews)}   comparisons: ${fmtNum(s.raven.comparisons)}   decisions: ${fmtNum(s.raven.decisions)}`);
+  lines.push(`  last activity:     ${s.raven.last_activity ?? "—"}`);
   lines.push("");
   lines.push("Top tools by tokens saved");
   for (const t of s.by_tool) {
@@ -186,6 +196,17 @@ const renderHtml = (s: ReportSummary): string => {
   <strong>${fmtNum(s.total_tokens_saved)}</strong> tokens saved &nbsp;·&nbsp;
   ~$${s.estimated_usd_saved.toFixed(4)} USD</div>
 
+<h2>Raven bridge</h2>
+<div class="card">
+  <strong>${s.raven.enabled ? "enabled" : "disabled"}</strong> &nbsp;·&nbsp;
+  ${fmtNum(s.raven.packets)} packets &nbsp;·&nbsp;
+  ${fmtNum(s.raven.reviews)} reviews &nbsp;·&nbsp;
+  ${fmtNum(s.raven.comparisons)} comparisons &nbsp;·&nbsp;
+  ${fmtNum(s.raven.decisions)} decisions &nbsp;·&nbsp;
+  ${fmtNum(s.raven.repos)} repos &nbsp;·&nbsp;
+  last activity: ${escapeHtml(s.raven.last_activity ?? "—")}
+</div>
+
 <h2>Top tools by tokens saved</h2>
 <table><thead><tr><th>Tool</th><th>Calls</th><th>Tokens saved</th></tr></thead>
 <tbody>${rows(s.by_tool.map((t) => ({ label: t.tool, calls: t.calls, tokens: t.tokens_saved })))}</tbody></table>
@@ -221,7 +242,14 @@ export const runReport = (opts: ReportOptions): { summary: ReportSummary; htmlPa
   const logPath = defaultLogPath();
   const entries = readEntries(logPath, opts.since);
   const pricePerMillion = opts.pricePerMillion ?? readConfigPrice();
-  const summary = summarize(entries, { top: opts.top, pricePerMillion });
+  let ravenEnabled = false;
+  try {
+    ravenEnabled = loadConfig(process.cwd()).raven.enabled;
+  } catch {
+    // Config unreadable — render Raven as "disabled" rather than failing the report.
+  }
+  const raven = collectRavenStats(undefined, ravenEnabled);
+  const summary = summarize(entries, { top: opts.top, pricePerMillion, raven });
   const html = renderHtml(summary);
   const tui = renderTui(summary);
   const htmlPath = opts.out ?? join(tokenomyDir(), "report.html");

--- a/src/cli/statusline.ts
+++ b/src/cli/statusline.ts
@@ -1,8 +1,9 @@
 import { closeSync, existsSync, openSync, readFileSync, readSync, statSync } from "node:fs";
 import { loadConfig } from "../core/config.js";
-import { graphMetaPath, graphSnapshotPath, tokenomyGraphRootDir } from "../core/paths.js";
+import { graphMetaPath, graphSnapshotPath, tokenomyGraphRootDir, updateCachePath } from "../core/paths.js";
 import type { SavingsLogEntry } from "../core/types.js";
 import { TOKENOMY_VERSION } from "../core/version.js";
+import { compareVersions } from "./update.js";
 import { resolveRepoId } from "../graph/repo-id.js";
 import { resolveGolemMode } from "../rules/golem.js";
 import { safeParse } from "../util/json.js";
@@ -15,7 +16,34 @@ export interface StatusLineState {
   graph?: "fresh" | "stale";
   golem?: string;
   raven?: boolean;
+  // Populated when a cached `tokenomy update --check` reply indicates a
+  // newer version is available on npm. Renders as `↑` after the version.
+  updateAvailable?: string;
 }
+
+// Staleness window for the update cache. Past this, treat the cache as
+// unknown rather than a stale hit (registry state drifts; a 2-week-old
+// "update available" isn't signal worth rendering).
+const UPDATE_CACHE_TTL_MS = 14 * 86_400_000;
+
+export const readUpdateCache = (
+  path = updateCachePath(),
+  now = Date.now(),
+): string | undefined => {
+  if (!existsSync(path)) return undefined;
+  try {
+    const parsed = safeParse<{ remote?: string; fetched_at?: string }>(
+      readFileSync(path, "utf8"),
+    );
+    if (!parsed?.remote || !parsed.fetched_at) return undefined;
+    const fetchedAt = Date.parse(parsed.fetched_at);
+    if (!Number.isFinite(fetchedAt)) return undefined;
+    if (now - fetchedAt > UPDATE_CACHE_TTL_MS) return undefined;
+    return compareVersions(parsed.remote, TOKENOMY_VERSION) > 0 ? parsed.remote : undefined;
+  } catch {
+    return undefined;
+  }
+};
 
 const localDateKey = (d: Date): string => {
   const month = `${d.getMonth() + 1}`.padStart(2, "0");
@@ -71,23 +99,22 @@ const graphState = (cwd: string): "fresh" | "stale" | undefined => {
   }
 };
 
-const VERSION_TAG = `v${TOKENOMY_VERSION}`;
-
 export const renderStatusLine = (state: StatusLineState): string => {
   if (!state.active) return "";
+  const versionTag = `v${TOKENOMY_VERSION}${state.updateAvailable ? "↑" : ""}`;
   const raven = state.raven ? " · Raven" : "";
   if (state.golem) {
     const savings = state.tokensToday > 0 ? ` · ${compact(state.tokensToday)} saved` : "";
-    return `[Tokenomy ${VERSION_TAG} · GOLEM-${state.golem.toUpperCase()}${savings}${raven}]`;
+    return `[Tokenomy ${versionTag} · GOLEM-${state.golem.toUpperCase()}${savings}${raven}]`;
   }
-  if (state.tokensToday <= 0) return `[Tokenomy ${VERSION_TAG} · active${raven}]`;
+  if (state.tokensToday <= 0) return `[Tokenomy ${versionTag} · active${raven}]`;
   const graph =
     state.graph === "fresh"
       ? " · graph fresh"
       : state.graph === "stale"
         ? " · graph stale - rebuild"
         : "";
-  return `[Tokenomy ${VERSION_TAG} · ${compact(state.tokensToday)} saved${graph}${raven}]`;
+  return `[Tokenomy ${versionTag} · ${compact(state.tokensToday)} saved${graph}${raven}]`;
 };
 
 export const runStatusLine = (argv: string[]): number => {
@@ -99,6 +126,7 @@ export const runStatusLine = (argv: string[]): number => {
       graph: graphState(process.cwd()),
       golem: cfg.golem.enabled ? resolveGolemMode(cfg) : undefined,
       raven: cfg.raven.enabled,
+      updateAvailable: readUpdateCache(),
     };
     if (argv.includes("--json")) process.stdout.write(JSON.stringify(state, null, 2) + "\n");
     else process.stdout.write(renderStatusLine(state) + "\n");

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -1,9 +1,30 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, realpathSync, statSync } from "node:fs";
-import { sep } from "node:path";
+import { existsSync, mkdirSync, realpathSync, statSync } from "node:fs";
+import { dirname, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { TOKENOMY_VERSION } from "../core/version.js";
+import { updateCachePath } from "../core/paths.js";
+import { atomicWrite } from "../util/atomic.js";
+import { stableStringify } from "../util/json.js";
 import { getClaudeMcpServer } from "../util/claude-user-config.js";
+
+// Cache the most recent registry lookup so the statusline can render an
+// update-available marker without making a blocking network call on every
+// render. Only written for dist-tag lookups (not pinned versions), since a
+// pinned `--version=X` isn't meaningful as "latest on npm".
+export const writeUpdateCache = (remote: string, tag: string): void => {
+  try {
+    const path = updateCachePath();
+    mkdirSync(dirname(path), { recursive: true });
+    atomicWrite(
+      path,
+      stableStringify({ installed: TOKENOMY_VERSION, remote, tag, fetched_at: new Date().toISOString() }) + "\n",
+      false,
+    );
+  } catch {
+    // Cache write failures must never break `update --check`.
+  }
+};
 
 // Read the previously-registered graph path so `tokenomy update` can restage
 // the graph MCP server for the user without making them remember their path.
@@ -189,6 +210,9 @@ export const runUpdate = async (opts: UpdateOptions): Promise<number> => {
     process.stdout.write(`  installed:       ${installed}\n`);
     process.stdout.write(`  ${label.padEnd(16)}: ${resolved}\n`);
     const cmp = compareVersions(resolved, installed);
+    // Cache the registry reply so the statusline can render an ↑ marker.
+    // Skip pinned-version checks — those aren't meaningful as "latest".
+    if (!isPinnedVersion) writeUpdateCache(resolved, target);
     if (cmp === 0) {
       process.stdout.write(`  ✓ Up to date\n`);
       return 0;

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -16,6 +16,9 @@ export const golemTunePath = (): string => join(tokenomyDir(), "golem-tune.json"
 // Written by `tokenomy analyze` as a side effect; read by the budget
 // PreToolUse rule for p95-response-size lookups.
 export const analyzeCachePath = (): string => join(tokenomyDir(), "analyze-cache.json");
+// Written by `tokenomy update --check`; read by the statusline to render
+// a `↑` marker after the version when a newer build exists on npm.
+export const updateCachePath = (): string => join(tokenomyDir(), "update-cache.json");
 // Per-session running totals for the budget rule. Cleared on SessionStart
 // of a new session. Session-state files are append-only JSONL ledgers keyed
 // by a sanitized hash of the session_id (to prevent path traversal when a

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,1 +1,1 @@
-export const TOKENOMY_VERSION = "0.1.1-beta.4";
+export const TOKENOMY_VERSION = "0.1.1-beta.5";

--- a/src/raven/stats.ts
+++ b/src/raven/stats.ts
@@ -1,0 +1,69 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { ravenRootDir } from "../core/paths.js";
+
+export interface RavenStats {
+  enabled: boolean;
+  packets: number;
+  reviews: number;
+  comparisons: number;
+  decisions: number;
+  repos: number;
+  last_activity: string | null;
+}
+
+const countJsonFiles = (dir: string): { count: number; latestMs: number } => {
+  if (!existsSync(dir)) return { count: 0, latestMs: 0 };
+  let count = 0;
+  let latestMs = 0;
+  for (const name of readdirSync(dir)) {
+    if (!name.endsWith(".json")) continue;
+    count++;
+    try {
+      const ms = statSync(join(dir, name)).mtimeMs;
+      if (ms > latestMs) latestMs = ms;
+    } catch {
+      // Racing with cleanStore — skip the file.
+    }
+  }
+  return { count, latestMs };
+};
+
+// Walk ~/.tokenomy/raven/<repo-id>/{packets,reviews,comparisons,decisions}
+// and roll the JSON file counts into a single summary. Intentionally
+// filesystem-driven rather than re-reading each JSON: callers only need
+// counts + newest-mtime, so this stays O(files) with no parse cost.
+export const collectRavenStats = (root = ravenRootDir(), enabled = false): RavenStats => {
+  const stats: RavenStats = {
+    enabled,
+    packets: 0,
+    reviews: 0,
+    comparisons: 0,
+    decisions: 0,
+    repos: 0,
+    last_activity: null,
+  };
+  if (!existsSync(root)) return stats;
+  let latestMs = 0;
+  for (const repoId of readdirSync(root)) {
+    const repoDir = join(root, repoId);
+    try {
+      if (!statSync(repoDir).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    stats.repos++;
+    for (const [sub, field] of [
+      ["packets", "packets"],
+      ["reviews", "reviews"],
+      ["comparisons", "comparisons"],
+      ["decisions", "decisions"],
+    ] as const) {
+      const { count, latestMs: ms } = countJsonFiles(join(repoDir, sub));
+      stats[field] += count;
+      if (ms > latestMs) latestMs = ms;
+    }
+  }
+  stats.last_activity = latestMs > 0 ? new Date(latestMs).toISOString() : null;
+  return stats;
+};

--- a/tests/unit/raven-stats.test.ts
+++ b/tests/unit/raven-stats.test.ts
@@ -1,0 +1,82 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { collectRavenStats } from "../../src/raven/stats.js";
+
+const makeRavenRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), "tokenomy-raven-"));
+  for (const repoId of ["repoA", "repoB"]) {
+    const base = join(root, repoId);
+    for (const sub of ["packets", "reviews", "comparisons", "decisions"]) {
+      mkdirSync(join(base, sub), { recursive: true });
+    }
+  }
+  return root;
+};
+
+test("collectRavenStats: empty root returns zeros and null last_activity", () => {
+  const root = mkdtempSync(join(tmpdir(), "tokenomy-raven-empty-"));
+  try {
+    const stats = collectRavenStats(root, true);
+    assert.equal(stats.enabled, true);
+    assert.equal(stats.packets, 0);
+    assert.equal(stats.reviews, 0);
+    assert.equal(stats.comparisons, 0);
+    assert.equal(stats.decisions, 0);
+    assert.equal(stats.repos, 0);
+    assert.equal(stats.last_activity, null);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("collectRavenStats: nonexistent root is safe", () => {
+  const stats = collectRavenStats("/nonexistent-raven-root-xxxxx", false);
+  assert.equal(stats.packets, 0);
+  assert.equal(stats.repos, 0);
+  assert.equal(stats.last_activity, null);
+});
+
+test("collectRavenStats: counts JSON files across repos and populates last_activity", () => {
+  const root = makeRavenRoot();
+  try {
+    writeFileSync(join(root, "repoA/packets/p1.json"), "{}");
+    writeFileSync(join(root, "repoA/packets/p2.json"), "{}");
+    writeFileSync(join(root, "repoA/packets/skip.md"), "# not json");
+    writeFileSync(join(root, "repoA/reviews/r1.json"), "{}");
+    writeFileSync(join(root, "repoB/packets/p1.json"), "{}");
+    writeFileSync(join(root, "repoB/comparisons/c1.json"), "{}");
+    writeFileSync(join(root, "repoB/decisions/d1.json"), "{}");
+
+    const stats = collectRavenStats(root, false);
+    assert.equal(stats.enabled, false);
+    assert.equal(stats.repos, 2);
+    assert.equal(stats.packets, 3);
+    assert.equal(stats.reviews, 1);
+    assert.equal(stats.comparisons, 1);
+    assert.equal(stats.decisions, 1);
+    assert.ok(stats.last_activity !== null, "expected last_activity to be set");
+    assert.ok(
+      Number.isFinite(Date.parse(stats.last_activity ?? "")),
+      "expected last_activity to parse as ISO timestamp",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("collectRavenStats: non-directory entries under root are skipped", () => {
+  const root = mkdtempSync(join(tmpdir(), "tokenomy-raven-mixed-"));
+  try {
+    writeFileSync(join(root, "stray-file"), "oops");
+    mkdirSync(join(root, "repoX/packets"), { recursive: true });
+    writeFileSync(join(root, "repoX/packets/p.json"), "{}");
+    const stats = collectRavenStats(root, true);
+    assert.equal(stats.repos, 1);
+    assert.equal(stats.packets, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/update-cache.test.ts
+++ b/tests/unit/update-cache.test.ts
@@ -1,0 +1,74 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readUpdateCache, renderStatusLine } from "../../src/cli/statusline.js";
+import { TOKENOMY_VERSION } from "../../src/core/version.js";
+
+const makeTmpCache = (body: unknown): string => {
+  const dir = mkdtempSync(join(tmpdir(), "tokenomy-cache-"));
+  const path = join(dir, "update-cache.json");
+  writeFileSync(path, JSON.stringify(body), "utf8");
+  return path;
+};
+
+test("readUpdateCache: returns undefined when file is missing", () => {
+  assert.equal(readUpdateCache("/nonexistent/update-cache.json"), undefined);
+});
+
+test("readUpdateCache: returns undefined for older remote than installed", () => {
+  const path = makeTmpCache({ remote: "0.0.0", fetched_at: new Date().toISOString() });
+  try {
+    assert.equal(readUpdateCache(path), undefined);
+  } finally {
+    rmSync(path, { force: true });
+  }
+});
+
+test("readUpdateCache: returns remote when newer than installed", () => {
+  const path = makeTmpCache({ remote: "99.0.0", fetched_at: new Date().toISOString() });
+  try {
+    assert.equal(readUpdateCache(path), "99.0.0");
+  } finally {
+    rmSync(path, { force: true });
+  }
+});
+
+test("readUpdateCache: ignores cache older than 14 days", () => {
+  const old = new Date(Date.now() - 30 * 86_400_000).toISOString();
+  const path = makeTmpCache({ remote: "99.0.0", fetched_at: old });
+  try {
+    assert.equal(readUpdateCache(path), undefined);
+  } finally {
+    rmSync(path, { force: true });
+  }
+});
+
+test("readUpdateCache: malformed JSON returns undefined", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tokenomy-cache-"));
+  const path = join(dir, "update-cache.json");
+  writeFileSync(path, "{not json", "utf8");
+  try {
+    assert.equal(readUpdateCache(path), undefined);
+  } finally {
+    rmSync(path, { force: true });
+  }
+});
+
+test("renderStatusLine: appends ↑ when updateAvailable is set", () => {
+  const line = renderStatusLine({
+    active: true,
+    tokensToday: 0,
+    updateAvailable: "99.0.0",
+  });
+  assert.ok(
+    line.includes(`v${TOKENOMY_VERSION}↑`),
+    `expected up-arrow after version, got: ${line}`,
+  );
+});
+
+test("renderStatusLine: no arrow when updateAvailable is undefined", () => {
+  const line = renderStatusLine({ active: true, tokensToday: 0 });
+  assert.ok(!line.includes("↑"), `expected no up-arrow, got: ${line}`);
+});


### PR DESCRIPTION
## Summary

- Bump to `0.1.1-beta.5` across package.json, `src/core/version.ts`, CHANGELOG, README.
- **Statusline update marker** — `tokenomy update --check` now caches the registry reply at `~/.tokenomy/update-cache.json`. The statusline reads that cache (14-day TTL) and appends `↑` after the version tag when a newer build exists on npm, e.g. `[Tokenomy v0.1.1-beta.5↑ · …]`. Pinned-version lookups don't write the cache.
- **Raven in report + analyze** — both `tokenomy report` (TUI + HTML) and `tokenomy analyze` now surface Raven stats (packets, reviews, comparisons, decisions, repo count, last activity). New `src/raven/stats.ts` walks `~/.tokenomy/raven/<repo-id>/` and rolls up counts by file mtime — no JSON parsing on the hot path. `AggregateReport.raven` + `ReportSummary.raven` fields added; render is tolerant of older JSON/fixtures missing the field (guard added in `analyze/render.ts`).
- **+11 unit tests** — `tests/unit/update-cache.test.ts` (5 cases: missing / fresh / stale / malformed / renderStatusLine arrow) and `tests/unit/raven-stats.test.ts` (4 cases: empty / nonexistent / counts across repos / non-dir entries skipped). Total: **482/482 passing**.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` → 482/482 passing
- [x] `npm run coverage` still runs
- [ ] Manual: `tokenomy update --check` writes `~/.tokenomy/update-cache.json`
- [ ] Manual: statusline renders `↑` when cache holds a newer version
- [ ] Manual: `tokenomy report` shows `Raven bridge` block in TUI + HTML
- [ ] Manual: `tokenomy analyze` shows `Raven bridge` block when data present

🤖 Generated with [Claude Code](https://claude.com/claude-code)