### PR TITLE
feat: 0.1.4 — render Kratos in statusline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.1.4] — 2026-04-29
+
+### Fixed
+
+- **Statusline now renders Kratos.** Pre-0.1.4 the statusline already
+  showed `· Raven` and the GOLEM mode but silently dropped Kratos —
+  users couldn't tell at a glance whether the security shield was
+  actively scanning their prompts. The statusline now appends `·
+  Kratos` after `· Raven` whenever `kratos.enabled && kratos.continuous`
+  is true. CLI-only audit mode (`enabled: true, continuous: false`)
+  doesn't render the badge — that mode is opt-in scan only.
+- New StatusLineState field: `kratos?: boolean`.
+
 ## [0.1.3] — 2026-04-28
 
 ### Fixed
@@ -924,7 +937,8 @@ First public alpha. Phase 1 scope: transparent MCP tool-output trimming via `Pos
 - Statusline with live savings counter — Phase 2.
 - `tokenomy analyze` over transcripts — Phase 2.
 
-[Unreleased]: https://github.com/RahulDhiman93/Tokenomy/compare/v0.1.3...HEAD
+[Unreleased]: https://github.com/RahulDhiman93/Tokenomy/compare/v0.1.4...HEAD
+[0.1.4]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.4
 [0.1.3]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.3
 [0.1.2]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.2
 [0.1.1-beta.5]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.1-beta.5

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ tokenomy doctor                     # all checks passing
 
 Codex CLI, Cursor, Windsurf, Cline, Gemini auto-detected and registered when each is on PATH. Force one target with `--agent <name>`; inspect first with `tokenomy init --list-agents`.
 
-> **Pre-`1.0`.** Breaking changes may land before `1.0.0` (see [CHANGELOG](./CHANGELOG.md)). Pin: `npm install -g tokenomy@0.1.3`. Upgrade: `tokenomy update`.
+> **Pre-`1.0`.** Breaking changes may land before `1.0.0` (see [CHANGELOG](./CHANGELOG.md)). Pin: `npm install -g tokenomy@0.1.4`. Upgrade: `tokenomy update`.
 
 ---
 
@@ -233,7 +233,7 @@ Removes both hook entries from `~/.claude/settings.json` (matched by absolute co
 - [x] **Phase 4.5.** OSS-alternatives-first nudge — `find_oss_alternatives` MCP tool + Write context nudge.
 - [x] **Phase 5.** Polish — Golem output mode, statusline, prompt-classifier, `compress`, `bench`, cross-agent installers.
 - [x] **Phase 5.5.** Codex hook foothold — user-scoped `SessionStart` + `UserPromptSubmit` hooks for Golem and prompt-classifier nudges.
-- [x] **Phase 6 (0.1.x).** Raven bridge, Kratos security shield, statusline update marker, Raven in report/analyze, Golem `recon` mode, `tokenomy feedback` command, live graph freshness + cross-repo isolation + auto-update-check (0.1.3).
+- [x] **Phase 6 (0.1.x).** Raven bridge, Kratos security shield, statusline update marker, Raven in report/analyze, Golem `recon` mode, `tokenomy feedback` command, live graph freshness + cross-repo isolation + auto-update-check (0.1.3), Kratos statusline badge (0.1.4).
 - [ ] **Phase 7.** Language breadth — Python parser plugin, richer benchmark fixtures, npm publish at 1.0.
 - [ ] **Phase 8.** Agent operating layer — rule-pack generator, compaction-time memory hygiene, workflow MCP tools, session ledgers, team-ready reports. See [docs/NEXT_FEATURES.md](./docs/NEXT_FEATURES.md).
 

--- a/docs/features/kratos.md
+++ b/docs/features/kratos.md
@@ -76,3 +76,13 @@ Capped at `kratos.notice_max_bytes` (default 1200) — long notices are truncate
 ## Logging
 
 Every flag appends a row to `~/.tokenomy/savings.jsonl` with `tool: "UserPromptSubmit"` and `reason: "kratos:<category-list>:<count>"` so `tokenomy report` / `tokenomy analyze` can surface kratos activity alongside trims. Token-savings value is 0 — kratos is about leak prevention, not compression.
+
+## Statusline badge (0.1.4+)
+
+When `kratos.enabled && kratos.continuous` are both true, the statusline appends ` · Kratos` so users see at a glance that the prompt-time shield is active:
+
+```
+[Tokenomy v0.1.4 · GOLEM-RECON · 1.9k saved · Raven · Kratos]
+```
+
+CLI-only audit mode (`enabled: true, continuous: false`) doesn't render the badge — that mode is on-demand `tokenomy kratos scan` only, with no per-turn rule firing.

--- a/docs/features/observability.md
+++ b/docs/features/observability.md
@@ -92,9 +92,11 @@ tokenomy bench compare <a.json> <b.json>   # per-scenario regressions
 
 ## `tokenomy status-line` (beta.2+)
 
-`tokenomy init` patches `settings.json.statusLine`. Reads today's `savings.jsonl`, aggregates by tool/reason, emits a one-liner like `[Tokenomy v0.1.3 · GOLEM-GRUNT · 4.2k saved | graph fresh]`.
+`tokenomy init` patches `settings.json.statusLine`. Reads today's `savings.jsonl`, aggregates by tool/reason, emits a one-liner like `[Tokenomy v0.1.4 · GOLEM-GRUNT · 4.2k saved · graph fresh · Raven · Kratos]`.
 
-After `tokenomy update --check`, a `↑` is appended when a newer release exists on npm (e.g. `v0.1.3↑`). 0.1.3+: cache TTL is 24h and SessionStart + the statusline (every 3h) auto-spawn `tokenomy update --check --quiet` so a new release surfaces on the next Claude Code restart or within 3h on a long-running session.
+Segments (left-to-right): version + `↑` if an update is available, GOLEM mode (when on), today's saved-tokens count, graph freshness, Raven badge (when enabled), Kratos badge (when continuous shield is on).
+
+After `tokenomy update --check`, a `↑` is appended when a newer release exists on npm (e.g. `v0.1.4↑`). 0.1.3+: cache TTL is 24h and SessionStart + the statusline (every 3h) auto-spawn `tokenomy update --check --quiet` so a new release surfaces on the next Claude Code restart or within 3h on a long-running session.
 
 Must return in < 50 ms — uses a bounded read of the log and no external I/O. Fails open: missing config or parse error → empty string → Claude Code renders nothing.
 
@@ -116,8 +118,8 @@ Single-command self-update.
 ```bash
 tokenomy update              # install latest + re-stage hook
 tokenomy update --check      # query registry, print installed vs remote, exit 1 if out of date
-tokenomy update@0.1.3 # npm-style pin
-tokenomy update --version=0.1.3
+tokenomy update@0.1.4 # npm-style pin
+tokenomy update --version=0.1.4
 tokenomy update --tag=beta   # opt into a non-default dist-tag
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tokenomy",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tokenomy",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenomy",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Surgical Claude Code hook that transparently trims bloated MCP tool responses and clamps oversized file reads — stop burning tokens on tool chatter.",
   "type": "module",
   "engines": {

--- a/src/cli/statusline.ts
+++ b/src/cli/statusline.ts
@@ -17,6 +17,10 @@ export interface StatusLineState {
   graph?: "fresh" | "stale";
   golem?: string;
   raven?: boolean;
+  // 0.1.4+: rendered as ` · Kratos` when continuous prompt-time scan is
+  // active. Mirrors the Raven badge so users notice the security shield
+  // is on at a glance.
+  kratos?: boolean;
   // Populated when a cached `tokenomy update --check` reply indicates a
   // newer version is available on npm. Renders as `↑` after the version.
   updateAvailable?: string;
@@ -143,18 +147,19 @@ export const renderStatusLine = (state: StatusLineState): string => {
   if (!state.active) return "";
   const versionTag = `v${TOKENOMY_VERSION}${state.updateAvailable ? "↑" : ""}`;
   const raven = state.raven ? " · Raven" : "";
+  const kratos = state.kratos ? " · Kratos" : "";
   if (state.golem) {
     const savings = state.tokensToday > 0 ? ` · ${compact(state.tokensToday)} saved` : "";
-    return `[Tokenomy ${versionTag} · GOLEM-${state.golem.toUpperCase()}${savings}${raven}]`;
+    return `[Tokenomy ${versionTag} · GOLEM-${state.golem.toUpperCase()}${savings}${raven}${kratos}]`;
   }
-  if (state.tokensToday <= 0) return `[Tokenomy ${versionTag} · active${raven}]`;
+  if (state.tokensToday <= 0) return `[Tokenomy ${versionTag} · active${raven}${kratos}]`;
   const graph =
     state.graph === "fresh"
       ? " · graph fresh"
       : state.graph === "stale"
         ? " · graph stale - rebuild"
         : "";
-  return `[Tokenomy ${versionTag} · ${compact(state.tokensToday)} saved${graph}${raven}]`;
+  return `[Tokenomy ${versionTag} · ${compact(state.tokensToday)} saved${graph}${raven}${kratos}]`;
 };
 
 export const runStatusLine = (argv: string[]): number => {
@@ -166,6 +171,10 @@ export const runStatusLine = (argv: string[]): number => {
       graph: graphState(process.cwd()),
       golem: cfg.golem.enabled ? resolveGolemMode(cfg) : undefined,
       raven: cfg.raven.enabled,
+      // 0.1.4+: surface kratos when the continuous prompt-time shield
+      // is on. Both flags must be true; `enabled: true, continuous: false`
+      // is the CLI-only audit mode and shouldn't render a session badge.
+      kratos: cfg.kratos?.enabled === true && cfg.kratos?.continuous === true,
       updateAvailable: readUpdateCache(),
     };
     // 0.1.3+: keep the update cache fresh on the order of 3h so a new

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,1 +1,1 @@
-export const TOKENOMY_VERSION = "0.1.3";
+export const TOKENOMY_VERSION = "0.1.4";

--- a/tests/unit/statusline-render.test.ts
+++ b/tests/unit/statusline-render.test.ts
@@ -44,3 +44,31 @@ test("renderStatusLine: Raven marker appears when enabled", () => {
     `[Tokenomy ${V} · active · Raven]`,
   );
 });
+
+test("renderStatusLine: Kratos marker appears when continuous shield is on", () => {
+  assert.equal(
+    renderStatusLine({ active: true, tokensToday: 0, kratos: true }),
+    `[Tokenomy ${V} · active · Kratos]`,
+  );
+});
+
+test("renderStatusLine: Raven + Kratos render together", () => {
+  assert.equal(
+    renderStatusLine({ active: true, tokensToday: 0, raven: true, kratos: true }),
+    `[Tokenomy ${V} · active · Raven · Kratos]`,
+  );
+});
+
+test("renderStatusLine: Kratos appended after savings + graph segments", () => {
+  assert.equal(
+    renderStatusLine({ active: true, tokensToday: 4500, graph: "fresh", kratos: true }),
+    `[Tokenomy ${V} · 4.5k saved · graph fresh · Kratos]`,
+  );
+});
+
+test("renderStatusLine: Kratos appended in GOLEM line", () => {
+  assert.equal(
+    renderStatusLine({ active: true, tokensToday: 1900, golem: "recon", raven: true, kratos: true }),
+    `[Tokenomy ${V} · GOLEM-RECON · 1.9k saved · Raven · Kratos]`,
+  );
+});


### PR DESCRIPTION
## Summary

User noticed Kratos was missing from the statusline. Pre-0.1.4 it rendered Raven + GOLEM mode but silently dropped Kratos so users couldn't tell at a glance whether the continuous prompt-time shield was actively scanning.

## Fix

- `StatusLineState` gains `kratos?: boolean`
- `renderStatusLine` appends ` · Kratos` after ` · Raven` when `kratos.enabled && kratos.continuous` are both true
- CLI-only audit mode (`continuous: false`) does NOT render the badge — that mode is on-demand `tokenomy kratos scan` only

Example:
```
[Tokenomy v0.1.4 · GOLEM-RECON · 1.9k saved · Raven · Kratos]
```

## Test plan

- [x] `npm test` — 638/638 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run coverage` — 90.74 % (≥ 90 % gate)
- [x] 4 new tests: Kratos alone, Raven+Kratos, savings+graph+Kratos, GOLEM full line
- [ ] Manual: `tokenomy kratos enable` → `tokenomy status-line` shows ` · Kratos`
- [ ] Manual: `tokenomy config set kratos.continuous false` → badge disappears (CLI-only mode)
- [ ] Manual: `tokenomy kratos disable` → badge disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)