### PR TITLE
release: 0.1.6 — production-scale graph defaults + diagnostic build-failure surfacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 ## [Unreleased]
 
+## [0.1.6] — 2026-04-30
+
+### Fixed
+
+- **Production-scale graph defaults.** Raised the graph file cap from
+  5,000 to 25,000 JS/TS files and the local snapshot cap from 20 MB to
+  100 MB so large frontend repos can actually use graph queries instead
+  of falling back to grep.
+- **Compact graph snapshots.** Store graph snapshots as compact JSON
+  instead of pretty-printed JSON. Query responses remain budget-clipped;
+  only local cache size changed.
+- **Generated-output excludes.** Default graph excludes now skip tracked
+  `.next`, `.nuxt`, `.turbo`, `coverage`, `dist`, `build`, and
+  `storybook-static` directories.
+- **Actionable graph failure reporting.** `graph-too-large` now reports
+  actual snapshot bytes and configured `graph.max_snapshot_bytes`, and
+  Raven/status/diagnose surface the last failed build reason instead of
+  masking it as `graph-not-built`.
+
 ## [0.1.5] — 2026-04-29
 
 ### Added
@@ -982,7 +1001,8 @@ First public alpha. Phase 1 scope: transparent MCP tool-output trimming via `Pos
 - Statusline with live savings counter — Phase 2.
 - `tokenomy analyze` over transcripts — Phase 2.
 
-[Unreleased]: https://github.com/RahulDhiman93/Tokenomy/compare/v0.1.5...HEAD
+[Unreleased]: https://github.com/RahulDhiman93/Tokenomy/compare/v0.1.6...HEAD
+[0.1.6]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.6
 [0.1.5]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.5
 [0.1.4]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.4
 [0.1.3]: https://github.com/RahulDhiman93/Tokenomy/releases/tag/v0.1.3

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ tokenomy doctor                     # all checks passing
 
 Codex CLI, Cursor, Windsurf, Cline, Gemini auto-detected and registered when each is on PATH. Force one target with `--agent <name>`; inspect first with `tokenomy init --list-agents`.
 
-> **Pre-`1.0`.** Breaking changes may land before `1.0.0` (see [CHANGELOG](./CHANGELOG.md)). Pin: `npm install -g tokenomy@0.1.5`. Upgrade: `tokenomy update`.
+> **Pre-`1.0`.** Breaking changes may land before `1.0.0` (see [CHANGELOG](./CHANGELOG.md)). Pin: `npm install -g tokenomy@0.1.6`. Upgrade: `tokenomy update`.
 
 ---
 
@@ -246,7 +246,7 @@ Removes both hook entries from `~/.claude/settings.json` (matched by absolute co
 - [x] **Phase 4.5.** OSS-alternatives-first nudge — `find_oss_alternatives` MCP tool + Write context nudge.
 - [x] **Phase 5.** Polish — Golem output mode, statusline, prompt-classifier, `compress`, `bench`, cross-agent installers.
 - [x] **Phase 5.5.** Codex hook foothold — user-scoped `SessionStart` + `UserPromptSubmit` hooks for Golem and prompt-classifier nudges.
-- [x] **Phase 6 (0.1.x).** Raven bridge, Kratos security shield, statusline update marker, Raven in report/analyze, Golem `recon` mode, `tokenomy feedback` command, live graph freshness + cross-repo isolation + auto-update-check (0.1.3), Kratos statusline badge (0.1.4), `tokenomy diagnose` + production-hardening pass + RECON v2 (0.1.5).
+- [x] **Phase 6 (0.1.x).** Raven bridge, Kratos security shield, statusline update marker, Raven in report/analyze, Golem `recon` mode, `tokenomy feedback` command, live graph freshness + cross-repo isolation + auto-update-check (0.1.3), Kratos statusline badge (0.1.4), `tokenomy diagnose` + production-hardening pass + RECON v2 (0.1.5), production-scale graph defaults (0.1.6).
 - [ ] **Phase 7.** Language breadth — Python parser plugin, richer benchmark fixtures, npm publish at 1.0.
 - [ ] **Phase 8.** Agent operating layer — rule-pack generator, compaction-time memory hygiene, workflow MCP tools, session ledgers, team-ready reports. See [docs/NEXT_FEATURES.md](./docs/NEXT_FEATURES.md).
 

--- a/docs/features/code-graph.md
+++ b/docs/features/code-graph.md
@@ -43,6 +43,17 @@ tokenomy init --graph-path "$PWD"   # registers in every detected agent + builds
 
 TypeScript / JavaScript AST via the TS compiler (no type checker). `tsconfig.paths` / `jsconfig.paths` resolved (alpha.17+) so `@/hooks/foo` and friends link to real source files on Next.js, Vite, Nuxt, monorepos. Read-side auto-refresh (alpha.15+) rebuilds on demand when files change between queries. Fail-open everywhere.
 
+## Production-scale defaults (0.1.6+)
+
+Default graph capacity is sized for real frontend repos: 25,000 JS/TS files, 100 MB compact snapshot cap, and generated-directory excludes for tracked `dist`, `build`, `coverage`, `.next`, `.nuxt`, `.turbo`, and `storybook-static` outputs. Query responses remain budget-clipped; the larger cap only affects local snapshot storage.
+
+If a repo still exceeds the cap, `graph-too-large` reports actual snapshot bytes and configured `graph.max_snapshot_bytes` so the fix is mechanical:
+
+```bash
+tokenomy config set graph.max_snapshot_bytes 200000000
+tokenomy graph build --path "$PWD" --exclude '**/generated/**'
+```
+
 ## Incremental updates (beta.3+)
 
 `cfg.graph.incremental: true` enables delta rebuilds that re-parse only stale files + direct importers. Falls back to full rebuild if tsconfig/exclude fingerprints shift or > 40 % of files changed. Opt-in.

--- a/docs/features/observability.md
+++ b/docs/features/observability.md
@@ -92,11 +92,11 @@ tokenomy bench compare <a.json> <b.json>   # per-scenario regressions
 
 ## `tokenomy status-line` (beta.2+)
 
-`tokenomy init` patches `settings.json.statusLine`. Reads today's `savings.jsonl`, aggregates by tool/reason, emits a one-liner like `[Tokenomy v0.1.5 · GOLEM-GRUNT · 4.2k saved · graph fresh · Raven · Kratos]`.
+`tokenomy init` patches `settings.json.statusLine`. Reads today's `savings.jsonl`, aggregates by tool/reason, emits a one-liner like `[Tokenomy v0.1.6 · GOLEM-GRUNT · 4.2k saved · graph fresh · Raven · Kratos]`.
 
 Segments (left-to-right): version + `↑` if an update is available, GOLEM mode (when on), today's saved-tokens count, graph freshness, Raven badge (when enabled), Kratos badge (when continuous shield is on).
 
-After `tokenomy update --check`, a `↑` is appended when a newer release exists on npm (e.g. `v0.1.5↑`). 0.1.3+: cache TTL is 24h and SessionStart + the statusline (every 3h) auto-spawn `tokenomy update --check --quiet` so a new release surfaces on the next Claude Code restart or within 3h on a long-running session.
+After `tokenomy update --check`, a `↑` is appended when a newer release exists on npm (e.g. `v0.1.6↑`). 0.1.3+: cache TTL is 24h and SessionStart + the statusline (every 3h) auto-spawn `tokenomy update --check --quiet` so a new release surfaces on the next Claude Code restart or within 3h on a long-running session.
 
 Must return in < 50 ms — uses a bounded read of the log and no external I/O. Fails open: missing config or parse error → empty string → Claude Code renders nothing.
 
@@ -118,8 +118,8 @@ Single-command self-update.
 ```bash
 tokenomy update              # install latest + re-stage hook
 tokenomy update --check      # query registry, print installed vs remote, exit 1 if out of date
-tokenomy update@0.1.5 # npm-style pin
-tokenomy update --version=0.1.5
+tokenomy update@0.1.6 # npm-style pin
+tokenomy update --version=0.1.6
 tokenomy update --tag=beta   # opt into a non-default dist-tag
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tokenomy",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tokenomy",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenomy",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Surgical Claude Code hook that transparently trims bloated MCP tool responses and clamps oversized file reads — stop burning tokens on tool chatter.",
   "type": "module",
   "engines": {

--- a/src/cli/diagnose.ts
+++ b/src/cli/diagnose.ts
@@ -6,6 +6,7 @@ import { loadConfig } from "../core/config.js";
 import {
   feedbackLogPath,
   graphDirtySentinelPath,
+  graphBuildLogPath,
   graphMetaPath,
   graphRebuildLockPath,
   graphSnapshotPath,
@@ -14,6 +15,7 @@ import {
   updateCachePath,
 } from "../core/paths.js";
 import { resolveRepoId } from "../graph/repo-id.js";
+import { readLastGraphBuildFailure, readLastGraphBuildLog } from "../graph/build-log.js";
 import { commandExists } from "./agents/common.js";
 import { runDoctor } from "./doctor.js";
 
@@ -108,18 +110,38 @@ const sectionGraph = (): SectionResult => {
     const { repoId, repoPath } = resolveRepoId(process.cwd());
     const meta = graphMetaPath(repoId);
     const snapshot = graphSnapshotPath(repoId);
+    const buildLog = graphBuildLogPath(repoId);
     const dirty = graphDirtySentinelPath(repoId);
     const lock = graphRebuildLockPath(repoId);
     const built = existsSync(meta) && existsSync(snapshot);
+    const lastBuild = readLastGraphBuildLog(repoId);
+    const lastFailure = readLastGraphBuildFailure(repoId);
     const out: SectionResult = {
       ok: built,
       repo_id: repoId,
       repo_path: repoPath,
       meta_present: existsSync(meta),
       snapshot_present: existsSync(snapshot),
+      build_log_present: existsSync(buildLog),
       dirty_sentinel_present: existsSync(dirty),
       rebuild_in_progress: existsSync(lock),
     };
+    if (lastBuild) {
+      out.last_build = {
+        ts: lastBuild.ts,
+        built: lastBuild.built,
+        reason: lastBuild.reason,
+        hint: lastBuild.hint,
+        node_count: lastBuild.node_count,
+        edge_count: lastBuild.edge_count,
+        parse_error_count: lastBuild.parse_error_count,
+        duration_ms: lastBuild.duration_ms,
+      };
+      if (!built && !lastBuild.built && lastBuild.reason) {
+        out.reason = lastBuild.reason;
+        if (lastFailure?.hint) out.hint = lastFailure.hint;
+      }
+    }
     if (existsSync(snapshot)) {
       try {
         const st = statSync(snapshot);

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -42,11 +42,11 @@ export const DEFAULT_CONFIG: Config = {
   },
   graph: {
     enabled: true,
-    max_files: 2_000,
-    hard_max_files: 5_000,
+    max_files: 10_000,
+    hard_max_files: 25_000,
     build_timeout_ms: 30_000,
     max_edges_per_file: 1_000,
-    max_snapshot_bytes: 20_000_000,
+    max_snapshot_bytes: 100_000_000,
     query_budget_bytes: {
       // Build summary is a fixed small payload — 4KB is plenty.
       build_or_update_graph: 4_000,
@@ -87,6 +87,13 @@ export const DEFAULT_CONFIG: Config = {
       "**/*-bundle.js",
       "**/*-bundle.cjs",
       "**/*-bundle.mjs",
+      "**/.next/**",
+      "**/.nuxt/**",
+      "**/.turbo/**",
+      "**/coverage/**",
+      "**/dist/**",
+      "**/build/**",
+      "**/storybook-static/**",
     ],
     auto_refresh_on_read: true,
     async_rebuild: true,

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,1 +1,1 @@
-export const TOKENOMY_VERSION = "0.1.5";
+export const TOKENOMY_VERSION = "0.1.6";

--- a/src/graph/build-log.ts
+++ b/src/graph/build-log.ts
@@ -1,0 +1,51 @@
+import { existsSync, readFileSync } from "node:fs";
+import { graphBuildLogPath } from "../core/paths.js";
+import { safeParse } from "../util/json.js";
+import type { GraphBuildLogEntry } from "./schema.js";
+import type { FailOpen } from "./types.js";
+
+const isGraphBuildLogEntry = (value: unknown): value is GraphBuildLogEntry =>
+  !!value &&
+  typeof value === "object" &&
+  typeof (value as { ts?: unknown }).ts === "string" &&
+  typeof (value as { repo_id?: unknown }).repo_id === "string" &&
+  typeof (value as { repo_path?: unknown }).repo_path === "string" &&
+  typeof (value as { built?: unknown }).built === "boolean";
+
+export const readLastGraphBuildLog = (repoId: string): GraphBuildLogEntry | null => {
+  const path = graphBuildLogPath(repoId);
+  if (!existsSync(path)) return null;
+  try {
+    const lines = readFileSync(path, "utf8").trimEnd().split("\n");
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i]?.trim();
+      if (!line) continue;
+      const parsed = safeParse<unknown>(line);
+      if (isGraphBuildLogEntry(parsed)) return parsed;
+    }
+  } catch {
+    // Build-log lookup is diagnostic only.
+  }
+  return null;
+};
+
+const fallbackHint = (reason: string): string | undefined => {
+  if (reason === "graph-too-large") {
+    return "Last graph build exceeded graph.max_snapshot_bytes; raise graph.max_snapshot_bytes or exclude generated/large files, then run `tokenomy graph build`.";
+  }
+  if (reason === "typescript-not-installed") {
+    return "Install `typescript` in the target repo or alongside Tokenomy, then re-run `tokenomy graph build`.";
+  }
+  return undefined;
+};
+
+export const readLastGraphBuildFailure = (repoId: string): FailOpen | null => {
+  const last = readLastGraphBuildLog(repoId);
+  if (!last || last.built || !last.reason) return null;
+  const hint = last.hint ?? fallbackHint(last.reason);
+  return {
+    ok: false,
+    reason: last.reason,
+    ...(hint ? { hint } : {}),
+  };
+};

--- a/src/graph/build.ts
+++ b/src/graph/build.ts
@@ -2,7 +2,6 @@ import { closeSync, existsSync, mkdirSync, openSync, readFileSync, rmSync, statS
 import { dirname, join } from "node:path";
 import type { Config } from "../core/types.js";
 import { graphBuildLogPath, graphDirtySentinelPath, graphLockPath } from "../core/paths.js";
-import { stableStringify } from "../util/json.js";
 import { TOKENOMY_VERSION } from "../core/version.js";
 import { enumerateAllFiles, enumerateGraphFiles } from "./enumerate.js";
 import { fingerprintExcludes } from "./exclude-fingerprint.js";
@@ -20,7 +19,8 @@ import {
   type Node,
 } from "./schema.js";
 import { getGraphStaleStatus } from "./stale.js";
-import { JsonGraphStore } from "./store.js";
+import { JsonGraphStore, serializeGraphSnapshot } from "./store.js";
+import { readLastGraphBuildFailure } from "./build-log.js";
 import type { BuildGraphResult, FailOpen } from "./types.js";
 import { loadTypescript } from "../parsers/ts/loader.js";
 import { extractTsFileGraph } from "../parsers/ts/extract.js";
@@ -48,7 +48,7 @@ const logGraphBuild = (
     edge_count: result.ok ? result.data.edge_count : 0,
     parse_error_count: result.ok ? result.data.parse_error_count : 0,
     duration_ms: result.ok ? result.data.duration_ms : 0,
-    ...(result.ok ? { skipped_files: result.data.skipped_files } : { reason: result.reason }),
+    ...(result.ok ? { skipped_files: result.data.skipped_files } : { reason: result.reason, hint: result.hint }),
   });
 };
 
@@ -182,10 +182,13 @@ const deltaBuildFromSnapshot = async (
       edges: [...keptEdges, ...addedEdges],
       parse_errors: [...keptParseErrors, ...addedErrors],
     });
-    const serialized = `${stableStringify(graph)}\n`;
+    const serialized = serializeGraphSnapshot(graph);
     const snapshotBytes = Buffer.byteLength(serialized, "utf8");
     if (snapshotBytes > cfg.graph.max_snapshot_bytes) {
-      return fail("graph-too-large", "Snapshot exceeded graph.max_snapshot_bytes");
+      return fail(
+        "graph-too-large",
+        `Snapshot was ${snapshotBytes} bytes, exceeding graph.max_snapshot_bytes=${cfg.graph.max_snapshot_bytes}. Raise graph.max_snapshot_bytes or exclude generated/large files.`,
+      );
     }
 
     const tsconfigFingerprint = computeTsconfigFingerprint(
@@ -312,10 +315,13 @@ const buildGraphFromFiles = async (
     edges,
     parse_errors,
   });
-  const serialized = `${stableStringify(graph)}\n`;
+  const serialized = serializeGraphSnapshot(graph);
   const snapshotBytes = Buffer.byteLength(serialized, "utf8");
   if (snapshotBytes > cfg.graph.max_snapshot_bytes) {
-    return fail("graph-too-large", "Snapshot exceeded graph.max_snapshot_bytes");
+    return fail(
+      "graph-too-large",
+      `Snapshot was ${snapshotBytes} bytes, exceeding graph.max_snapshot_bytes=${cfg.graph.max_snapshot_bytes}. Raise graph.max_snapshot_bytes or exclude generated/large files.`,
+    );
   }
 
   const meta: GraphMeta = {
@@ -482,7 +488,7 @@ export const readGraphStatus = (cwd: string, config: Config): import("./types.js
   const store = new JsonGraphStore();
   const meta = store.loadMeta(identity.repoId);
   const graph = store.loadGraph(identity.repoId);
-  if (!meta || !graph) return fail("graph-not-built");
+  if (!meta || !graph) return readLastGraphBuildFailure(identity.repoId) ?? fail("graph-not-built");
 
   const stale = getGraphStaleStatus(identity.repoPath, meta, config);
   if (!stale.ok) return stale;

--- a/src/graph/query/common.ts
+++ b/src/graph/query/common.ts
@@ -3,6 +3,7 @@ import { resolveRepoId } from "../repo-id.js";
 import type { Edge, Graph, GraphMeta, Node, NodeKind } from "../schema.js";
 import { JsonGraphStore } from "../store.js";
 import { getGraphStaleStatus } from "../stale.js";
+import { readLastGraphBuildFailure } from "../build-log.js";
 import type { FailOpen, QueryResult } from "../types.js";
 
 export interface GraphQueryContext {
@@ -41,7 +42,7 @@ export const loadGraphContext = (
   const store = new JsonGraphStore();
   const graph = store.loadGraph(identity.repoId);
   const meta = store.loadMeta(identity.repoId);
-  if (!graph || !meta) return fail("graph-not-built");
+  if (!graph || !meta) return readLastGraphBuildFailure(identity.repoId) ?? fail("graph-not-built");
 
   let staleFlag: boolean;
   let staleFiles: string[];

--- a/src/graph/schema.ts
+++ b/src/graph/schema.ts
@@ -85,6 +85,7 @@ export interface GraphBuildLogEntry {
   parse_error_count: number;
   duration_ms: number;
   reason?: string;
+  hint?: string;
   skipped_files?: string[];
 }
 

--- a/src/graph/store.ts
+++ b/src/graph/store.ts
@@ -10,6 +10,9 @@ export interface GraphStore {
   save(repoId: string, graph: Graph, meta: GraphMeta): void;
 }
 
+export const serializeGraphSnapshot = (graph: Graph): string => `${JSON.stringify(graph)}\n`;
+export const serializeGraphMeta = (meta: GraphMeta): string => `${stableStringify(meta)}\n`;
+
 const isGraph = (value: unknown): value is Graph =>
   !!value &&
   typeof value === "object" &&
@@ -42,7 +45,7 @@ export class JsonGraphStore implements GraphStore {
   }
 
   save(repoId: string, graph: Graph, meta: GraphMeta): void {
-    atomicWrite(graphSnapshotPath(repoId), `${stableStringify(graph)}\n`, false);
-    atomicWrite(graphMetaPath(repoId), `${stableStringify(meta)}\n`, false);
+    atomicWrite(graphSnapshotPath(repoId), serializeGraphSnapshot(graph), false);
+    atomicWrite(graphMetaPath(repoId), serializeGraphMeta(meta), false);
   }
 }

--- a/tests/unit/graph-exclude.test.ts
+++ b/tests/unit/graph-exclude.test.ts
@@ -45,6 +45,25 @@ test("enumerate: config exclude filters files (git mode)", () => {
   });
 });
 
+test("enumerate: default exclude skips tracked generated directories", () => {
+  return withTmpRepo((dir) => {
+    execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+    mkdirSync(join(dir, "src"), { recursive: true });
+    mkdirSync(join(dir, "dist"), { recursive: true });
+    mkdirSync(join(dir, ".next", "server"), { recursive: true });
+    writeFileSync(join(dir, "src", "app.ts"), "export const app = 1;\n");
+    writeFileSync(join(dir, "dist", "bundle.js"), "var x = 1;\n");
+    writeFileSync(join(dir, ".next", "server", "page.js"), "var y = 1;\n");
+    execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
+
+    const result = enumerateGraphFiles(dir, DEFAULT_CONFIG);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(result.files, ["src/app.ts"]);
+    assert.deepEqual(result.skipped_files, [".next/server/page.js", "dist/bundle.js"]);
+  });
+});
+
 test("enumerate: exclude filter runs BEFORE hard_max_files cap", () => {
   // 10 excluded vendor files + 2 real source files. hard_max_files=3.
   // Without in-loop filtering the vendor files would trip repo-too-large

--- a/tests/unit/raven-brief.test.ts
+++ b/tests/unit/raven-brief.test.ts
@@ -10,6 +10,8 @@ import {
   createAndSaveRavenPacket,
   packetDigest,
 } from "../../src/raven/brief.js";
+import { loadConfig } from "../../src/core/config.js";
+import { buildGraph } from "../../src/graph/build.js";
 import type { RavenPacket } from "../../src/raven/schema.js";
 
 const runGit = (cwd: string, args: string[]): void => {
@@ -75,6 +77,32 @@ test("buildRavenPacket: returns ok with packet + markdown for a real git repo", 
     assert.equal(packet.repo.base_ref, "main");
     assert.ok(packet.git.changed_files.includes("src/feature.ts"));
     assert.match(result.data.markdown, /# Tokenomy Raven Packet/);
+  } finally {
+    cleanup();
+  }
+});
+
+test("buildRavenPacket: graph context surfaces last build failure when snapshot is missing", async () => {
+  const { repo, home, cleanup } = initRepo();
+  try {
+    writeFileSync(
+      join(home, ".tokenomy", "config.json"),
+      JSON.stringify({ raven: { enabled: true }, graph: { max_snapshot_bytes: 1 } }),
+    );
+    const built = await buildGraph({ cwd: repo, force: true, config: loadConfig(repo) });
+    assert.equal(built.ok, false);
+    if (!built.ok) assert.equal(built.reason, "graph-too-large");
+
+    const packet = buildRavenPacket({ cwd: repo, intent: "review" });
+    assert.equal(packet.ok, true, JSON.stringify(packet));
+    if (!packet.ok) return;
+    const review = packet.data.packet.graph?.review_context as { ok?: boolean; reason?: string; hint?: string };
+    const impact = packet.data.packet.graph?.impact_radius as { ok?: boolean; reason?: string; hint?: string };
+    assert.equal(review.ok, false);
+    assert.equal(review.reason, "graph-too-large");
+    assert.match(review.hint ?? "", /graph\.max_snapshot_bytes/);
+    assert.equal(impact.ok, false);
+    assert.equal(impact.reason, "graph-too-large");
   } finally {
     cleanup();
   }


### PR DESCRIPTION
## Summary

Addresses real-user feedback from 0.1.5: `chat-frontend` failed `graph build` with bare `graph-too-large`, raven packets came back with `graph-not-built` even when a recent build had failed, default exclude list missed common generated dirs, and there was no way to see the last build's reason without grepping `~/.tokenomy/graphs/<repo>/build.jsonl`.

## Changes

| Area | Change |
|---|---|
| `graph` defaults | `max_files` 2k → 10k, `hard_max_files` 5k → 25k, `max_snapshot_bytes` 20MB → 100MB |
| `graph.exclude` defaults | added `**/.next/**`, `**/.nuxt/**`, `**/.turbo/**`, `**/coverage/**`, `**/dist/**`, `**/build/**`, `**/storybook-static/**` |
| `graph-too-large` hint | now reports actual snapshot bytes + configured cap so the fix is mechanical |
| New `src/graph/build-log.ts` | `readLastGraphBuildFailure()` — surfaces last build's reason+hint |
| `loadGraphContext` / `readGraphStatus` | fall back to last failure instead of bare `graph-not-built`. Raven packets now carry the real reason |
| `diagnose.graph` | new `last_build` block (ts, built, reason, hint, counts, duration_ms) |
| `serializeGraphSnapshot` | shared between full + delta build (removed inline `stableStringify` duplication) |
| Tests | +2 (default-exclude skips dist/.next, raven graph context surfaces last failure) |
| Docs | new "Production-scale defaults (0.1.6+)" section in code-graph.md, README pin bumped, CHANGELOG `[0.1.6]` |

## Test plan

- [x] `npm test` — 665/665 passing (was 663)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: rerun `tokenomy graph build` on chat-frontend with 0.1.6 — should build (was `graph-too-large`)
- [ ] Manual: `tokenomy diagnose --json` on a repo with a failed build — `graph.last_build.reason` populated
- [ ] Manual: `tokenomy raven brief` after a failed build — packet's `graph.review_context.reason` is the actual reason, not `graph-not-built`

🤖 Generated with [Claude Code](https://claude.com/claude-code)