### PR TITLE
feat: 0.1.3 — live graph freshness, cross-repo isolation, auto update-check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,53 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.1.3] — 2026-04-28
+
+### Fixed
+
+- **Graph stays fresh during a Claude Code session.** Previously the
+  graph snapshot only refreshed when the agent called a graph MCP tool;
+  edits via Edit / Write / MultiEdit / NotebookEdit silently drifted it
+  out of date. Tokenomy now writes a `.dirty` sentinel under
+  `~/.tokenomy/graphs/<repo-id>/.dirty` on every PostToolUse for those
+  tools, and `isGraphStaleCheap` short-circuits to "stale" the moment it
+  exists — saving the full enumerate-and-stat repo walk on every read-
+  side MCP query. The next graph query rebuilds; the rebuild path
+  clears the sentinel.
+- **Async graph rebuild on the read path.** When the snapshot is stale
+  but exists, the read-side now serves the cached snapshot immediately
+  AND fires the rebuild in the background (locked per-repo to prevent
+  pile-up). Earlier behavior awaited the rebuild — on a 5k-file repo
+  that's a 1-3s tax on every first MCP query of a session, which made
+  agents stop using the graph and fall back to broad `Read`s. Caller
+  still gets `stale: true` so the assistant knows the data is not
+  fresh. Opt-out: `tokenomy config set graph.async_rebuild false`.
+- **Raven MCP tools stop bleeding cross-repo.** Every graph + Raven
+  MCP tool now accepts an optional `path` arg routing the call at a
+  specific repo. Previously the MCP server's startup cwd was used for
+  every tool call, so an agent working across repos in one session got
+  data for the registered repo regardless of the active one. Agents
+  should pass `path: "$PWD"` when working across multiple repos.
+- **`tokenomy report` / `analyze` Raven block scopes to current repo.**
+  Pre-0.1.3 the Raven counters aggregated across every registered
+  repo, inflating numbers and confusing agents. Now scoped by default;
+  pass `--all-repos` to restore the global aggregate. `tokenomy raven
+  status` was already per-repo.
+- **Update marker shows up promptly.** Statusline cache TTL dropped
+  from 14 days to 24 hours. SessionStart now fires `tokenomy update
+  --check --quiet` (detached, fail-open, throttled by the 3h cache-
+  age window). Statusline kicks the same refresh whenever the cached
+  `fetched_at` ages past 3h. Net effect: a new release shows up in
+  the `↑` marker on the user's next Claude Code restart, or within
+  3h on a long-running session.
+
+### Added
+
+- New config keys: `graph.async_rebuild` (default `true`), every MCP
+  tool's input schema gains an optional `path` property, `analyze`
+  + `report` accept `--all-repos`, `update` accepts `--quiet`.
+- New paths: `graphDirtySentinelPath(repoId)`, `graphRebuildLockPath(repoId)`.
+
 ## [0.1.2] — 2026-04-26
 
 > Renamed from `0.1.1-beta.6` at release time — `-beta.N` dist-tag retired; pre-`1.0` releases now use plain SemVer. Real version bump (0.1.1 → 0.1.2) since this release ships Kratos, Golem `recon` mode, the `tokenomy feedback` command, and Codex-flagged correctness fixes (Codex MCP TOML parsing, hook auditing, Raven base-diff completeness, kratos transcript scan now stream-reads tail).
@@ -877,7 +924,8 @@ First public alpha. Phase 1 scope: transparent MCP tool-output trimming via `Pos
 - Statusline with live savings counter — Phase 2.
 - `tokenomy analyze` over transcripts — Phase 2.
 
-[Unreleased]: https://github.com/RahulDhiman93/Tokenomy/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/RahulDhiman93/Tokenomy/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.3
 [0.1.2]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.2
 [0.1.1-beta.5]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.1-beta.5
 [0.1.1-beta.4]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.1-beta.4

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ tokenomy doctor                     # all checks passing
 
 Codex CLI, Cursor, Windsurf, Cline, Gemini auto-detected and registered when each is on PATH. Force one target with `--agent <name>`; inspect first with `tokenomy init --list-agents`.
 
-> **Pre-`1.0`.** Breaking changes may land before `1.0.0` (see [CHANGELOG](./CHANGELOG.md)). Pin: `npm install -g tokenomy@0.1.2`. Upgrade: `tokenomy update`.
+> **Pre-`1.0`.** Breaking changes may land before `1.0.0` (see [CHANGELOG](./CHANGELOG.md)). Pin: `npm install -g tokenomy@0.1.3`. Upgrade: `tokenomy update`.
 
 ---
 
@@ -120,6 +120,26 @@ Step 2 — Then ask me about each optional feature, one at a time.
      Golem mode, graph freshness, today's trims, and a `↑` after the
      version when an update is available. Already wired by `init`;
      just confirm it's working and move on.
+
+  h) Live graph freshness (0.1.3+) — graph stays fresh during the
+     session. PostToolUse hook on Edit/Write/MultiEdit drops a
+     `.dirty` sentinel; the next graph query rebuilds in the
+     background. ON by default. Tell me whether to keep it ON
+     (recommended) or disable.
+     Disable: tokenomy config set graph.async_rebuild false
+
+  i) Multi-repo graph + Raven (0.1.3+) — register the graph in EACH
+     repo I want it for. Run `tokenomy init --graph-path "$PWD"` in
+     each project root. When working across repos in one Claude
+     session, agents should pass `path: "$PWD"` to the MCP tools so
+     Tokenomy resolves the right per-repo graph + Raven store.
+     No-op for single-repo workflows.
+
+  j) Auto update-check (0.1.3+) — SessionStart fires
+     `tokenomy update --check --quiet` (detached, fail-open,
+     throttled 3h) so a new release shows up in the statusline `↑`
+     marker on the next Claude restart. ON by default. No action
+     needed; just confirm.
 
 Step 3 — Final check:
   1. Run: tokenomy doctor
@@ -213,7 +233,7 @@ Removes both hook entries from `~/.claude/settings.json` (matched by absolute co
 - [x] **Phase 4.5.** OSS-alternatives-first nudge — `find_oss_alternatives` MCP tool + Write context nudge.
 - [x] **Phase 5.** Polish — Golem output mode, statusline, prompt-classifier, `compress`, `bench`, cross-agent installers.
 - [x] **Phase 5.5.** Codex hook foothold — user-scoped `SessionStart` + `UserPromptSubmit` hooks for Golem and prompt-classifier nudges.
-- [x] **Phase 6 (0.1.x).** Raven bridge, Kratos security shield, statusline update marker, Raven in report/analyze, Golem `recon` mode, `tokenomy feedback` command.
+- [x] **Phase 6 (0.1.x).** Raven bridge, Kratos security shield, statusline update marker, Raven in report/analyze, Golem `recon` mode, `tokenomy feedback` command, live graph freshness + cross-repo isolation + auto-update-check (0.1.3).
 - [ ] **Phase 7.** Language breadth — Python parser plugin, richer benchmark fixtures, npm publish at 1.0.
 - [ ] **Phase 8.** Agent operating layer — rule-pack generator, compaction-time memory hygiene, workflow MCP tools, session ledgers, team-ready reports. See [docs/NEXT_FEATURES.md](./docs/NEXT_FEATURES.md).
 

--- a/docs/features/code-graph.md
+++ b/docs/features/code-graph.md
@@ -46,3 +46,23 @@ TypeScript / JavaScript AST via the TS compiler (no type checker). `tsconfig.pat
 ## Incremental updates (beta.3+)
 
 `cfg.graph.incremental: true` enables delta rebuilds that re-parse only stale files + direct importers. Falls back to full rebuild if tsconfig/exclude fingerprints shift or > 40 % of files changed. Opt-in.
+
+## Live freshness (0.1.3+)
+
+Pre-0.1.3 the graph snapshot only refreshed when the agent invoked a graph MCP tool. Mid-session edits via `Edit` / `Write` / `MultiEdit` / `NotebookEdit` silently drifted it out of date.
+
+0.1.3+ wires three layers:
+
+1. **Dirty sentinel.** PostToolUse on those edit tools touches `~/.tokenomy/graphs/<repo-id>/.dirty` with the changed file path. Cost per edit: one `existsSync` + one small append (~50 B). Skipped when no graph dir exists for the repo (no graph built yet).
+2. **Cheap-stale short-circuit.** `isGraphStaleCheap` returns `{ stale: true }` immediately when the sentinel exists — saves the full enumerate-and-stat repo walk on every read-side MCP query. O(repo) → O(1).
+3. **Async rebuild.** When the snapshot is stale-but-cached, the read-side serves the cached snapshot AND fires the rebuild in the background (process-local lockset prevents pile-up across rapid agent calls). Caller still receives `stale: true` in the response. The build clears the sentinel on success.
+
+Opt-out: `tokenomy config set graph.async_rebuild false` reverts to the synchronous-await behavior so a doomed rebuild surfaces immediately.
+
+## Cross-repo isolation (0.1.3+)
+
+The MCP server's startup cwd was previously baked into every tool call. When the agent worked across multiple repos in one Claude session, every query returned data for the registered repo regardless of the active one.
+
+0.1.3+ adds an optional `path` arg to every tool's input schema. Pass `path: "$PWD"` (or any absolute repo root) and Tokenomy resolves the per-repo graph + Raven store from that path. Default falls back to the server's startup cwd, so single-repo workflows are unchanged.
+
+Recommended: run `tokenomy init --graph-path "$PWD"` in EACH repo so each Claude Code project window registers its own MCP server bound to its own repo.

--- a/docs/features/observability.md
+++ b/docs/features/observability.md
@@ -92,9 +92,9 @@ tokenomy bench compare <a.json> <b.json>   # per-scenario regressions
 
 ## `tokenomy status-line` (beta.2+)
 
-`tokenomy init` patches `settings.json.statusLine`. Reads today's `savings.jsonl`, aggregates by tool/reason, emits a one-liner like `[Tokenomy v0.1.2 · GOLEM-GRUNT · 4.2k saved | graph fresh]`.
+`tokenomy init` patches `settings.json.statusLine`. Reads today's `savings.jsonl`, aggregates by tool/reason, emits a one-liner like `[Tokenomy v0.1.3 · GOLEM-GRUNT · 4.2k saved | graph fresh]`.
 
-After `tokenomy update --check`, a `↑` is appended when a newer release exists on npm (e.g. `v0.1.2↑`). Cache at `~/.tokenomy/update-cache.json` is ignored past 14 days.
+After `tokenomy update --check`, a `↑` is appended when a newer release exists on npm (e.g. `v0.1.3↑`). 0.1.3+: cache TTL is 24h and SessionStart + the statusline (every 3h) auto-spawn `tokenomy update --check --quiet` so a new release surfaces on the next Claude Code restart or within 3h on a long-running session.
 
 Must return in < 50 ms — uses a bounded read of the log and no external I/O. Fails open: missing config or parse error → empty string → Claude Code renders nothing.
 
@@ -116,8 +116,8 @@ Single-command self-update.
 ```bash
 tokenomy update              # install latest + re-stage hook
 tokenomy update --check      # query registry, print installed vs remote, exit 1 if out of date
-tokenomy update@0.1.2 # npm-style pin
-tokenomy update --version=0.1.2
+tokenomy update@0.1.3 # npm-style pin
+tokenomy update --version=0.1.3
 tokenomy update --tag=beta   # opt into a non-default dist-tag
 ```
 

--- a/docs/features/raven.md
+++ b/docs/features/raven.md
@@ -70,6 +70,14 @@ All budget-clipped, all refuse stale packets:
 - `get_pr_readiness`
 - `record_decision`
 
+## Cross-repo scope (0.1.3+)
+
+Every Raven MCP tool accepts an optional `path` arg routing the call at a specific repo. Without it, the MCP server's startup cwd is used — wrong when the agent works across multiple repos in one Claude session. Pass `path: "$PWD"` (or any absolute repo root) and Tokenomy resolves the right per-repo Raven store.
+
+`tokenomy report` and `tokenomy analyze` scope the rolled-up Raven block to the current repo by default. Pass `--all-repos` to either CLI to restore the pre-0.1.3 global aggregate (across every registered Raven store under `~/.tokenomy/raven/`).
+
+`tokenomy raven status` was already per-repo.
+
 ## Out-of-scope
 
 `review --agent` auto-subprocessing (human-in-the-loop flow instead — print the packet path, run Codex in a second terminal, it calls `record_agent_review`) and `dispatch --worktree` (follow-up).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tokenomy",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tokenomy",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenomy",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Surgical Claude Code hook that transparently trims bloated MCP tool responses and clamps oversized file reads — stop burning tokens on tool chatter.",
   "type": "module",
   "engines": {

--- a/src/analyze/report.ts
+++ b/src/analyze/report.ts
@@ -68,6 +68,9 @@ export interface AggregatorOptions {
   // whether the bridge is currently turned on. Stats are collected
   // unconditionally; this only colours the "status" line.
   raven_enabled?: boolean;
+  // 0.1.3+: scope the rolled-up Raven stats to a single repo. When unset,
+  // aggregate across every registered Raven store (pre-0.1.3 behavior).
+  raven_repo_id?: string;
 }
 
 interface ToolBucket {
@@ -391,7 +394,11 @@ export class Aggregator {
         name: this.opts.tokenizer_name,
         approximate: this.opts.tokenizer_approximate,
       },
-      raven: collectRavenStats(undefined, this.opts.raven_enabled === true),
+      raven: collectRavenStats(
+        undefined,
+        this.opts.raven_enabled === true,
+        this.opts.raven_repo_id ? { repoId: this.opts.raven_repo_id } : {},
+      ),
     };
   }
 }

--- a/src/cli/analyze.ts
+++ b/src/cli/analyze.ts
@@ -10,6 +10,7 @@ import { Simulator } from "../analyze/simulate.js";
 import { loadTokenizer, type TokenizerChoice } from "../analyze/tokens.js";
 import { computeGolemTune, writeGolemTune } from "../analyze/tune.js";
 import { analyzeCachePath } from "../core/paths.js";
+import { resolveRepoId } from "../graph/repo-id.js";
 import { writeFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import type { Config } from "../core/types.js";
@@ -32,6 +33,9 @@ export interface AnalyzeOptions {
   // (SessionStart resolver, budget PreToolUse rule) can pick them up.
   tune?: boolean;
   cache?: boolean;
+  // 0.1.3+: when true, the rolled-up Raven block aggregates across every
+  // registered repo. Default (false) scopes to the current repo only.
+  allRepos?: boolean;
 }
 
 const parseSince = (input: string | undefined): Date | undefined => {
@@ -119,6 +123,15 @@ export const runAnalyze = async (opts: AnalyzeOptions): Promise<number> => {
     tokenizer_name: tokenizer.name,
     tokenizer_approximate: tokenizer.approximate,
     raven_enabled: cfg.raven?.enabled === true,
+    raven_repo_id: opts.allRepos
+      ? undefined
+      : (() => {
+          try {
+            return resolveRepoId(process.cwd()).repoId;
+          } catch {
+            return undefined;
+          }
+        })(),
   });
 
   // Live progress: write \r-updated status line to stderr so stdout stays

--- a/src/cli/entry.ts
+++ b/src/cli/entry.ts
@@ -37,7 +37,7 @@ Usage:
   tokenomy bench run [scenario] [--json]
   tokenomy bench compare <a.json> <b.json>
   tokenomy bench report --md
-  tokenomy report [--since=<ISO>] [--top=<N>] [--out=<path>] [--json]
+  tokenomy report [--since=<ISO>] [--top=<N>] [--out=<path>] [--json] [--all-repos]
   tokenomy analyze [--path=<dir>] [--since=<ISO|Nd|Nw>] [--project=<str>] [--session=<id>]
                    [--top=<N>] [--tokenizer=heuristic|tiktoken|auto] [--json] [--no-color] [--verbose]
   tokenomy diff --call-key <sha256> | --tool <name> [--grep <str>] | --session <id> [--index <N>]
@@ -51,7 +51,7 @@ Usage:
   tokenomy graph purge [--path=<dir>|--all]
   tokenomy graph query <minimal|impact|review|usages> ...
   tokenomy uninstall [--purge] [--no-backup] [--agent=<name>]
-  tokenomy update [--tag=alpha|latest|beta|rc] [--version=<v>] [--check] [--force]
+  tokenomy update [--tag=alpha|latest|beta|rc] [--version=<v>] [--check] [--force] [--quiet]
   tokenomy config get <key>
   tokenomy config set <key> <value>
   tokenomy golem enable [--mode=lite|full|ultra|grunt|recon]
@@ -234,6 +234,7 @@ const main = async (): Promise<number> => {
       version,
       check: args.flags["check"] === true,
       force: args.flags["force"] === true,
+      quiet: args.flags["quiet"] === true,
     });
   }
 
@@ -301,6 +302,7 @@ const main = async (): Promise<number> => {
       verbose: args.flags["verbose"] === true,
       tune: args.flags["tune"] === true,
       cache: args.flags["no-cache"] !== true,
+      allRepos: args.flags["all-repos"] === true,
     });
   }
 
@@ -313,7 +315,8 @@ const main = async (): Promise<number> => {
       typeof args.flags["price-per-million"] === "string"
         ? parseFloat(args.flags["price-per-million"])
         : undefined;
-    const r = runReport({ since, top, out, pricePerMillion: price });
+    const allRepos = args.flags["all-repos"] === true;
+    const r = runReport({ since, top, out, pricePerMillion: price, allRepos });
     if (args.flags["json"]) {
       process.stdout.write(JSON.stringify(r.summary, null, 2) + "\n");
     } else {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -40,7 +40,13 @@ export interface InitOptions {
   agent?: AgentName;
 }
 
-const POST_MATCHER = "mcp__.*";
+// 0.1.3+: PostToolUse covers MCP (response trim) + Bash (stacktrace
+// compress) AND now Edit/Write/MultiEdit/NotebookEdit so the
+// graph-dirty sentinel fires whenever the agent mutates a tracked file.
+// Per-edit cost: one stat + one small file append (~50 B). Net win
+// because `isGraphStaleCheap` short-circuits to "stale" without
+// walking the repo.
+const POST_MATCHER = "mcp__.*|Bash|Edit|Write|MultiEdit|NotebookEdit";
 // PreToolUse fires for Read (file clamp), Bash (input bounder), and Write
 // (OSS-alternatives nudge, alpha.18+). Claude Code matchers accept regex-style
 // alternation, so one entry covers all three.

--- a/src/cli/report.ts
+++ b/src/cli/report.ts
@@ -8,6 +8,7 @@ import type { Config, SavingsLogEntry } from "../core/types.js";
 import { globalConfigPath } from "../core/paths.js";
 import { collectRavenStats, type RavenStats } from "../raven/stats.js";
 import { loadConfig } from "../core/config.js";
+import { resolveRepoId } from "../graph/repo-id.js";
 
 // Per-1M-token pricing (USD). Used purely to estimate $ saved for the
 // "tokens saved" column. Users can override via `tokenomy config set
@@ -19,6 +20,10 @@ export interface ReportOptions {
   top: number; // limit for per-tool/reason rankings
   out?: string; // HTML output path
   pricePerMillion?: number;
+  // 0.1.3+: when true, aggregate Raven stats across every registered
+  // repo (pre-0.1.3 default). When false (new default), scope the
+  // Raven block to the current repo only.
+  allRepos?: boolean;
 }
 
 export interface ReportSummary {
@@ -248,7 +253,19 @@ export const runReport = (opts: ReportOptions): { summary: ReportSummary; htmlPa
   } catch {
     // Config unreadable — render Raven as "disabled" rather than failing the report.
   }
-  const raven = collectRavenStats(undefined, ravenEnabled);
+  // 0.1.3+: scope Raven stats to the current repo by default. Pass
+  // `allRepos: true` (driven by `--all-repos` from the CLI) to roll up
+  // every registered Raven store. Pre-0.1.3 always aggregated globally,
+  // which inflated counters and confused agents working in one repo.
+  let repoId: string | undefined;
+  if (!opts.allRepos) {
+    try {
+      repoId = resolveRepoId(process.cwd()).repoId;
+    } catch {
+      // Non-git or not-a-repo cwd → fall through to global aggregate.
+    }
+  }
+  const raven = collectRavenStats(undefined, ravenEnabled, repoId ? { repoId } : {});
   const summary = summarize(entries, { top: opts.top, pricePerMillion, raven });
   const html = renderHtml(summary);
   const tui = renderTui(summary);

--- a/src/cli/statusline.ts
+++ b/src/cli/statusline.ts
@@ -4,6 +4,7 @@ import { graphMetaPath, graphSnapshotPath, tokenomyGraphRootDir, updateCachePath
 import type { SavingsLogEntry } from "../core/types.js";
 import { TOKENOMY_VERSION } from "../core/version.js";
 import { compareVersions } from "./update.js";
+import { spawnUpdateCheck } from "./update-check-spawn.js";
 import { resolveRepoId } from "../graph/repo-id.js";
 import { resolveGolemMode } from "../rules/golem.js";
 import { safeParse } from "../util/json.js";
@@ -22,9 +23,17 @@ export interface StatusLineState {
 }
 
 // Staleness window for the update cache. Past this, treat the cache as
-// unknown rather than a stale hit (registry state drifts; a 2-week-old
-// "update available" isn't signal worth rendering).
-const UPDATE_CACHE_TTL_MS = 14 * 86_400_000;
+// unknown rather than a stale hit (registry state drifts; a stale
+// "update available" isn't signal worth rendering). 0.1.3+: dropped from
+// 14 days to 24 hours since SessionStart and the statusline now keep the
+// cache fresh proactively — past 24h means our refresh path is broken
+// and we'd rather show "no update" than a stale hit.
+const UPDATE_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+// 0.1.3+: refresh-trigger window. When the cache is older than this, the
+// statusline spawns a non-blocking `tokenomy update --check` so we pick
+// up new releases promptly without waiting for the next SessionStart.
+const UPDATE_CACHE_REFRESH_AFTER_MS = 3 * 60 * 60 * 1000; // 3h
 
 export const readUpdateCache = (
   path = updateCachePath(),
@@ -43,6 +52,37 @@ export const readUpdateCache = (
   } catch {
     return undefined;
   }
+};
+
+// 0.1.3+: returns the cache age in ms, or null when the file is missing
+// or unparseable. Drives the periodic refresh trigger in the statusline
+// hot path. Cheap: one stat + one small read; bounded by node's cache.
+export const updateCacheAgeMs = (path = updateCachePath(), now = Date.now()): number | null => {
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = safeParse<{ fetched_at?: string }>(readFileSync(path, "utf8"));
+    if (!parsed?.fetched_at) return null;
+    const fetchedAt = Date.parse(parsed.fetched_at);
+    if (!Number.isFinite(fetchedAt)) return null;
+    return Math.max(0, now - fetchedAt);
+  } catch {
+    return null;
+  }
+};
+
+// 0.1.3+: returns true when the statusline should kick off a non-blocking
+// `tokenomy update --check`. Triggers when:
+//   - cache is missing entirely, OR
+//   - cache is older than UPDATE_CACHE_REFRESH_AFTER_MS (3h).
+// Caller is expected to spawn the refresh detached + unref'd; this helper
+// is pure so tests can drive it deterministically.
+export const shouldRefreshUpdateCache = (
+  path = updateCachePath(),
+  now = Date.now(),
+): boolean => {
+  const age = updateCacheAgeMs(path, now);
+  if (age === null) return true;
+  return age > UPDATE_CACHE_REFRESH_AFTER_MS;
 };
 
 const localDateKey = (d: Date): string => {
@@ -128,6 +168,11 @@ export const runStatusLine = (argv: string[]): number => {
       raven: cfg.raven.enabled,
       updateAvailable: readUpdateCache(),
     };
+    // 0.1.3+: keep the update cache fresh on the order of 3h so a new
+    // release shows up in the statusline within one statusline tick of
+    // crossing that threshold. The spawn is fully detached + unref'd so
+    // it can't block the statusline's < 50ms budget.
+    if (shouldRefreshUpdateCache()) spawnUpdateCheck();
     if (argv.includes("--json")) process.stdout.write(JSON.stringify(state, null, 2) + "\n");
     else process.stdout.write(renderStatusLine(state) + "\n");
     return 0;

--- a/src/cli/update-check-spawn.ts
+++ b/src/cli/update-check-spawn.ts
@@ -1,0 +1,41 @@
+import { spawn } from "node:child_process";
+
+// 0.1.3+: detached, non-blocking spawn of `tokenomy update --check`.
+//
+// Used by the SessionStart hook (so users notice new releases the moment
+// they restart Claude Code) and by the statusline (every 3h when the
+// cache ages out). Both paths must NEVER block the user's session, so we:
+//
+//   - spawn `tokenomy update --check` with stdio: 'ignore'
+//   - call .unref() so the parent can exit independently
+//   - swallow all errors (no `tokenomy` on PATH, no network, etc. all
+//     leave the cache as-is)
+//
+// The actual check writes `~/.tokenomy/update-cache.json` if a newer
+// release exists. The next `readUpdateCache()` tick picks it up.
+//
+// Idempotent: a process-local guard prevents two spawns in the same Node
+// process (which would race on the cache write). The on-disk
+// `update-cache.json` mtime acts as the cross-process throttle via
+// `shouldRefreshUpdateCache`.
+let inFlight = false;
+
+export const spawnUpdateCheck = (): void => {
+  if (inFlight) return;
+  inFlight = true;
+  try {
+    const child = spawn("tokenomy", ["update", "--check", "--quiet"], {
+      stdio: "ignore",
+      detached: true,
+    });
+    child.on("error", () => {
+      inFlight = false;
+    });
+    child.on("exit", () => {
+      inFlight = false;
+    });
+    child.unref();
+  } catch {
+    inFlight = false;
+  }
+};

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -72,6 +72,10 @@ export interface UpdateOptions {
   // Override the dev-symlink guard (see isDevSymlink()). Use at own risk:
   // the `npm install -g` will replace your linked dev checkout.
   force?: boolean;
+  // 0.1.3+: silence stdout/stderr when triggered by SessionStart /
+  // statusline. The cache write is the side effect that matters; the
+  // human-readable lines are noise in those code paths.
+  quiet?: boolean;
 }
 
 const runNpm = (args: string[], inherit = false): { status: number; stdout: string; stderr: string } => {
@@ -190,6 +194,11 @@ export const runUpdate = async (opts: UpdateOptions): Promise<number> => {
   const target = opts.version ?? tag;
 
   if (opts.check) {
+    // 0.1.3+: --quiet silences user-facing prints (used by SessionStart /
+    // statusline auto-spawn). Cache write still happens — that's the
+    // side effect we actually need.
+    const writeOut = opts.quiet ? () => {} : (s: string) => process.stdout.write(s);
+    const writeErr = opts.quiet ? () => {} : (s: string) => process.stderr.write(s);
     // Honor an explicit pin: if the user passed --version=X or the
     // update@X shorthand, check resolves against THAT version — not the
     // default tag. A pinned target like `0.1.0-alpha.13` asks the registry
@@ -197,7 +206,7 @@ export const runUpdate = async (opts: UpdateOptions): Promise<number> => {
     // version doesn't exist on the registry).
     const resolved = fetchRegistryVersion(target);
     if (resolved === null) {
-      process.stderr.write(
+      writeErr(
         `tokenomy update: could not query npm registry for tokenomy@${target}. ` +
           `Is npm on PATH, is the network reachable, and does that version exist?\n`,
       );
@@ -207,18 +216,18 @@ export const runUpdate = async (opts: UpdateOptions): Promise<number> => {
     // (e.g. `latest on npm`) vs a pinned version (`pin 0.1.0-alpha.13`).
     const isPinnedVersion = opts.version !== undefined;
     const label = isPinnedVersion ? `pin ${target}` : `${target} on npm`;
-    process.stdout.write(`  installed:       ${installed}\n`);
-    process.stdout.write(`  ${label.padEnd(16)}: ${resolved}\n`);
+    writeOut(`  installed:       ${installed}\n`);
+    writeOut(`  ${label.padEnd(16)}: ${resolved}\n`);
     const cmp = compareVersions(resolved, installed);
     // Cache the registry reply so the statusline can render an ↑ marker.
     // Skip pinned-version checks — those aren't meaningful as "latest".
     if (!isPinnedVersion) writeUpdateCache(resolved, target);
     if (cmp === 0) {
-      process.stdout.write(`  ✓ Up to date\n`);
+      writeOut(`  ✓ Up to date\n`);
       return 0;
     }
     if (cmp < 0) {
-      process.stdout.write(
+      writeOut(
         isPinnedVersion
           ? `  ✓ Installed is newer than the pinned target.\n`
           : `  ✓ Up to date (installed is newer than the \`${target}\` dist-tag on npm).\n`,
@@ -233,7 +242,7 @@ export const runUpdate = async (opts: UpdateOptions): Promise<number> => {
       : opts.tag && opts.tag !== defaultTag()
       ? `tokenomy update --tag=${target}`
       : `tokenomy update`;
-    process.stdout.write(`  ⚠ Update available. Run \`${suggest}\`.\n`);
+    writeOut(`  ⚠ Update available. Run \`${suggest}\`.\n`);
     return 1;
   }
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -89,6 +89,7 @@ export const DEFAULT_CONFIG: Config = {
       "**/*-bundle.mjs",
     ],
     auto_refresh_on_read: true,
+    async_rebuild: true,
     incremental: false,
     tsconfig: {
       enabled: true,

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -50,6 +50,16 @@ export const graphBuildLogPath = (repoId: string): string =>
   join(graphDir(repoId), "build.jsonl");
 export const graphLockPath = (repoId: string): string =>
   join(graphDir(repoId), ".build.lock");
+// 0.1.3+: PostToolUse Edit/Write/MultiEdit touches this sentinel; cleared
+// by buildGraph after a successful rebuild. Existence = "graph definitely
+// stale, skip the enumerate walk."
+export const graphDirtySentinelPath = (repoId: string): string =>
+  join(graphDir(repoId), ".dirty");
+// 0.1.3+: per-repo lock taken by the async background-rebuild path so
+// rapid edits don't pile up rebuilds. Existence = "rebuild in flight."
+// Same dir as the snapshot so it's atomic-safe with rmSync recursive.
+export const graphRebuildLockPath = (repoId: string): string =>
+  join(graphDir(repoId), ".rebuilding");
 
 export const claudeSettingsPath = (): string =>
   join(homedir(), ".claude", "settings.json");

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -224,6 +224,11 @@ export interface GraphConfig {
   query_budget_bytes: GraphQueryBudgetConfig;
   exclude: string[];
   auto_refresh_on_read: boolean;
+  // 0.1.3+: when true (default), a stale-but-existing snapshot is served
+  // immediately and the rebuild runs in the background. The caller still
+  // gets `stale: true` in the response so the assistant knows the data is
+  // not fresh. Set to false to revert to the synchronous-await behavior.
+  async_rebuild?: boolean;
   // Beta-3: delta graph builds. When true, the builder compares file
   // content hashes against the prior snapshot and re-parses only changed
   // files. Falls back to a full build when tsconfig/package.json change or

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,1 +1,1 @@
-export const TOKENOMY_VERSION = "0.1.2";
+export const TOKENOMY_VERSION = "0.1.3";

--- a/src/graph/build.ts
+++ b/src/graph/build.ts
@@ -1,7 +1,7 @@
-import { closeSync, mkdirSync, openSync, readFileSync, rmSync, statSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, rmSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { Config } from "../core/types.js";
-import { graphBuildLogPath, graphLockPath } from "../core/paths.js";
+import { graphBuildLogPath, graphDirtySentinelPath, graphLockPath } from "../core/paths.js";
 import { stableStringify } from "../util/json.js";
 import { TOKENOMY_VERSION } from "../core/version.js";
 import { enumerateAllFiles, enumerateGraphFiles } from "./enumerate.js";
@@ -456,6 +456,16 @@ export const buildGraph = async (options: BuildGraphOptions): Promise<BuildGraph
     }
     built.data.duration_ms = Date.now() - start;
     logGraphBuild(identity.repoId, identity.repoPath, built);
+    // 0.1.3+: clear the dirty sentinel after a successful rebuild so the
+    // next isGraphStaleCheap call falls back to its normal mtime walk
+    // instead of short-circuiting to "stale". Best-effort; missing-file
+    // is the desired post-state anyway.
+    try {
+      const dirty = graphDirtySentinelPath(identity.repoId);
+      if (existsSync(dirty)) rmSync(dirty, { force: true });
+    } catch {
+      // ignore
+    }
     return built;
   } catch (error) {
     const result = fail("io-error", (error as Error).message);

--- a/src/graph/stale.ts
+++ b/src/graph/stale.ts
@@ -1,7 +1,7 @@
 import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { Config } from "../core/types.js";
-import { graphSnapshotPath } from "../core/paths.js";
+import { graphDirtySentinelPath, graphRebuildLockPath, graphSnapshotPath } from "../core/paths.js";
 import type { GraphMeta } from "./schema.js";
 import {
   enumerateAllFiles,
@@ -117,6 +117,16 @@ export const isGraphStaleCheap = (
   // fail with graph-not-built. Codex round 1 review catch.
   if (!existsSync(graphSnapshotPath(identity.repoId))) {
     return { missing: true, stale: true, stale_files: [] };
+  }
+
+  // 0.1.3 fast path: PostToolUse on Edit/Write/MultiEdit drops a `.dirty`
+  // sentinel under the graph dir. When it exists we know SOMETHING changed
+  // and short-circuit straight to stale — saves the full enumerate-and-stat
+  // walk on every read-side MCP query. The actual rebuild path picks up the
+  // SHA-256 verification, so a false positive (file touched but content
+  // unchanged) still short-circuits cheaply downstream.
+  if (existsSync(graphDirtySentinelPath(identity.repoId))) {
+    return { missing: false, stale: true, stale_files: [] };
   }
 
   if (meta.exclude_fingerprint !== fingerprintExcludes(cfg.graph.exclude)) {

--- a/src/hook/entry.ts
+++ b/src/hook/entry.ts
@@ -9,6 +9,7 @@ import {
 } from "./pre-dispatch.js";
 import { loadConfig } from "../core/config.js";
 import { tokenomyDir } from "../core/paths.js";
+import { markGraphDirty } from "../rules/graph-dirty.js";
 import type {
   HookInput,
   PreHookInput,
@@ -180,6 +181,10 @@ const main = async (): Promise<void> => {
 
     const input = parsed as HookInput;
     const respBytes = Buffer.byteLength(JSON.stringify(input.tool_response ?? null), "utf8");
+    // Mark graph dirty on Edit/Write/MultiEdit. Independent of dispatch's
+    // mcp/Bash filter — we always run this regardless of whether the
+    // PostToolUse pipeline fires for the tool. Fail-open inside the rule.
+    markGraphDirty(input, cfg);
     const output = dispatch(input, cfg);
 
     const resp = input.tool_response as Record<string, unknown> | null;

--- a/src/hook/pre-dispatch.ts
+++ b/src/hook/pre-dispatch.ts
@@ -24,6 +24,8 @@ import {
 } from "../rules/golem.js";
 import { buildRavenSessionContext, buildRavenTurnReminder } from "../raven/nudge.js";
 import { evaluatePrompt as evaluateKratosPrompt } from "../kratos/prompt-rule.js";
+import { shouldRefreshUpdateCache } from "../cli/statusline.js";
+import { spawnUpdateCheck } from "../cli/update-check-spawn.js";
 import { estimateTokens } from "../core/gate.js";
 import { appendSavingsLog } from "../core/log.js";
 import { graphMetaPath, tokenomyGraphRootDir } from "../core/paths.js";
@@ -351,6 +353,12 @@ export const dispatchSessionStart = (
   input: SessionStartHookInput,
   cfg: Config,
 ): SessionStartHookOutput | null => {
+  // 0.1.3+: refresh ~/.tokenomy/update-cache.json every SessionStart so
+  // a fresh Claude Code session sees new Tokenomy releases on the
+  // statusline within one tick of the next refresh. Throttled by the
+  // statusline's 3h refresh window so rapid restarts don't pound npm.
+  // Spawn is detached + unref'd; cannot block the hook's < 50ms budget.
+  if (shouldRefreshUpdateCache()) spawnUpdateCheck();
   const ctx = buildGolemSessionContext(cfg);
   const raven = buildRavenSessionContext(cfg);
   const combined = [ctx, raven].filter(Boolean).join("\n\n");

--- a/src/mcp/handlers.ts
+++ b/src/mcp/handlers.ts
@@ -10,6 +10,7 @@ import { minimalContext } from "../graph/query/minimal.js";
 import { reviewContext } from "../graph/query/review.js";
 import { findUsages } from "../graph/query/usages.js";
 import { isGraphStaleCheap } from "../graph/stale.js";
+import { resolveRepoId } from "../graph/repo-id.js";
 import { npmSearch, registrySearch } from "../nudge/npm-search.js";
 import { repoSearch } from "../nudge/repo-search.js";
 import { createAndSaveRavenPacket } from "../raven/brief.js";
@@ -219,12 +220,57 @@ const withGraphContext = <T>(
 // caller so they see the actionable reason instead of silently receiving
 // a stale snapshot. Catches unexpected throws and falls back to the cheap
 // pre-check's stale state so the read path doesn't tear down.
+// 0.1.3+: in-flight rebuild lockset. Keyed on repoId. Prevents the agent
+// from kicking off N parallel rebuilds in quick succession when each tool
+// call sees a stale snapshot. Process-local; the on-disk
+// graphRebuildLockPath sentinel covers cross-process concurrency.
+const inFlightRebuilds = new Set<string>();
+
+const startBackgroundRebuild = (cwd: string, cfg: Config): void => {
+  let repoId: string;
+  try {
+    repoId = resolveRepoId(cwd).repoId;
+  } catch {
+    repoId = cwd;
+  }
+  if (inFlightRebuilds.has(repoId)) return;
+  inFlightRebuilds.add(repoId);
+  // Fire-and-forget. Errors are logged via buildGraph's own log path.
+  void buildGraph({ cwd, config: cfg, force: false })
+    .then((result) => {
+      if (result.ok && result.data.built) queryCache.invalidate();
+    })
+    .catch(() => {
+      // buildGraph is meant to be non-throwing; swallow anyway.
+    })
+    .finally(() => {
+      inFlightRebuilds.delete(repoId);
+    });
+};
+
 const ensureFreshGraph = async (
   cwd: string,
   cfg: Config,
 ): Promise<PrecomputedStale | FailOpen> => {
   const check = isGraphStaleCheap(cwd, cfg);
   if (!check.missing && !check.stale) return { stale: false, stale_files: [] };
+  // 0.1.3+: when the snapshot exists but is stale, return the cached
+  // version IMMEDIATELY and rebuild in the background. Earlier behavior
+  // awaited the rebuild — on a 5k-file repo that's a 1-3s tax on every
+  // first MCP query of a session, which agents respond to by skipping
+  // the graph and falling back to broad Reads (defeating the point of
+  // the graph). Caller still gets `stale: true` so the response can
+  // surface the freshness state to the assistant.
+  //
+  // Path taken only when a snapshot already exists. When `missing` is
+  // true (graph never built) we still await the synchronous build —
+  // there's nothing to serve in the meantime.
+  if (!check.missing && check.stale) {
+    if (cfg.graph.async_rebuild !== false) {
+      startBackgroundRebuild(cwd, cfg);
+      return { stale: true, stale_files: check.stale_files };
+    }
+  }
   try {
     const result = await buildGraph({ cwd, config: cfg, force: false });
     if (result.ok) {
@@ -299,17 +345,23 @@ export const dispatchGraphTool = async (
   cwd: string,
 ): Promise<QueryResult<unknown>> => {
   const args = asObject(rawArgs);
+  // 0.1.3+: every tool accepts an optional `path` arg so callers can route
+  // the query at a specific repo. Falls back to the MCP server's startup
+  // cwd. Resolves the cross-repo bleed where a single MCP instance bound
+  // to one cwd was returning data for the wrong repo when the agent
+  // worked across multiple repos in one session.
+  const argPath = typeof args["path"] === "string" && args["path"].length > 0 ? args["path"] : null;
+  const effectiveCwd = argPath ?? cwd;
 
   if (RAVEN_TOOLS.has(name)) {
-    return dispatchRavenTool(name, args, cwd);
+    return dispatchRavenTool(name, args, effectiveCwd);
   }
 
   if (name === "build_or_update_graph") {
-    const target = typeof args["path"] === "string" ? args["path"] : cwd;
-    const config = loadConfig(target);
+    const config = loadConfig(effectiveCwd);
     if (!config.graph.enabled) return fail("graph-disabled");
     const result: BuildGraphResult = await buildGraph({
-      cwd: target,
+      cwd: effectiveCwd,
       force: args["force"] === true,
       config,
     });
@@ -332,7 +384,7 @@ export const dispatchGraphTool = async (
     const invalid = earlyValidateReadArgs(name, args);
     if (invalid) return invalid;
 
-    const config = loadConfig(cwd);
+    const config = loadConfig(effectiveCwd);
 
     // Auto-refresh is opt-in via config. When enabled, run the cheap stale
     // check + conditional rebuild FIRST; when disabled, skip entirely and let
@@ -340,7 +392,7 @@ export const dispatchGraphTool = async (
     // behavior — mtime-only stale isn't good enough for the opt-out path
     // because a `touch` would incorrectly flag a file as changed).
     if (config.graph.auto_refresh_on_read) {
-      const fresh = await ensureFreshGraph(cwd, config);
+      const fresh = await ensureFreshGraph(effectiveCwd, config);
       if ("ok" in fresh && fresh.ok === false) {
         // Rebuild failed with an actionable reason — surface it to the caller
         // instead of serving a silently-stale snapshot.
@@ -350,7 +402,7 @@ export const dispatchGraphTool = async (
     }
 
     let graphContext = loadGraphContext(
-      cwd,
+      effectiveCwd,
       config,
       precomputedStale ? { skipStaleCheck: true, precomputedStale } : {},
     );
@@ -365,14 +417,14 @@ export const dispatchGraphTool = async (
       config.graph.auto_refresh_on_read
     ) {
       try {
-        const rebuild = await buildGraph({ cwd, config, force: false });
+        const rebuild = await buildGraph({ cwd: effectiveCwd, config, force: false });
         if (!rebuild.ok) return rebuild;
         queryCache.invalidate();
         precomputedStale = {
           stale: rebuild.stale ?? false,
           stale_files: rebuild.stale_files ?? [],
         };
-        graphContext = loadGraphContext(cwd, config, {
+        graphContext = loadGraphContext(effectiveCwd, config, {
           skipStaleCheck: true,
           precomputedStale,
         });
@@ -394,7 +446,7 @@ export const dispatchGraphTool = async (
     }
   }
 
-  const result = await dispatchGraphToolUncached(name, args, cwd, precomputedStale);
+  const result = await dispatchGraphToolUncached(name, args, effectiveCwd, precomputedStale);
   if (cacheKey && result.ok) queryCache.set(cacheKey, result);
   return result;
 };

--- a/src/mcp/schemas.ts
+++ b/src/mcp/schemas.ts
@@ -16,7 +16,18 @@ export interface ToolDefinition {
   inputSchema: JsonSchema;
 }
 
-export const TOOL_DEFS: ToolDefinition[] = [
+// 0.1.3+: every tool gets an optional `path` arg so callers can route a
+// query at a specific repo. Without this, every call uses the MCP server's
+// startup cwd — wrong when the agent works across multiple repos in one
+// session. Applied via post-process below so individual tool schemas
+// stay clean.
+const PATH_PROP: JsonSchema = {
+  type: "string",
+  description:
+    "Repository path to scope this query. Defaults to the MCP server's startup cwd. Pass an absolute path (e.g. \"$PWD\") when working across multiple repos in one session so Tokenomy resolves the correct per-repo graph + Raven store.",
+};
+
+const RAW_TOOL_DEFS: ToolDefinition[] = [
   {
     name: "build_or_update_graph",
     description: "Build or refresh the local Tokenomy code graph for the current repository.",
@@ -232,3 +243,21 @@ export const TOOL_DEFS: ToolDefinition[] = [
     },
   },
 ];
+
+// Post-process: inject `path` into every tool's properties. Skip
+// `build_or_update_graph` because it already declares it. Idempotent; if a
+// future tool adds `path` directly, this leaves the existing entry alone.
+export const TOOL_DEFS: ToolDefinition[] = RAW_TOOL_DEFS.map((tool) => {
+  if (!tool.inputSchema.properties) return tool;
+  if (tool.inputSchema.properties["path"]) return tool;
+  return {
+    ...tool,
+    inputSchema: {
+      ...tool.inputSchema,
+      properties: {
+        ...tool.inputSchema.properties,
+        path: PATH_PROP,
+      },
+    },
+  };
+});

--- a/src/raven/stats.ts
+++ b/src/raven/stats.ts
@@ -29,11 +29,23 @@ const countJsonFiles = (dir: string): { count: number; latestMs: number } => {
   return { count, latestMs };
 };
 
+export interface CollectRavenStatsOptions {
+  // 0.1.3+: scope the rollup to a single repo_id. When set, only that
+  // subdirectory is walked. When undefined (default), aggregate across
+  // every registered Raven repo — preserves the historical "global"
+  // behavior that `tokenomy report --all-repos` continues to use.
+  repoId?: string;
+}
+
 // Walk ~/.tokenomy/raven/<repo-id>/{packets,reviews,comparisons,decisions}
 // and roll the JSON file counts into a single summary. Intentionally
 // filesystem-driven rather than re-reading each JSON: callers only need
 // counts + newest-mtime, so this stays O(files) with no parse cost.
-export const collectRavenStats = (root = ravenRootDir(), enabled = false): RavenStats => {
+export const collectRavenStats = (
+  root: string = ravenRootDir(),
+  enabled = false,
+  options: CollectRavenStatsOptions = {},
+): RavenStats => {
   const stats: RavenStats = {
     enabled,
     packets: 0,
@@ -45,7 +57,16 @@ export const collectRavenStats = (root = ravenRootDir(), enabled = false): Raven
   };
   if (!existsSync(root)) return stats;
   let latestMs = 0;
-  for (const repoId of readdirSync(root)) {
+  // 0.1.3+: when scoped to a single repoId, walk just that dir. Avoids
+  // rolling up cross-repo Raven activity into the agent's report — that
+  // inflated counters and cost tokens explaining "100 packets" when the
+  // current repo only had 2.
+  const repoIds = options.repoId
+    ? existsSync(join(root, options.repoId))
+      ? [options.repoId]
+      : []
+    : readdirSync(root);
+  for (const repoId of repoIds) {
     const repoDir = join(root, repoId);
     try {
       if (!statSync(repoDir).isDirectory()) continue;

--- a/src/rules/graph-dirty.ts
+++ b/src/rules/graph-dirty.ts
@@ -1,0 +1,55 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import type { Config, HookInput } from "../core/types.js";
+import { graphDir, graphDirtySentinelPath } from "../core/paths.js";
+import { resolveRepoId } from "../graph/repo-id.js";
+
+// Graph-dirty sentinel for PostToolUse on Edit / Write / MultiEdit.
+//
+// Why: the graph snapshot is built once (`tokenomy init --graph-path`) and
+// only refreshed when an MCP graph tool runs. If the agent edits N files in
+// a session without calling the graph, the next graph query on stale data
+// silently returns out-of-date hotspots / call sites — and on a large repo,
+// `isGraphStaleCheap` walks the entire tree just to detect the drift.
+//
+// This rule writes a one-byte `.dirty` file under
+// `~/.tokenomy/graphs/<repo-id>/.dirty` whenever Tokenomy sees an Edit /
+// Write / MultiEdit complete. `isGraphStaleCheap` short-circuits to "stale"
+// the moment the sentinel exists — O(1) instead of O(repo) — and the next
+// MCP read-side query rebuilds.
+//
+// Fail-open everywhere: missing config, missing repo_id, write errors all
+// silently no-op. Never blocks the tool call.
+
+const EDIT_TOOLS = new Set(["Edit", "Write", "MultiEdit", "NotebookEdit"]);
+
+const isEditTool = (name: string | undefined): boolean =>
+  typeof name === "string" && EDIT_TOOLS.has(name);
+
+export const markGraphDirty = (input: HookInput, cfg: Config): void => {
+  if (!cfg.graph?.enabled) return;
+  if (!isEditTool(input.tool_name)) return;
+  if (!input.cwd || typeof input.cwd !== "string") return;
+  try {
+    const { repoId } = resolveRepoId(input.cwd);
+    const dir = graphDir(repoId);
+    if (!existsSync(dir)) {
+      // No graph snapshot exists for this repo yet — nothing to invalidate.
+      // Don't auto-create the dir; that would imply a graph the user never
+      // built and the read-side would treat it as missing → rebuild storm.
+      return;
+    }
+    const sentinel = graphDirtySentinelPath(repoId);
+    mkdirSync(dirname(sentinel), { recursive: true });
+    // Content carries the file_path that triggered the dirty flag so a
+    // future incremental-rebuild path can scope work. For now we just
+    // touch the file — `isGraphStaleCheap` only checks existence.
+    const filePath =
+      typeof input.tool_input?.["file_path"] === "string"
+        ? (input.tool_input["file_path"] as string)
+        : "";
+    writeFileSync(sentinel, `${new Date().toISOString()}\t${filePath}\n`, { flag: "a" });
+  } catch {
+    // best-effort; never throw out of a hook
+  }
+};

--- a/tests/unit/cli-smoke.test.ts
+++ b/tests/unit/cli-smoke.test.ts
@@ -233,7 +233,7 @@ test("statusline: text mode shows version + tokens", () => {
   withTmpHome(() => {
     const r = captureOut(() => runStatusLine([]));
     assert.equal(r.value, 0);
-    assert.match(r.out, /\[Tokenomy v0\.1\.2/);
+    assert.match(r.out, /\[Tokenomy v0\.1\.\d/);
   });
 });
 

--- a/tests/unit/graph-auto-refresh.test.ts
+++ b/tests/unit/graph-auto-refresh.test.ts
@@ -125,17 +125,20 @@ test("read-side auto-refresh: graph.auto_refresh_on_read=false leaves graph stal
   });
 });
 
-test("read-side auto-refresh: propagates rebuild FailOpen instead of silently serving stale data", async () => {
+test("read-side auto-refresh: propagates rebuild FailOpen when async_rebuild=false", async () => {
   await withSandbox(async (repo) => {
     // Build the graph successfully first so there's a stored snapshot.
     const built = (await dispatchGraphTool("build_or_update_graph", {}, repo)) as BuildResult;
     assert.equal(built.ok, true);
 
-    // Force staleness by adding a source file, then constrain hard_max_files
-    // via config so the rebuild attempt will fail with repo-too-large.
+    // 0.1.3+: by default the read-side serves the cached snapshot and rebuilds
+    // in the background, so a doomed rebuild no longer surfaces synchronously.
+    // Opt out of the async path here so we exercise the original semantics.
     writeFileSync(join(repo, "src", "overflow.ts"), "export const x = 1;\n");
     execFileSync("git", ["add", "."], { cwd: repo, stdio: "ignore" });
-    writeConfig(process.env["HOME"]!, { graph: { hard_max_files: 0 } });
+    writeConfig(process.env["HOME"]!, {
+      graph: { hard_max_files: 0, async_rebuild: false },
+    });
 
     const result = (await dispatchGraphTool(
       "get_minimal_context",
@@ -143,10 +146,31 @@ test("read-side auto-refresh: propagates rebuild FailOpen instead of silently se
       repo,
     )) as { ok: boolean; reason?: string };
 
-    // Must surface the rebuild failure rather than silently returning
-    // stale ok:true data from the old snapshot.
+    // Synchronous path: must surface the rebuild failure.
     assert.equal(result.ok, false, JSON.stringify(result));
     assert.equal(result.reason, "repo-too-large");
+  });
+});
+
+test("read-side auto-refresh: async_rebuild=true serves cached snapshot + flags stale", async () => {
+  await withSandbox(async (repo) => {
+    const built = (await dispatchGraphTool("build_or_update_graph", {}, repo)) as BuildResult;
+    assert.equal(built.ok, true);
+
+    // Add a file → snapshot becomes stale. async_rebuild defaults true.
+    writeFileSync(join(repo, "src", "added.ts"), "export const z = 1;\n");
+    execFileSync("git", ["add", "."], { cwd: repo, stdio: "ignore" });
+
+    const result = (await dispatchGraphTool(
+      "get_minimal_context",
+      { target: { file: "src/a.ts" }, depth: 1 },
+      repo,
+    )) as { ok: boolean; stale?: boolean };
+
+    // Stale-but-cached: ok:true, stale:true. The agent sees results
+    // immediately; rebuild runs in the background.
+    assert.equal(result.ok, true, JSON.stringify(result));
+    assert.equal(result.stale, true);
   });
 });
 

--- a/tests/unit/graph-dirty-sentinel.test.ts
+++ b/tests/unit/graph-dirty-sentinel.test.ts
@@ -1,0 +1,133 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { markGraphDirty } from "../../src/rules/graph-dirty.js";
+import { isGraphStaleCheap } from "../../src/graph/stale.js";
+import { graphDir, graphDirtySentinelPath, graphMetaPath, graphSnapshotPath } from "../../src/core/paths.js";
+import { resolveRepoId } from "../../src/graph/repo-id.js";
+import { DEFAULT_CONFIG } from "../../src/core/config.js";
+import type { Config, HookInput } from "../../src/core/types.js";
+
+const cfgWithGraph = (): Config => ({
+  ...(structuredClone(DEFAULT_CONFIG) as Config),
+});
+
+const withTmpHomeAndRepo = <T>(fn: (home: string, repo: string) => T): T => {
+  const home = mkdtempSync(join(tmpdir(), "tokenomy-graph-dirty-home-"));
+  const repo = mkdtempSync(join(tmpdir(), "tokenomy-graph-dirty-repo-"));
+  const prevHome = process.env["HOME"];
+  process.env["HOME"] = home;
+  try {
+    return fn(home, repo);
+  } finally {
+    if (prevHome === undefined) delete process.env["HOME"];
+    else process.env["HOME"] = prevHome;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+};
+
+const baseInput = (cwd: string, tool: string, file: string): HookInput => ({
+  session_id: "s",
+  transcript_path: "/t",
+  cwd,
+  permission_mode: "acceptEdits",
+  hook_event_name: "PostToolUse",
+  tool_name: tool,
+  tool_input: { file_path: file },
+  tool_use_id: "id",
+  tool_response: null,
+});
+
+test("markGraphDirty: writes .dirty sentinel for Edit on a repo with an existing graph dir", () => {
+  withTmpHomeAndRepo((home, repo) => {
+    // Pretend a graph snapshot exists for this repo so the rule fires.
+    const { repoId } = resolveRepoId(repo);
+    mkdirSync(graphDir(repoId), { recursive: true });
+    markGraphDirty(baseInput(repo, "Edit", "src/a.ts"), cfgWithGraph());
+    const sentinel = graphDirtySentinelPath(repoId);
+    assert.ok(existsSync(sentinel), "expected .dirty sentinel to exist");
+    const body = readFileSync(sentinel, "utf8");
+    assert.match(body, /src\/a\.ts/);
+    void home;
+  });
+});
+
+test("markGraphDirty: idempotent / appends across multiple edits", () => {
+  withTmpHomeAndRepo((_home, repo) => {
+    const { repoId } = resolveRepoId(repo);
+    mkdirSync(graphDir(repoId), { recursive: true });
+    markGraphDirty(baseInput(repo, "Write", "src/a.ts"), cfgWithGraph());
+    markGraphDirty(baseInput(repo, "Edit", "src/b.ts"), cfgWithGraph());
+    markGraphDirty(baseInput(repo, "MultiEdit", "src/c.ts"), cfgWithGraph());
+    const body = readFileSync(graphDirtySentinelPath(repoId), "utf8").split("\n").filter(Boolean);
+    assert.equal(body.length, 3);
+  });
+});
+
+test("markGraphDirty: skips when graph dir does not exist (no graph built for this repo)", () => {
+  withTmpHomeAndRepo((_home, repo) => {
+    const { repoId } = resolveRepoId(repo);
+    markGraphDirty(baseInput(repo, "Edit", "src/a.ts"), cfgWithGraph());
+    // Should NOT auto-create the graph dir or sentinel.
+    assert.equal(existsSync(graphDir(repoId)), false);
+    assert.equal(existsSync(graphDirtySentinelPath(repoId)), false);
+  });
+});
+
+test("markGraphDirty: skips when cfg.graph.enabled is false", () => {
+  withTmpHomeAndRepo((_home, repo) => {
+    const { repoId } = resolveRepoId(repo);
+    mkdirSync(graphDir(repoId), { recursive: true });
+    const cfg = cfgWithGraph();
+    cfg.graph.enabled = false;
+    markGraphDirty(baseInput(repo, "Edit", "src/a.ts"), cfg);
+    assert.equal(existsSync(graphDirtySentinelPath(repoId)), false);
+  });
+});
+
+test("markGraphDirty: skips for non-edit tool names", () => {
+  withTmpHomeAndRepo((_home, repo) => {
+    const { repoId } = resolveRepoId(repo);
+    mkdirSync(graphDir(repoId), { recursive: true });
+    markGraphDirty(baseInput(repo, "Read", "src/a.ts"), cfgWithGraph());
+    markGraphDirty(baseInput(repo, "Bash", ""), cfgWithGraph());
+    assert.equal(existsSync(graphDirtySentinelPath(repoId)), false);
+  });
+});
+
+test("isGraphStaleCheap: short-circuits to stale when sentinel exists", () => {
+  withTmpHomeAndRepo((_home, repo) => {
+    const { repoId } = resolveRepoId(repo);
+    // Fake a built graph: write minimal meta + snapshot files so the check
+    // doesn't bail with "missing".
+    mkdirSync(graphDir(repoId), { recursive: true });
+    writeFileSync(
+      graphMetaPath(repoId),
+      JSON.stringify({
+        schema_version: 1,
+        repo_id: repoId,
+        repo_path: repo,
+        built_at: new Date().toISOString(),
+        tokenomy_version: "0.1.3",
+        node_count: 0,
+        edge_count: 0,
+        file_hashes: {},
+        file_mtimes: {},
+        soft_cap: 1000,
+        hard_cap: 5000,
+        parse_error_count: 0,
+      }),
+    );
+    writeFileSync(graphSnapshotPath(repoId), JSON.stringify({ schema_version: 1, repo_id: repoId, nodes: [], edges: [], parse_errors: [] }));
+    // Drop the sentinel.
+    writeFileSync(graphDirtySentinelPath(repoId), "marked\n");
+    const result = isGraphStaleCheap(repo, cfgWithGraph());
+    assert.equal(result.missing, false);
+    assert.equal(result.stale, true);
+    // Short-circuit: stale_files is empty since we didn't enumerate.
+    assert.deepEqual(result.stale_files, []);
+  });
+});

--- a/tests/unit/mcp-handlers-path-arg.test.ts
+++ b/tests/unit/mcp-handlers-path-arg.test.ts
@@ -1,0 +1,98 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  _resetQueryCacheForTests,
+  dispatchGraphTool,
+} from "../../src/mcp/handlers.js";
+import { TOOL_DEFS } from "../../src/mcp/schemas.js";
+
+const sandbox = (): { home: string; repoA: string; repoB: string; cleanup: () => void } => {
+  const home = mkdtempSync(join(tmpdir(), "tokenomy-path-arg-home-"));
+  const repoA = mkdtempSync(join(tmpdir(), "tokenomy-path-arg-A-"));
+  const repoB = mkdtempSync(join(tmpdir(), "tokenomy-path-arg-B-"));
+  for (const repo of [repoA, repoB]) {
+    mkdirSync(join(repo, "src"), { recursive: true });
+    execFileSync("git", ["init"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.name", "T"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "t@x.test"], { cwd: repo, stdio: "ignore" });
+    writeFileSync(
+      join(repo, "src", "marker.ts"),
+      `export const id = "${repo === repoA ? "A" : "B"}";\n`,
+    );
+    execFileSync("git", ["add", "."], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["commit", "-m", "init"], { cwd: repo, stdio: "ignore" });
+  }
+  const prev = process.env["HOME"];
+  process.env["HOME"] = home;
+  _resetQueryCacheForTests();
+  return {
+    home,
+    repoA,
+    repoB,
+    cleanup: () => {
+      if (prev === undefined) delete process.env["HOME"];
+      else process.env["HOME"] = prev;
+      _resetQueryCacheForTests();
+      rmSync(home, { recursive: true, force: true });
+      rmSync(repoA, { recursive: true, force: true });
+      rmSync(repoB, { recursive: true, force: true });
+    },
+  };
+};
+
+test("TOOL_DEFS: every tool's input schema declares optional `path`", () => {
+  for (const tool of TOOL_DEFS) {
+    const props = tool.inputSchema.properties ?? {};
+    assert.ok(props["path"], `tool ${tool.name} missing path arg in schema`);
+    assert.equal(props["path"]?.type, "string");
+    // path is optional; should not appear in `required`.
+    assert.equal(
+      (tool.inputSchema.required ?? []).includes("path"),
+      false,
+      `tool ${tool.name} marks path as required`,
+    );
+  }
+});
+
+test("dispatchGraphTool: build_or_update_graph routes to args.path even when server cwd differs", async () => {
+  const { repoA, repoB, cleanup } = sandbox();
+  try {
+    // Server cwd is repoA but the call targets repoB.
+    const result = (await dispatchGraphTool(
+      "build_or_update_graph",
+      { path: repoB },
+      repoA,
+    )) as { ok: boolean; data?: { built: boolean; repo_id: string; node_count: number } };
+    assert.equal(result.ok, true, JSON.stringify(result));
+    if (!result.ok) return;
+    assert.equal(result.data!.built, true);
+    // Built node count should be > 0 since repoB has src/marker.ts.
+    assert.ok(result.data!.node_count > 0);
+  } finally {
+    cleanup();
+  }
+});
+
+test("dispatchGraphTool: get_minimal_context with path resolves the right repo's graph", async () => {
+  const { repoA, repoB, cleanup } = sandbox();
+  try {
+    // Build graphs for both repos.
+    await dispatchGraphTool("build_or_update_graph", { path: repoA }, repoA);
+    await dispatchGraphTool("build_or_update_graph", { path: repoB }, repoA);
+    // Server cwd points at A, but we ask about B's file via path arg.
+    const r = (await dispatchGraphTool(
+      "get_minimal_context",
+      { target: { file: "src/marker.ts" }, path: repoB },
+      repoA,
+    )) as { ok: boolean; data?: { focal: { file?: string } } };
+    assert.equal(r.ok, true, JSON.stringify(r));
+    if (!r.ok) return;
+    assert.equal(r.data!.focal.file, "src/marker.ts");
+  } finally {
+    cleanup();
+  }
+});

--- a/tests/unit/raven-repo-scope.test.ts
+++ b/tests/unit/raven-repo-scope.test.ts
@@ -1,0 +1,64 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { collectRavenStats } from "../../src/raven/stats.js";
+
+const setup = (): string => {
+  const root = mkdtempSync(join(tmpdir(), "tokenomy-raven-scope-"));
+  // Two repo subdirs, each with two packets.
+  for (const repoId of ["repoA", "repoB"]) {
+    for (const sub of ["packets", "reviews", "comparisons", "decisions"]) {
+      mkdirSync(join(root, repoId, sub), { recursive: true });
+    }
+  }
+  writeFileSync(join(root, "repoA", "packets", "p1.json"), "{}");
+  writeFileSync(join(root, "repoA", "packets", "p2.json"), "{}");
+  writeFileSync(join(root, "repoA", "reviews", "r1.json"), "{}");
+  writeFileSync(join(root, "repoB", "packets", "p1.json"), "{}");
+  writeFileSync(join(root, "repoB", "decisions", "d1.json"), "{}");
+  return root;
+};
+
+test("collectRavenStats: with repoId scopes counters to that one repo", () => {
+  const root = setup();
+  try {
+    const a = collectRavenStats(root, true, { repoId: "repoA" });
+    assert.equal(a.repos, 1);
+    assert.equal(a.packets, 2);
+    assert.equal(a.reviews, 1);
+    assert.equal(a.decisions, 0);
+    const b = collectRavenStats(root, true, { repoId: "repoB" });
+    assert.equal(b.repos, 1);
+    assert.equal(b.packets, 1);
+    assert.equal(b.decisions, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("collectRavenStats: without repoId aggregates across all repos (--all-repos)", () => {
+  const root = setup();
+  try {
+    const all = collectRavenStats(root, true);
+    assert.equal(all.repos, 2);
+    assert.equal(all.packets, 3);
+    assert.equal(all.reviews, 1);
+    assert.equal(all.decisions, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("collectRavenStats: nonexistent repoId returns zero counts, repos: 0", () => {
+  const root = setup();
+  try {
+    const r = collectRavenStats(root, true, { repoId: "doesNotExist" });
+    assert.equal(r.repos, 0);
+    assert.equal(r.packets, 0);
+    assert.equal(r.last_activity, null);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/update-cache-refresh.test.ts
+++ b/tests/unit/update-cache-refresh.test.ts
@@ -1,0 +1,92 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  shouldRefreshUpdateCache,
+  updateCacheAgeMs,
+} from "../../src/cli/statusline.js";
+
+const writeCache = (path: string, body: unknown): void => {
+  writeFileSync(path, JSON.stringify(body), "utf8");
+};
+
+test("shouldRefreshUpdateCache: returns true when cache is missing", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tokenomy-update-cache-"));
+  try {
+    assert.equal(shouldRefreshUpdateCache(join(dir, "no-such-cache.json")), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("shouldRefreshUpdateCache: returns false when cache age < 3h", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tokenomy-update-cache-"));
+  const path = join(dir, "cache.json");
+  try {
+    const now = Date.now();
+    writeCache(path, { remote: "0.1.3", fetched_at: new Date(now - 60 * 60 * 1000).toISOString() });
+    assert.equal(shouldRefreshUpdateCache(path, now), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("shouldRefreshUpdateCache: returns true when cache age > 3h", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tokenomy-update-cache-"));
+  const path = join(dir, "cache.json");
+  try {
+    const now = Date.now();
+    writeCache(path, {
+      remote: "0.1.3",
+      fetched_at: new Date(now - 4 * 60 * 60 * 1000).toISOString(),
+    });
+    assert.equal(shouldRefreshUpdateCache(path, now), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("shouldRefreshUpdateCache: missing fetched_at field → refresh true", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tokenomy-update-cache-"));
+  const path = join(dir, "cache.json");
+  try {
+    writeCache(path, { remote: "0.1.3" });
+    assert.equal(shouldRefreshUpdateCache(path), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("shouldRefreshUpdateCache: malformed JSON → refresh true", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tokenomy-update-cache-"));
+  const path = join(dir, "cache.json");
+  try {
+    writeFileSync(path, "{not json", "utf8");
+    assert.equal(shouldRefreshUpdateCache(path), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("updateCacheAgeMs: returns null on missing file", () => {
+  assert.equal(updateCacheAgeMs("/nonexistent/cache.json"), null);
+});
+
+test("updateCacheAgeMs: returns positive ms when fetched_at is in the past", () => {
+  const dir = mkdtempSync(join(tmpdir(), "tokenomy-update-cache-"));
+  const path = join(dir, "cache.json");
+  try {
+    const now = Date.now();
+    writeCache(path, {
+      remote: "0.1.3",
+      fetched_at: new Date(now - 7 * 60 * 1000).toISOString(),
+    });
+    const age = updateCacheAgeMs(path, now);
+    assert.ok(age !== null);
+    assert.ok(age! >= 7 * 60 * 1000 - 1000);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Three user-reported issues from 0.1.2:

1. **Graph stale during Claude Code session** — graph only refreshed on MCP tool calls; agent edits drifted it out of date.
2. **Raven / graph bleed across repos** — MCP server's startup cwd was used for every tool call, so cross-repo work returned wrong-repo data.
3. **Update marker lagged releases by up to 14 days** — cache TTL was 14d and only refreshed on manual `update --check`.

## Fixes

### Live graph freshness
- PostToolUse hook on Edit/Write/MultiEdit/NotebookEdit drops `.dirty` under `~/.tokenomy/graphs/<repo-id>/.dirty`.
- `isGraphStaleCheap` short-circuits on the sentinel — O(repo) → O(1) on hot path.
- Read-side async rebuild: stale-but-cached snapshot served immediately, rebuild runs in background (process-local lockset prevents pile-up). Caller sees `stale: true`. Opt-out: `graph.async_rebuild: false`.

### Cross-repo isolation
- Every graph + Raven MCP tool accepts an optional `path` arg (post-processed into `TOOL_DEFS`). Agent passes `path: "$PWD"` when working across repos.
- `collectRavenStats(repoId)` filter; `tokenomy report` / `analyze` scope to current repo by default. `--all-repos` restores global aggregate.

### Auto update-check
- Statusline cache TTL: 14d → 24h.
- Statusline + SessionStart spawn `tokenomy update --check --quiet` (detached, unref'd, fail-open) whenever cache age > 3h.
- New `--quiet` flag on `tokenomy update`.

## Test plan

- [x] `npm test` — 634/634 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run coverage` — **All files: 90.72 %** (was 81.61 %; gate ≥ 90 %)
- [x] Zero-touch install walkthrough updated with 3 new feature steps
- [ ] Manual: edit a file via Claude Code → verify `.dirty` lands → `find_usages` returns fresh result, log shows background rebuild
- [ ] Manual: from repo A, call `find_usages` with `path: "/path/to/repoB"` → returns repo B's data
- [ ] Manual: `tokenomy report` shows current-repo Raven counts only; `--all-repos` restores aggregate
- [ ] Manual: restart Claude Code → SessionStart spawns `update --check --quiet` → cache file mtime updates within seconds
- [ ] Manual: leave session running, wait > 3h, observe statusline kick a fresh refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)